### PR TITLE
Fix blowing wind and other push abilities (#754)

### DIFF
--- a/development/src/abilities/Swine Thug.js
+++ b/development/src/abilities/Swine Thug.js
@@ -149,7 +149,6 @@ G.abilities[37] =[
 				}
 			}
 			var hexes = G.grid.getHexLine(target.x, target.y, dir, target.flipped);
-			var movementPoints = 0;
 			var hex = null;
 			// See how far the target can be knocked back
 			// Skip the first hex as it is the same hex as the target
@@ -157,7 +156,6 @@ G.abilities[37] =[
 				// Check that the next knockback hex is valid
 				if (!hexes[i].isWalkable(target.size, target.id, true)) break;
 
-				movementPoints++;
 				hex = hexes[i];
 
 				if(!this.isUpgraded()) break;
@@ -180,7 +178,6 @@ G.abilities[37] =[
 					},
 					ignoreMovementPoint : true,
 					ignorePath : true,
-					customMovementPoint: movementPoints, // Ignore target's movement points
 					overrideSpeed: 1200, // Custom speed for knockback
 					animation : "push",
 				});

--- a/development/src/animations.js
+++ b/development/src/animations.js
@@ -29,7 +29,7 @@ var Animations = Class.create({
 
 				var hex = path[hexId];
 
-				if( hexId < path.length && crea.remainingMove > 0 ){
+				if (hexId < path.length && (crea.remainingMove > 0 || opts.ignoreMovementPoint)) {
 					G.animations.movements.leaveHex(crea,hex,opts);
 				}else{
 					G.animations.movements.movementComplete(crea,hex,anim_id,opts); return;


### PR DESCRIPTION
Push animation should either require creature
has enough remaining moves, OR ignoreMovementPoint
is set to true. Previously ignoreMovementPoint was
ignored, which means that creatures without movement
points for a turn could not be pushed.