### PR TITLE
Rewrote carousel and added eager loading

### DIFF
--- a/units/cards.css
+++ b/units/cards.css
@@ -64,7 +64,7 @@
 .ability { position: relative; padding-right: 3px; }
 
 .abilities .ability .wrapper{
-	display: table-cell; 
+	display: table-cell;
 	height: 100px;
 	padding-left: 103px;
 	vertical-align: middle;
@@ -167,6 +167,14 @@ span.mental {
 	height: 15px;
 	margin: 0px 3px !important;
 	padding: 0px !important;
-	background-size: 100% 100%; 
+	background-size: 100% 100%;
 	vertical-align: -2px;
+}
+
+.unit-carousel-div {
+	background: url('../images/frame.png');
+	height: 128px;
+	width: 128px;
+	display: inline-block;
+	cursor: pointer;
 }

--- a/units/carousel.js
+++ b/units/carousel.js
@@ -1,34 +1,51 @@
 $(function() {
+	// this will hold the JSON array of all units
+	var units;
+	// this is which unit is currently selected
+	var selectedUnit = 0;
 	// Get the units data as an array
-	$.getJSON("data.json", function(units) {
-		// Select URL defined unit or a random one to spice things up
-		//var selected = Math.floor(Math.random()*units.length);
-		// The selected unit is defined before script inclusion
+	$.getJSON("data.json", function(results) {
+		// draw the carousel
+		units = results;
+		drawCarousel();
+		// add an EL for any carousel divs
+		// it's important to note that the EL is bound to document on purpose
+		// since the events are on dom elements not added at runtime, we have to do this
+		$(document).on("click", ".unit-carousel-div", function(e) {
+			console.log("clicked");
+			selectedUnit = $(e.target).data("id");
+			drawCarousel();
+		});
 
-		//window.history.pushState("", "", '?view=viewer&id=' + selected);
-
-		// Change the avatars, always showing the focused unit in middle
-		function carousel() {
-            $('#carousel').html('');
-			for(var i = -3; i<=3; i++) {
-				var number = Math.abs((units.length+selected+i)%units.length);
-				var name = units[number].name;
-				var style = 'style="background: url(\'../images/frame.png\'), url(\'avatars/'+name+'.jpg\'); height: 128px; width: 128px; display: inline-block;"';
-                var $div = $('<div '+style+'></div>').css('cursor', 'pointer');
-                $div.click(update.bind(null, number));
-				$("#carousel").append($div);
-			}
-		};
-		function update(number) {
-			selected = number;
-			carousel();
-		};
-
-		carousel();
-
-			// Show the cards for the selected unit, progress indicator (update if different unit)
-			// If new avatar is clicked, repeat the whole process and also update the URL to match
-			// Bonus: Page title and disqus commenting system could also match the selected unit
-			// Note: It's hard to do PHP's ksort algorithm inside javascript, so use type sorting
 	});
+
+	function drawCarousel() {
+		clearCarousel();
+		// total items in the carousel (needs to be odd)
+		var carouselLength = 7;
+		// essentially, the amount on each side after you remove the middle
+		var modValue = (carouselLength - 1) / 2;
+		// start at -mod
+		var i = modValue * -1;
+		// go until positive mod, should result in carouselLength iterations
+		while (i <= modValue) {
+			// grabs a spot from the unit array
+			var index = Math.abs((units.length + selectedUnit + i) % units.length);
+			// add in the div we'll build on
+			var unitDiv = document.createElement("div");
+			// add the class and data id (index)
+			$(unitDiv).addClass("unit-carousel-div");
+			$(unitDiv).data("id", index);
+			// add in the background images
+			$(unitDiv).css("background", "url('../images/frame.png'), url('avatars/" + units[index].name + ".jpg')");
+			// add it to the carousel
+			$("#carousel").append(unitDiv);
+			i++;
+		}
+	}
+
+	function clearCarousel() {
+		// remove all the data from the carousel and that's about it
+		$("#carousel").html("");
+	}
 });

--- a/units/carousel.js
+++ b/units/carousel.js
@@ -3,6 +3,11 @@ $(function() {
 	var units;
 	// this is which unit is currently selected
 	var selectedUnit = 0;
+	// total items in the carousel (needs to be odd)
+	var carouselLength = 7;
+	// essentially, the amount on each side after you remove the middle
+	var modValue = (carouselLength - 1) / 2;
+
 	// Get the units data as an array
 	$.getJSON("data.json", function(results) {
 		// draw the carousel
@@ -14,17 +19,13 @@ $(function() {
 		$(document).on("click", ".unit-carousel-div", function(e) {
 			console.log("clicked");
 			selectedUnit = $(e.target).data("id");
-			drawCarousel();
+			updateCarousel();
 		});
 
 	});
 
 	function drawCarousel() {
 		clearCarousel();
-		// total items in the carousel (needs to be odd)
-		var carouselLength = 7;
-		// essentially, the amount on each side after you remove the middle
-		var modValue = (carouselLength - 1) / 2;
 		// start at -mod
 		var i = modValue * -1;
 		// go until positive mod, should result in carouselLength iterations
@@ -42,6 +43,19 @@ $(function() {
 			$("#carousel").append(unitDiv);
 			i++;
 		}
+	}
+
+	function updateCarousel() {
+		var i = modValue * -1;
+		$(".unit-carousel-div").each(function(index) {
+			// grabs a spot from the unit array
+			var unitIndex = Math.abs((units.length + selectedUnit + i) % units.length);
+			// add in the data id
+			$(this).data("id", unitIndex);
+			// add in the background images
+			$(this).css("background", "url('../images/frame.png'), url('avatars/" + units[unitIndex].name + ".jpg')");
+			i++;
+		});
 	}
 
 	function clearCarousel() {

--- a/units/carousel.js
+++ b/units/carousel.js
@@ -10,9 +10,12 @@ $(function() {
 
 	// Get the units data as an array
 	$.getJSON("data.json", function(results) {
-		// draw the carousel
+		// set the global var
 		units = results;
+		// draw the carousel
 		drawCarousel();
+		// preload all the images
+		preloadImages(units);
 		// add an EL for any carousel divs
 		// it's important to note that the EL is bound to document on purpose
 		// since the events are on dom elements not added at runtime, we have to do this
@@ -61,5 +64,15 @@ $(function() {
 	function clearCarousel() {
 		// remove all the data from the carousel and that's about it
 		$("#carousel").html("");
+	}
+
+	function preloadImages(unitArr) {
+		var images = [];
+		var i = 0;
+		while (i < unitArr.length) {
+			images[i] = new Image();
+			images[i].src = "avatars/" + unitArr[i].name + ".jpg";
+			i++;
+		}
 	}
 });


### PR DESCRIPTION
I've cached all images after the initial carousel loads.  With the current load of avatars and the size of them, it's super fast.  If they get higher res or you get a bunch more later, you could adjust the preloading to be a little smarter, but it shouldn't be needed for now.

fixes #893 