### PR TITLE
Toxic spores tweak (#874)

### DIFF
--- a/development/src/abilities.js
+++ b/development/src/abilities.js
@@ -184,8 +184,6 @@ var Ability = Class.create( {
 				opt.callback();
 			}
 		},100);
-
-		if( G.triggers.onAttack.test(ab.trigger) ) return ab.activate.apply(ab, args);
 	},
 
 

--- a/development/src/abilities.js
+++ b/development/src/abilities.js
@@ -19,8 +19,15 @@ var Ability = Class.create( {
 
 	isUpgraded: function() {
 		if(G.abilityUpgrades == -1 || !this.upgrade) return false;
-		if(this.trigger == "onQuery") return this.timesUsed >= G.abilityUpgrades;
+		if(this.trigger === "onQuery") return this.timesUsed >= G.abilityUpgrades;
 		else return this.creature.turnsActive >= G.abilityUpgrades;
+	},
+
+	getTrigger: function() {
+		if (this.trigger) {
+			return this.trigger;
+		}
+		return this.triggerFunc();
 	},
 
 
@@ -30,7 +37,7 @@ var Ability = Class.create( {
 	*
 	*/
 	use: function() {
-		if( this.trigger != "onQuery" ) return;
+		if( this.getTrigger() !== "onQuery" ) return;
 		if( !this.require() ) return;
 		if( this.used === true ) { G.log("Ability already used!"); return; }
 		G.grid.clearHexViewAlterations();
@@ -52,7 +59,7 @@ var Ability = Class.create( {
 		G.UI.btnDelay.changeState("disabled");
 		G.activeCreature.delayable = false;
 		G.UI.selectAbility(-1);
-		if(this.trigger == "onQuery" && !deferedEnding) {
+		if(this.getTrigger() === "onQuery" && !deferedEnding) {
 			G.activeCreature.queryMove();
 		}
 	},
@@ -88,7 +95,7 @@ var Ability = Class.create( {
 	animation: function() {
 
 		// Gamelog Event Registration
-		if( G.triggers.onQuery.test(this.trigger) ) {
+		if( G.triggers.onQuery.test(this.getTrigger()) ) {
 			if(arguments[0] instanceof Hex) {
 				var args = $j.extend( {}, arguments);
 				delete args[0];
@@ -140,7 +147,7 @@ var Ability = Class.create( {
 		p2 += (this.creature.player.flipped)? -5 : 5;
 
 		// Play animations and sounds only for active abilities
-		if( this.trigger === 'onQuery' ) {
+		if( this.getTrigger() === 'onQuery' ) {
 			var anim_id = Math.random();
 
 			G.animationQueue.push(anim_id);
@@ -160,7 +167,7 @@ var Ability = Class.create( {
 			.start();
 
 			setTimeout(function() {
-				if( !G.triggers.onAttack.test(ab.trigger) ) {
+				if( !G.triggers.onAttacked.test(ab.getTrigger()) ) {
 					G.soundsys.playSound(G.soundLoaded[2], G.soundsys.effectsGainNode);
 					activateAbility();
 				}

--- a/development/src/abilities/Dark Priest.js
+++ b/development/src/abilities/Dark Priest.js
@@ -8,7 +8,7 @@ G.abilities[0] =[
 // 	First Ability: Plasma Field
 {
 	//	Type : Can be "onQuery", "onStartPhase", "onDamage"
-	trigger : "onAttack",
+	trigger : "onAttacked",
 
 	// 	require() :
 	require : function(damage) {
@@ -23,7 +23,7 @@ G.abilities[0] =[
                     /* only used when unit isn't active */
                     return damage; // Return Damage
                 }
-                
+
                 if(this.isUpgraded()&&damage.melee&&!damage.counter){
                     //counter damage
                     var counter=new Damage(
@@ -36,7 +36,7 @@ G.abilities[0] =[
                     counter.counter=true;
                     G.activeCreature.takeDamage(counter);
                 }
-                
+
                 this.creature.player.plasma  -= 1;
 
                 this.creature.protectedFromFatigue = this.testRequirements();
@@ -165,7 +165,7 @@ G.abilities[0] =[
 
 		var plasmaCost = target.size;
 		var damage = target.baseStats.health-target.health;
-                
+
                 if (this.isUpgraded() && damage<40) damage=40;
 
 		ability.creature.player.plasma -= plasmaCost;
@@ -212,7 +212,7 @@ G.abilities[0] =[
 	query : function() {
 		var ability = this;
 		G.grid.updateDisplay(); // Retrace players creatures
-                
+
                 if(this.isUpgraded()) this.summonRange=6;
 
 		// Ask the creature to summon

--- a/development/src/abilities/Impaler.js
+++ b/development/src/abilities/Impaler.js
@@ -8,7 +8,7 @@ G.abilities[5] =[
 // 	First Ability: Electrified Hair
 {
 	//	Type : Can be "onQuery", "onStartPhase", "onDamage"
-	trigger : "onAttack",
+	trigger : "onAttacked",
 
 	// 	require() :
 	require : function() { return this.testRequirements(); },

--- a/development/src/abilities/Uncle Fungus.js
+++ b/development/src/abilities/Uncle Fungus.js
@@ -8,7 +8,12 @@ G.abilities[3] =[
 // First Ability: Toxic Spores
 {
 	// Type : Can be "onQuery", "onStartPhase", "onDamage"
-	trigger : "onAttack",
+	triggerFunc: function() {
+		if (this.isUpgraded()) {
+			return "onAttacked onAttack";
+		}
+		return "onAttacked";
+	},
 
 	priority : 10,
 

--- a/development/src/abilities/Uncle Fungus.js
+++ b/development/src/abilities/Uncle Fungus.js
@@ -8,7 +8,7 @@ G.abilities[3] =[
 // First Ability: Toxic Spores
 {
 	// Type : Can be "onQuery", "onStartPhase", "onDamage"
-	trigger : "onStepIn onStartPhase onOtherStepIn",
+	trigger : "onAttack",
 
 	priority : 10,
 
@@ -16,32 +16,36 @@ G.abilities[3] =[
 	require : function(hex) {
 		if( !this.atLeastOneTarget( this.creature.adjacentHexs(1), "enemy" ) ) return false;
 
+		var i;
+		var targets;
 		if( hex instanceof Hex && hex.creature instanceof Creature && hex.creature != this.creature) {
 
-			var targets = this.getTargets(hex.creature.adjacentHexs(1));
+			targets = this.getTargets(hex.creature.adjacentHexs(1));
 
 			var isAdj = false;
 
 			// Search if Uncle is adjacent to the creature that is moving
-			for (var i = 0; i < targets.length; i++) {
-				if( targets[i] == undefined ) continue;
+			for (i = 0; i < targets.length; i++) {
+				if( targets[i] === undefined ) continue;
 				if( !(targets[i].target instanceof Creature) ) continue;
 				if( targets[i].target == this.creature ) isAdj = true;
-			};
+			}
 
 			if( !isAdj ) return false;
 		}
 
-		var targets = this.getTargets(this.creature.adjacentHexs(1));
+		targets = this.getTargets(this.creature.adjacentHexs(1));
 
-		for (var i = 0; i < targets.length; i++) {
-			if( targets[i] == undefined ) continue;
+		for (i = 0; i < targets.length; i++) {
+			if( targets[i] === undefined ) continue;
 			if( !(targets[i].target instanceof Creature) ) continue;
-			if( !targets[i].target.isAlly(this.creature.team) && targets[i].target.findEffect(this.title).length == 0 )
+			if( !targets[i].target.isAlly(this.creature.team) &&
+				targets[i].target.findEffect(this.title).length === 0 ) {
 				return this.testRequirements();
-		};
+			}
+		}
 
-		return false
+		return false;
 	},
 
 	// activate() :

--- a/development/src/creature.js
+++ b/development/src/creature.js
@@ -355,7 +355,7 @@ var Creature = Class.create( {
 		G.creatures.each(function() { //For all Creature
 			if(this instanceof Creature) {
 				this.abilities.each(function() {
-					if( G.triggers.oncePerDamageChain.test(this.trigger) ) {
+					if( G.triggers.oncePerDamageChain.test(this.getTrigger()) ) {
 						this.setUsed(false);
 					}
 				});
@@ -822,7 +822,8 @@ var Creature = Class.create( {
 		});
 
 		// Trigger
-		G.triggersFn.onAttack(this, damage);
+		G.triggersFn.onAttacked(this, damage);
+		G.triggersFn.onAttack(damage.attacker, damage);
 
 		// Calculation
 		if( damage.status === "" ) {

--- a/development/src/game.js
+++ b/development/src/game.js
@@ -751,34 +751,36 @@ var Game = Class.create( {
 
 	/*	Regex Test for triggers */
 	triggers : {
-		onStepIn : new RegExp('onStepIn', 'i'),
-		onStepOut : new RegExp('onStepOut', 'i'),
-		onStartPhase : new RegExp('onStartPhase', 'i'),
-		onEndPhase : new RegExp('onEndPhase', 'i'),
-		onMovement : new RegExp('onMovement', 'i'),
-		onAttack : new RegExp('onAttack', 'i'),
-		onDamage : new RegExp('onDamage', 'i'),
-		onCreatureMove : new RegExp('onCreatureMove', 'i'),
-		onCreatureDeath : new RegExp('onCreatureDeath', 'i'),
-		onCreatureSummon : new RegExp('onCreatureSummon', 'i'),
+		onStepIn : /\bonStepIn\b/,
+		onStepOut : /\bonStepOut\b/,
+		onStartPhase : /\bonStartPhase\b/,
+		onEndPhase : /\bonEndPhase\b/,
+		onMovement : /\bonMovement\b/,
+		onAttacked : /\bonAttacked\b/,
+		onDamage : /\bonDamage\b/,
+		onAttack : /\bonAttack\b/,
+		onCreatureMove : /\bonCreatureMove\b/,
+		onCreatureDeath : /\bonCreatureDeath\b/,
+		onCreatureSummon : /\bonCreatureSummon\b/,
 
-		onStepIn_other : new RegExp('onOtherStepIn', 'i'),
-		onStepOut_other : new RegExp('onOtherStepOut', 'i'),
-		onStartPhase_other : new RegExp('onOtherStartPhase', 'i'),
-		onEndPhase_other : new RegExp('onOtherEndPhase', 'i'),
-		onMovement_other : new RegExp('onOtherMovement', 'i'),
-		onAttack_other : new RegExp('onOtherAttack', 'i'),
-		onDamage_other : new RegExp('onOtherDamage', 'i'),
-		onCreatureMove_other : new RegExp('onOtherCreatureMove', 'i'),
-		onCreatureDeath_other : new RegExp('onOtherCreatureDeath', 'i'),
-		onCreatureSummon_other : new RegExp('onOtherCreatureSummon', 'i'),
+		onStepIn_other : /\bonOtherStepIn\b/,
+		onStepOut_other : /\bonOtherStepOut\b/,
+		onStartPhase_other : /\bonOtherStartPhase\b/,
+		onEndPhase_other : /\bonOtherEndPhase\b/,
+		onMovement_other : /\bonOtherMovement\b/,
+		onAttack_other : /\bonOtherAttack\b/,
+		onDamage_other : /\bonOtherDamage\b/,
+		onAttacked_other : /\bonOtherAttacked\b/,
+		onCreatureMove_other : /\bonOtherCreatureMove\b/,
+		onCreatureDeath_other : /\bonOtherCreatureDeath\b/,
+		onCreatureSummon_other : /\bonOtherCreatureSummon\b/,
 
-		onEffectAttachement : new RegExp('onEffectAttachement', 'i'),
-		onEffectAttachement_other : new RegExp('onOtherEffectAttachement', 'i'),
+		onEffectAttachement : /\bonEffectAttachement\b/,
+		onEffectAttachement_other : /\bonOtherEffectAttachement\b/,
 
-		onStartOfRound : new RegExp('onStartOfRound', 'i'),
-		onQuery : new RegExp('onQuery', 'i'),
-		oncePerDamageChain : new RegExp('oncePerDamageChain', 'i')
+		onStartOfRound : /\bonStartOfRound\b/,
+		onQuery : /\bonQuery\b/,
+		oncePerDamageChain : /\boncePerDamageChain\b/
 	},
 
 	triggerAbility : function( trigger, arg, retValue ) {
@@ -786,7 +788,7 @@ var Game = Class.create( {
 		// For triggered creature
 		arg[0].abilities.each(function() {
 			if( arg[0].dead === true ) return;
-			if( G.triggers[trigger].test(this.trigger) ) {
+			if( G.triggers[trigger].test(this.getTrigger()) ) {
 				if( this.require(arg[1]) ) {
 					retValue = this.animation(arg[1]);
 				}
@@ -797,7 +799,7 @@ var Game = Class.create( {
 		G.creatures.each(function() {
 			if( arg[0] === this || this.dead === true ) return;
 			this.abilities.each(function() {
-				if( G.triggers[trigger+"_other"].test(this.trigger) ) {
+				if( G.triggers[trigger+"_other"].test(this.getTrigger()) ) {
 					if( this.require(arg[1]) ) {
 						retValue = this.animation(arg[1], arg[0]);
 					}
@@ -927,15 +929,20 @@ var Game = Class.create( {
 		},
 
 
-		onAttack : function( creature, damage ) {
-			damage = G.triggerAbility("onAttack", arguments, damage);
-			damage = G.triggerEffect("onAttack", arguments, damage);
+		onAttacked : function( creature, damage ) {
+			damage = G.triggerAbility("onAttacked", arguments, damage);
+			damage = G.triggerEffect("onAttacked", arguments, damage);
 			return damage;
 		},
 
 		onDamage : function( creature, damage ) {
 			G.triggerAbility("onDamage", arguments);
 			G.triggerEffect("onDamage", arguments);
+		},
+
+		onAttack : function( creature, damage ) {
+			damage = G.triggerAbility("onAttack", arguments, damage);
+			damage = G.triggerEffect("onAttack", arguments, damage);
 		}
 	},
 

--- a/development/src/interface.js
+++ b/development/src/interface.js
@@ -141,39 +141,39 @@ var UI = Class.create( {
 			}
 		});
 
+		var hotkeys = {
+			overview: 9, // Tab TODO: This should open/close score screen
+			cycle: 81, // Q TODO: Make this work
+			attack: 87, // W
+			ability: 69, // E
+			ultimate: 82, // R
+			audio: 65, // A TODO: Make this work
+			skip: 83, // S
+			delay: 68, // D
+			flee: 70, // F
+			chat: 13, // Return TODO: Should open, send & hide chat
+			close: 27, // Escape
+			//pause: 80, // P, might get deprecated
+			show_grid: 16, // Shift
+			dash_up: 38, // Up arrow
+			dash_down: 40, // Down arrow
+			dash_left: 37, // Left arrow
+			dash_right: 39, // Right arrow
+			dash_materializeButton: 13, // Return
+
+			grid_up: 38, // Up arrow
+			grid_down: 40, // Down arrow
+			grid_left: 37, // Left arrow
+			grid_right: 39, // Right arrow
+			grid_confirm: 32 // Space
+		};
+
 		// Binding Hotkeys
 		$j(document).keydown(function(e) {
 			if(G.freezedInput) return;
 
 			var keypressed = e.keyCode || e.which;
 			//console.log(keypressed); // For debugging
-
-			hotkeys = {
-				overview: 9, // Tab TODO: This should open/close score screen
-				cycle: 81, // Q TODO: Make this work
-				attack: 87, // W
-				ability: 69, // E
-				ultimate: 82, // R
-				audio: 65, // A TODO: Make this work
-				skip: 83, // S
-				delay: 68, // D
-				flee: 70, // F
-				chat: 13, // Return TODO: Should open, send & hide chat
-				close: 27, // Escape
-				//pause: 80, // P, might get deprecated
-				show_grid: 16, // Shift
-				dash_up: 38, // Up arrow
-				dash_down: 40, // Down arrow
-				dash_left: 37, // Left arrow
-				dash_right: 39, // Right arrow
-				dash_materializeButton: 13, // Return
-
-				grid_up: 38, // Up arrow
-				grid_down: 40, // Down arrow
-				grid_left: 37, // Left arrow
-				grid_right: 39, // Right arrow
-				grid_confirm: 32 // Space
-			};
 
 			var prevD = false;
 


### PR DESCRIPTION
Here's the toxic spores part for #874, but I'm not sure about the changes so I would like a review first.

- Renamed `onAttack` to `onAttacked`, and added an `onAttack` trigger. So `onAttack` is when a creature attacks another, and `onAttacked` is when a creature is attacked by another. I didn't find an existing trigger for when a creature is attacked, hence adding this new trigger.
- Adding an `Ability.triggerFunc()`, which is used when `Ability.trigger` is undefined. This is to implement Toxic Spore's upgrade, which needs to trigger on both `onAttack` and `onAttacked`. There's no precedent for dynamic triggers, so this was the one that required the least amount of code changes. If I completely replaced `Ability.trigger` with a function, that will require code changes to all the existing ability files.
- Also, I removed [this line](https://github.com/FreezingMoon/AncientBeast/compare/master...cxong:master#diff-c3a976b8e51fd3cbb1793b29e516eaa8L188) because otherwise Toxic Spore would trigger twice, but I'm not sure if this breaks any existing abilities.