### PR TITLE
Log msg for spa goggles (#877)

### DIFF
--- a/development/src/abilities/Swine Thug.js
+++ b/development/src/abilities/Swine Thug.js
@@ -44,6 +44,16 @@ G.abilities[37] =[
 			alterations : alterations
 		});
 		this.creature.addEffect(effect);
+		var log = "%CreatureName"+this.creature.id+"%'s ";
+		var first = true;
+		for (var k in alterations) {
+			if (!first) {
+				log += ", ";
+			}
+			log += k + " is increased by " + alterations[k];
+			first = false;
+		}
+		G.log(log);
 	},
 },
 

--- a/development/src/abilities/Swine Thug.js
+++ b/development/src/abilities/Swine Thug.js
@@ -44,15 +44,21 @@ G.abilities[37] =[
 			alterations : alterations
 		});
 		this.creature.addEffect(effect);
+
+		// Log message, assume that all buffs are the same amount, and there are
+		// only two buffs (otherwise the grammar doesn't make sense)
 		var log = "%CreatureName"+this.creature.id+"%'s ";
 		var first = true;
+		var amount;
 		for (var k in alterations) {
 			if (!first) {
-				log += ", ";
+				log += "and ";
 			}
-			log += k + " is increased by " + alterations[k];
+			log += k + " ";
 			first = false;
+			amount = alterations[k];
 		}
+		log += "are increased by " + amount;
 		G.log(log);
 	},
 },


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1083215/15448267/3a91c544-1fa0-11e6-8e4d-1e5efff083db.png)

- Would it be better to assume that the buff amounts are the same and condense the message, i.e. "Swine Thug's regrowth and defense are increased by 20"?
- Also, I noticed in data.json that the ability's info says +5 but the effects are +10. Should info be updated to 10?