### PR TITLE
Gumble ability tweaks (#899)

### DIFF
--- a/development/deploy/css/cards.css
+++ b/development/deploy/css/cards.css
@@ -67,7 +67,6 @@
 .ability { position: relative; }
 
 .abilities .ability .wrapper{
-	display: table-cell;
 	height: 100px;
 	padding-left: 103px;
 	vertical-align: middle;

--- a/development/deploy/units/data.json
+++ b/development/deploy/units/data.json
@@ -1213,7 +1213,7 @@
 				"info": "16 crush damage done to 7 hexagons.",
 				"upgrade" : "Does half damage to allies.",
 				"damages": {
-					"crush": 15
+					"crush": 16
 				},
 				"costs": {
 					"energy": 30
@@ -1228,7 +1228,7 @@
 					"special": "%movement% is set to 0 for a turn."
 				}],
 				"costs": {
-					"energy": 31
+					"energy": 20
 				}
             },
 			{
@@ -1243,7 +1243,7 @@
 					"special": "One hexagon knockback."
 				}],
 				"costs": {
-					"energy": 32
+					"energy": 30
 				}
             }
         ]

--- a/development/src/abilities.js
+++ b/development/src/abilities.js
@@ -35,6 +35,21 @@ var Ability = Class.create( {
 	},
 
 	/**
+	 * Get modified damage stats
+	 * Some passive abilities may modify stats for damage purposes
+	 * Apply modifications for this ability
+	 * Note: parameter will be modified in-place
+	 * @param {dict} stats - copy of creature stats
+	 */
+	getModifiedStats: function(stats) {
+		if (this._getModifiedStats === undefined) {
+			return stats;
+		} else {
+			return this._getModifiedStats(stats);
+		}
+	},
+
+	/**
 	 * Reset ability at start of turn.
 	 */
 	reset: function() {
@@ -505,9 +520,9 @@ var Damage = Class.create( {
 	/* applyDamage()
 	*/
 	applyDamage: function() {
-		var trg = this.target.stats;
+		var trg = this.target.getModifiedStats();
 		var dmg = this;
-		var atk = dmg.attacker.stats;
+		var atk = dmg.attacker.getModifiedStats();
 		var returnObj = {total:0};
 
 		// DAMAGE CALCULATION

--- a/development/src/abilities.js
+++ b/development/src/abilities.js
@@ -282,11 +282,11 @@ var Ability = Class.create( {
 	*
 	*	targets : Array : Example : target = [ { target: crea1, hexsHit: 2 }, { target: crea2, hexsHit: 1 } ]
 	*/
-	areaDamage : function(attacker, type, damages, effects, targets, notrigger) {
+	areaDamage: function(attacker, damages, effects, targets, notrigger) {
 		var multiKill = 0;
 		for (var i = 0; i < targets.length; i++) {
 			if(targets[i]===undefined) continue;
-			dmg = new Damage(attacker, type, damages, targets[i].hexsHit, effects);
+			dmg = new Damage(attacker, damages, targets[i].hexsHit, effects);
 			multiKill += (targets[i].target.takeDamage(dmg, notrigger).kill+0);
 		}
 		if(multiKill>1)	attacker.player.score.push( { type: "combo", kills: multiKill } );
@@ -485,17 +485,15 @@ abilities = []; // Array containing all javascript methods for abilities
 */
 var Damage = Class.create( {
 
-	/* Constructor(amount,type,effects)
+	/**
 	*
 	*	attacker :	Creature : Unit that initiated the damage
-	*	type :	String : Can be "target", "zone" or "effect"
 	*	damages :	Object : Object containing the damage by type {frost : 5} for example
 	*	area :	Integer : Number of hexagons being hit
 	*	effects :	Array : Contains Effect object to apply to the target
 	*/
-	initialize: function(attacker, type, damages, area, effects) {
+	initialize: function(attacker, damages, area, effects) {
 		this.attacker = attacker;
-		this.type = type;
 		this.damages = damages;
 		this.status = "";
 		this.effects = effects;
@@ -527,12 +525,7 @@ var Damage = Class.create( {
 		returnObj.total = Math.max(returnObj.total, 1); // Minimum of 1 damage
 
 		return returnObj;
-	},
-
-	dmgIsType :function(type) {
-		return G.dmgType[type].test(this.type);
-	},
-
+	}
 });
 
 

--- a/development/src/abilities.js
+++ b/development/src/abilities.js
@@ -512,10 +512,11 @@ var Damage = Class.create( {
 
 		// DAMAGE CALCULATION
 		$j.each(this.damages,function(key, value) {
+			var points;
 			if(key=="pure") { // Bypass defense calculation
-				var points = value;
+				points = value;
 			} else {
-				var points = Math.round(value * (1 + (atk.offense - trg.defense / dmg.area + atk[key] - trg[key] )/100));
+				points = Math.round(value * (1 + (atk.offense - trg.defense / dmg.area + atk[key] - trg[key] )/100));
 				//For Debuging
 				if( G.debugMode ) console.log("damage = " + value + key + "dmg * (1 + (" + atk.offense + "atkoffense - " + trg.defense + "trgdefense / " + dmg.area + "area + " + atk[key] + "atk" + key + " - " + trg[key] + "trg" + key + " )/100)");
 			}

--- a/development/src/abilities.js
+++ b/development/src/abilities.js
@@ -575,6 +575,9 @@ var Effect = Class.create( {
 	activate: function(arg) {
 		if( !this.requireFn(arg) ) return false;
 		if( !this.noLog ) console.log("Effect " + this.name + " triggered");
+		if (arg instanceof Creature) {
+			arg.addEffect(this);
+		}
 		this.effectFn(this,arg);
 	},
 

--- a/development/src/abilities.js
+++ b/development/src/abilities.js
@@ -35,21 +35,6 @@ var Ability = Class.create( {
 	},
 
 	/**
-	 * Get modified damage stats
-	 * Some passive abilities may modify stats for damage purposes
-	 * Apply modifications for this ability
-	 * Note: parameter will be modified in-place
-	 * @param {dict} stats - copy of creature stats
-	 */
-	getModifiedStats: function(stats) {
-		if (this._getModifiedStats === undefined) {
-			return stats;
-		} else {
-			return this._getModifiedStats(stats);
-		}
-	},
-
-	/**
 	 * Reset ability at start of turn.
 	 */
 	reset: function() {
@@ -520,9 +505,9 @@ var Damage = Class.create( {
 	/* applyDamage()
 	*/
 	applyDamage: function() {
-		var trg = this.target.getModifiedStats();
+		var trg = this.target.stats;
 		var dmg = this;
-		var atk = dmg.attacker.getModifiedStats();
+		var atk = dmg.attacker.stats;
 		var returnObj = {total:0};
 
 		// DAMAGE CALCULATION

--- a/development/src/abilities.js
+++ b/development/src/abilities.js
@@ -541,12 +541,13 @@ var Damage = Class.create( {
 */
 var Effect = Class.create( {
 
-	/* Constructor(owner,parent,trigger,effectFn)
+	/* Constructor(name, owner, target, trigger, optArgs)
 	*
+	* @param {string} name: name of the effect
 	*	owner :	Creature : Creature that casted the effect
 	*	target :	Object : Creature or Hex : the object that possess the effect
 	*	trigger :	String : Event that trigger the effect
-	*	effectFn :	Function : Function to trigger
+	*	@param {object} optArgs: dictionary of optional arguments
 	*/
 	initialize: function(name, owner, target, trigger, optArgs) {
 		this.id = effectId++;

--- a/development/src/abilities/Abolished.js
+++ b/development/src/abilities/Abolished.js
@@ -82,7 +82,6 @@ G.abilities[7] =[
 
 		var damage = new Damage(
 			ability.creature, // Attacker
-			"target", // Attack Type
 			ability.damages, // Damage Type
 			1, // Area
 			[]	// Effects
@@ -174,7 +173,7 @@ G.abilities[7] =[
 
 		// Leave a Firewall in old location
 		var effectFn = function(effect,crea) {
-			crea.takeDamage(new Damage( effect.attacker, "effect", ability.damages , 1,[] ));
+			crea.takeDamage(new Damage( effect.attacker, ability.damages , 1,[] ));
 			this.trap.destroy();
 		};
 
@@ -246,7 +245,6 @@ G.abilities[7] =[
 		targets.each(function() {
 			this.target.takeDamage(new Damage(
 				ability.creature, // Attacker
-				"area", // Attack Type
 				ability.damages, // Damage Type
 				1, // Area
 				[]	// Effects

--- a/development/src/abilities/Chimera.js
+++ b/development/src/abilities/Chimera.js
@@ -89,7 +89,6 @@ G.abilities[45] =[
 
 		var damage = new Damage(
 			ability.creature, // Attacker
-			"target", // Attack Type
 			ability.damages, // Damage Type
 			1, // Area
 			[]	// Effects
@@ -154,13 +153,11 @@ G.abilities[45] =[
 			( path[0].direction == 4 && !ability.creature.player.flipped )  ||
 			( path[0].direction == 1 && ability.creature.player.flipped )
 		);
-		console.log(invertFlipped)
 
 		var target = path.last().creature;
 
 		var damage = new Damage(
 			ability.creature, // Attacker
-			"target", // Attack Type
 			ability.damages, // Damage Type
 			1, // Area
 			[]	// Effects
@@ -184,7 +181,6 @@ G.abilities[45] =[
 
 			var damage = new Damage(
 				ability.creature, // Attacker
-				"target", // Attack Type
 				{sonic:result.damages.sonic}, // Damage Type
 				1, // Area
 				[]	// Effects
@@ -257,7 +253,6 @@ G.abilities[45] =[
 
 			var damage = new Damage(
 				ability.creature, // Attacker
-				"target", // Attack Type
 				nextdmg, // Damage Type
 				1, // Area
 				[] // Effects

--- a/development/src/abilities/Cyber Hound.js
+++ b/development/src/abilities/Cyber Hound.js
@@ -33,7 +33,6 @@ G.abilities[31] =[
 
 		var damage = new Damage(
 			this.creature, // Attacker
-			"target", // Attack Type
 			this.damages, // Damage Type
 			1, // Area
 			[]	// Effects
@@ -86,7 +85,6 @@ G.abilities[31] =[
 
 		var damage = new Damage(
 			ability.creature, // Attacker
-			"target", // Attack Type
 			ability.damages, // Damage Type
 			1, // Area
 			[]	// Effects
@@ -191,7 +189,6 @@ G.abilities[31] =[
 
 			var damage = new Damage(
 				ability.creature, //Attacker
-				"target", //Attack Type
 				ability.damages, //Damage Type
 				1, //Area
 				[]	//Effects
@@ -268,7 +265,6 @@ G.abilities[31] =[
 		G.log("%CreatureName" + this.creature.id + "% redirects " + rocketsToUse + " rocket(s)");
 		var damage = new Damage(
 			ability.creature, // Attacker
-			"target", // Attack Type
 			damages, // Damage Type
 			1, // Area
 			[]	// Effects

--- a/development/src/abilities/Dark Priest.js
+++ b/development/src/abilities/Dark Priest.js
@@ -28,7 +28,6 @@ G.abilities[0] =[
                     //counter damage
                     var counter=new Damage(
                         this.creature, // Attacker
-                        "target", // Attack Type
                         {pure:5}, // Damage Type
                         1, // Area
                         []	// Effects
@@ -96,7 +95,6 @@ G.abilities[0] =[
 
 		var damage = new Damage(
 			ability.creature, // Attacker
-			"target", // Attack Type
 			damage, // Damage Type
 			1, // Area
 			[]	// Effects
@@ -172,7 +170,6 @@ G.abilities[0] =[
 
 		damage = new Damage(
 			ability.creature, // Attacker
-			"target", // Attack Type
 			{ pure: damage }, // Damage Type
 			1, // Area
 			[]	// Effects

--- a/development/src/abilities/Golden Wyrm.js
+++ b/development/src/abilities/Golden Wyrm.js
@@ -132,7 +132,6 @@ G.abilities[33] =[
 
 		var damage = new Damage(
 			ability.creature, // Attacker
-			"target", // Attack Type
 			ability.damages, // Damage Type
 			1, // Area
 			[]	// Effects
@@ -274,7 +273,6 @@ G.abilities[33] =[
 
 		var damage = new Damage(
 			ability.creature, //Attacker
-			"target", //Attack Type
 			ability.damages, //Damage Type
 			1, //Area
 			[]	//Effects

--- a/development/src/abilities/Gumble.js
+++ b/development/src/abilities/Gumble.js
@@ -7,14 +7,49 @@ G.abilities[14] =[
 
 // 	First Ability: Gooey Body
 {
+	// Update stat buffs whenever health changes
+	trigger: "onCreatureSummon onDamage onHeal",
+
 	require : function() {
 		// Always active
 		return true;
 	},
 
 	activate: function() {
-		// Do nothing; ability is passive buff only
-	}
+		if (this.creature.dead) {
+			return;
+		}
+		// Attach a permanent effect that gives Gumble stat buffs
+		// Bonus points to pierce, slash and crush based on remaining health
+		var healthBonusDivisor = this.isUpgraded() ? 5 : 10;
+		var bonus = Math.floor(this.creature.health / healthBonusDivisor);
+		// Log whenever the bonus applied changes
+		var noLog = bonus == this._lastBonus;
+		this._lastBonus = bonus;
+		var statsToApplyBonus = ['pierce', 'slash', 'crush'];
+		var alterations = {};
+		for (var i = 0; i < statsToApplyBonus.length; i++) {
+			var key = statsToApplyBonus[i];
+			alterations[key] = bonus;
+		}
+		this.creature.replaceEffect(new Effect(
+			"Gooey Body",		// name
+			this.creature,	// Caster
+			this.creature,	// Target
+			"",							// Trigger
+			{
+				alterations: alterations,
+				deleteTrigger: "",
+				stackable: false,
+				noLog: noLog
+			}
+		));
+		if (!noLog) {
+			G.log("%CreatureName" + this.creature.id + "%'s pierce, slash and crush are buffed by " + bonus);
+		}
+	},
+
+	_lastBonus: 0
 },
 
 

--- a/development/src/abilities/Gumble.js
+++ b/development/src/abilities/Gumble.js
@@ -175,11 +175,11 @@ G.abilities[14] =[
 					requireFn: function(crea) { return crea !== this.owner; },
 					effectFn: function(effect, crea) {
 						crea.remainingMove = 0;
-						// Immobilize target so that they can't move and no
-						// abilities/effects can move them
-						crea.stats.moveable = false;
 						this.trap.destroy();
-					}
+					},
+					// Immobilize target so that they can't move and no
+					// abilities/effects can move them
+					alterations: { moveable: false }
 				}
 			);
 

--- a/development/src/abilities/Gumble.js
+++ b/development/src/abilities/Gumble.js
@@ -102,20 +102,16 @@ G.abilities[14] =[
 		});
 	},
 
-
-	//	activate() :
-	activate : function(target, args) {
+	activate: function(hexes, args) {
 		var ability = this;
 		ability.end();
 
-		var damage = new Damage(
-			ability.creature, // Attacker
-			"target", // Attack Type
-			ability.damages, // Damage Type
-			1, // Area
-			[] // Effects
+		ability.areaDamage(
+			ability.creature, //Attacker
+			ability.damages, //Damage Type
+			[],	//Effects
+			ability.getTargets(hexes) //Targets
 		);
-		target.takeDamage(damage);
 	},
 },
 
@@ -225,7 +221,6 @@ G.abilities[14] =[
 
 		var damage = new Damage(
 			ability.creature, // Attacker
-			"target", // Attack Type
 			d, // Damage Type
 			1, // Area
 			[] // Effects

--- a/development/src/abilities/Gumble.js
+++ b/development/src/abilities/Gumble.js
@@ -7,35 +7,14 @@ G.abilities[14] =[
 
 // 	First Ability: Gooey Body
 {
-	//	Type : Can be "onQuery", "onStartPhase", "onDamage"
-	trigger : "onStartPhase",
-
-	// 	require() :
-	require : function(damage) {
-		if( !this.testRequirements() ) return false;
-
-		if( !this.atLeastOneTarget( this.creature.adjacentHexs(1), "ally" ) ) {
-			this.message = G.msg.abilities.notarget;
-			return false;
-		}
-
+	require : function() {
+		// Always active
 		return true;
 	},
 
-	//	activate() :
-	activate : function() {
-		var ability = this;
-		ability.end();
-
-		var crea = this.creature;
-		var targets = this.getTargets(crea.adjacentHexs(1));
-		var nbrAlly = 0;
-		for (var i = 0; i < targets.length; i++) {
-			if(targets[i]===undefined) continue;
-			if(targets[i].target.isAlly(crea.team)) nbrAlly++;
-		};
-		crea.heal(crea.stats.health*nbrAlly/6);
-	},
+	activate: function() {
+		// Do nothing; ability is passive buff only
+	}
 },
 
 

--- a/development/src/abilities/Gumble.js
+++ b/development/src/abilities/Gumble.js
@@ -172,7 +172,11 @@ G.abilities[14] =[
 			var effect = new Effect(
 				"Royal Seal", ability.creature, hex, "onStepIn",
 				{
-					requireFn: function(crea) { return crea !== this.owner; },
+					// Gumbles immune
+					requireFn: function() {
+						var crea = this.trap.hex.creature;
+						return crea && crea.type !== this.owner.type;
+					},
 					effectFn: function(effect, crea) {
 						crea.remainingMove = 0;
 						this.trap.destroy();

--- a/development/src/abilities/Gumble.js
+++ b/development/src/abilities/Gumble.js
@@ -90,6 +90,12 @@ G.abilities[14] =[
 			G.grid.getHexMap(
 				this.creature.x-1+dx, this.creature.y-2+dy, 0, false, area),	// up-left
 		];
+		// Reorder choices based on number of hexes
+		// This ensures that if a choice contains overlapping hexes only, that
+		// choice won't be available for selection.
+		choices.sort(function(choice1, choice2) {
+			return choice1.length < choice2.length;
+		});
 		G.grid.queryChoice({
 			fnOnCancel: function() {
 				G.activeCreature.queryMove();

--- a/development/src/abilities/Gumble.js
+++ b/development/src/abilities/Gumble.js
@@ -14,19 +14,6 @@ G.abilities[14] =[
 
 	activate: function() {
 		// Do nothing; ability is passive buff only
-	},
-
-	_getModifiedStats: function(stats) {
-		// This ability modifies the creature's stats when damage is applied
-		// Bonus points to pierce, slash and crush based on remaining health
-		var healthBonusDivisor = this.isUpgraded() ? 5 : 10;
-		var bonus = Math.floor(stats.health / healthBonusDivisor);
-		var statsToApplyBonus = ['pierce', 'slash', 'crush'];
-		for (var i = 0; i < statsToApplyBonus.length; i++) {
-			var key = statsToApplyBonus[i];
-			stats[key] = stats[key] + bonus;
-		}
-		return stats;
 	}
 },
 

--- a/development/src/abilities/Gumble.js
+++ b/development/src/abilities/Gumble.js
@@ -280,8 +280,10 @@ G.abilities[14] =[
 				break;
 		}
 
+		var canKnockBack = dir.length > 1 && target.stats.moveable;
+
 		// Perform extra damage if upgraded and cannot push back
-		if (this.isUpgraded() && dir.length <= 1) {
+		if (this.isUpgraded() && !canKnockBack) {
 			d.sonic += 10;
 		}
 
@@ -297,7 +299,7 @@ G.abilities[14] =[
 		if (result.kill) return; // if creature die stop here
 
 		// Knockback the target 1 hex
-		if (dir.length > 1) {
+		if (canKnockBack) {
 			if (dir[1].isWalkable(target.size, target.id, true)) {
 				target.moveTo(dir[1], {
 					ignoreMovementPoint : true,

--- a/development/src/abilities/Gumble.js
+++ b/development/src/abilities/Gumble.js
@@ -175,8 +175,11 @@ G.abilities[14] =[
 					requireFn: function(crea) { return crea !== this.owner; },
 					effectFn: function(effect, crea) {
 						crea.remainingMove = 0;
+						// Immobilize target so that they can't move and no
+						// abilities/effects can move them
+						crea.stats.moveable = false;
 						this.trap.destroy();
-					},
+					}
 				}
 			);
 

--- a/development/src/abilities/Gumble.js
+++ b/development/src/abilities/Gumble.js
@@ -142,8 +142,8 @@ G.abilities[14] =[
 		var showConfirm = true;
 		if (this.isUpgraded()) {
 			// Upgraded Royal Seal can target up to 4 hexes range
-			hexes = G.grid.getFlyingRange(
-				creature.x, creature.y, 4, creature.size, creature.id);
+			hexes = hexes.concat(G.grid.getFlyingRange(
+				creature.x, creature.y, 4, creature.size, creature.id));
 			showConfirm = false;
 		}
 		// If we can only target one hex (unupgraded) then show a confirm hint

--- a/development/src/abilities/Gumble.js
+++ b/development/src/abilities/Gumble.js
@@ -138,14 +138,24 @@ G.abilities[14] =[
 		var ability = this;
 		var creature = this.creature;
 
-		creature.hint("Confirm", "confirm constant");
+		var hexes = creature.hexagons;
+		var showConfirm = true;
+		if (this.isUpgraded()) {
+			// Upgraded Royal Seal can target up to 4 hexes range
+			hexes = creature.hexagons[0].adjacentHex(4);
+			showConfirm = false;
+		}
+		// If we can only target one hex (unupgraded) then show a confirm hint
+		if (showConfirm) {
+			creature.hint("Confirm", "confirm constant");
+		}
 
 		G.grid.queryHexs({
 			fnOnConfirm : function() { ability.animation.apply(ability, arguments); },
 			size : creature.size,
 			flipped : creature.player.flipped,
 			id : creature.id,
-			hexs : creature.hexagons,
+			hexs: hexes,
 			ownCreatureHexShade : true,
 			hideNonTarget : true
 		});
@@ -154,23 +164,20 @@ G.abilities[14] =[
 
 	//	activate() :
 	activate : function(hex) {
-		var hex = this.creature.hexagons[0];
 		this.end();
 
-		var effects = [
-			new Effect(
-				"Royal Seal", this.creature, hex, "onStepIn",
-				{
-					requireFn: function(crea) { return crea !== this.owner; },
-					effectFn: function(effect, crea) {
-						crea.remainingMove = 0;
-						this.trap.destroy();
-					},
-				}
-			),
-		]
+		var effect = new Effect(
+			"Royal Seal", this.creature, hex, "onStepIn",
+			{
+				requireFn: function(crea) { return crea !== this.owner; },
+				effectFn: function(effect, crea) {
+					crea.remainingMove = 0;
+					this.trap.destroy();
+				},
+			}
+		);
 
-		var trap = hex.createTrap("royal-seal", effects, this.creature.player);
+		var trap = hex.createTrap("royal-seal", [effect], this.creature.player);
 		trap.hide();
 	},
 },

--- a/development/src/abilities/Gumble.js
+++ b/development/src/abilities/Gumble.js
@@ -265,38 +265,36 @@ G.abilities[14] =[
 
 		var result = target.takeDamage(damage, true);
 
-		// if( result.kill ) return; // if creature die stop here
+		if (result.kill) return; // if creature die stop here
 
 		var dir = [];
 		switch( args.direction ) {
-			case 3: // Upright
-				dir = G.grid.getHexMap(ability.creature.x, ability.creature.y-8, 0, ability.creature.flipped, diagonalup).reverse();
+			case 0: // Upright
+				dir = G.grid.getHexMap(target.x, target.y-8, 0, target.flipped, diagonalup).reverse();
 				break;
-			case 4: // StraitForward
-				dir = G.grid.getHexMap(ability.creature.x, ability.creature.y, 0, ability.creature.flipped, straitrow);
+			case 1: // StraitForward
+				dir = G.grid.getHexMap(target.x, target.y, 0, target.flipped, straitrow);
 				break;
-			case 5: // Downright
-				dir = G.grid.getHexMap(ability.creature.x, ability.creature.y, 0, ability.creature.flipped, diagonaldown);
+			case 2: // Downright
+				dir = G.grid.getHexMap(target.x, target.y, 0, target.flipped, diagonaldown);
 				break;
-			case 0: // Downleft
-				dir = G.grid.getHexMap(ability.creature.x, ability.creature.y, -4, ability.creature.flipped, diagonalup);
+			case 3: // Downleft
+				dir = G.grid.getHexMap(target.x, target.y, -4, target.flipped, diagonalup);
 				break;
-			case 1: // StraitBackward
-				dir = G.grid.getHexMap(ability.creature.x, ability.creature.y, 0, !ability.creature.flipped, straitrow);
+			case 4: // StraitBackward
+				dir = G.grid.getHexMap(target.x, target.y, 0, !target.flipped, straitrow);
 				break;
-			case 2: // Upleft
-				dir = G.grid.getHexMap(ability.creature.x, ability.creature.y-8, -4, ability.creature.flipped, diagonaldown).reverse();
+			case 5: // Upleft
+				dir = G.grid.getHexMap(target.x, target.y-8, -4, target.flipped, diagonaldown).reverse();
 				break;
 			default:
 				break;
 		}
 
-		var pushed = false;
-
-		//Recoil
-		if(dir.length > 1) {
-			if(dir[1].isWalkable(ability.creature.size,ability.creature.id,true)) {
-				ability.creature.moveTo(dir[1], {
+		// Knockback the target 1 hex
+		if (dir.length > 1) {
+			if (dir[1].isWalkable(target.size, target.id, true)) {
+				target.moveTo(dir[1], {
 					ignoreMovementPoint : true,
 					ignorePath : true,
 					callback : function() {
@@ -307,11 +305,9 @@ G.abilities[14] =[
 					},
 					animation : "push",
 				});
-				pushed = true;
 			}
 		}
-
-	},
+	}
 }
 
 ];

--- a/development/src/abilities/Gumble.js
+++ b/development/src/abilities/Gumble.js
@@ -70,24 +70,25 @@ G.abilities[14] =[
 		// center of each area is two hexes away. Each area can be chosen regardless
 		// of whether targets are within.
 		var area = [
-			 [1,1,0],
+			 [1,1],
 			[1,1,1],
-			 [1,1,0]
+			 [1,1]
 		];
-		area.origin = [1, 1];
+		var dx = this.creature.y % 2 !== 0 ? -1 : 0;
+		var dy = -1;
 		var choices = [
 			G.grid.getHexMap(
-				this.creature.x+1, this.creature.y-2-1, 0, false, area),	// up-right
+				this.creature.x+1+dx, this.creature.y-2+dy, 0, false, area),	// up-right
 			G.grid.getHexMap(
-				this.creature.x+2, this.creature.y-1, 0, false, area),	// front
+				this.creature.x+2+dx, this.creature.y+dy, 0, false, area),	// front
 			G.grid.getHexMap(
-				this.creature.x+1, this.creature.y+2-1, 0, false, area),	// down-right
+				this.creature.x+1+dx, this.creature.y+2+dy, 0, false, area),	// down-right
 			G.grid.getHexMap(
-				this.creature.x-1, this.creature.y+2-1, 0, false, area),	// down-left
+				this.creature.x-1+dx, this.creature.y+2+dy, 0, false, area),	// down-left
 			G.grid.getHexMap(
-				this.creature.x-2, this.creature.y-1, 0, false, area),	// back
+				this.creature.x-2+dx, this.creature.y+dy, 0, false, area),	// back
 			G.grid.getHexMap(
-				this.creature.x-1, this.creature.y-2-1, 0, false, area),	// up-left
+				this.creature.x-1+dx, this.creature.y-2+dy, 0, false, area),	// up-left
 		];
 		G.grid.queryChoice({
 			fnOnCancel: function() {

--- a/development/src/abilities/Gumble.js
+++ b/development/src/abilities/Gumble.js
@@ -256,17 +256,6 @@ G.abilities[14] =[
 
 		var d = (melee) ? { sonic: 20, crush: 10 } : { sonic: 20 };
 
-		var damage = new Damage(
-			ability.creature, // Attacker
-			d, // Damage Type
-			1, // Area
-			[] // Effects
-		);
-
-		var result = target.takeDamage(damage, true);
-
-		if (result.kill) return; // if creature die stop here
-
 		var dir = [];
 		switch( args.direction ) {
 			case 0: // Upright
@@ -290,6 +279,22 @@ G.abilities[14] =[
 			default:
 				break;
 		}
+
+		// Perform extra damage if upgraded and cannot push back
+		if (this.isUpgraded() && dir.length <= 1) {
+			d.sonic += 10;
+		}
+
+		var damage = new Damage(
+			ability.creature, // Attacker
+			d, // Damage Type
+			1, // Area
+			[] // Effects
+		);
+
+		var result = target.takeDamage(damage, true);
+
+		if (result.kill) return; // if creature die stop here
 
 		// Knockback the target 1 hex
 		if (dir.length > 1) {

--- a/development/src/abilities/Gumble.js
+++ b/development/src/abilities/Gumble.js
@@ -14,6 +14,19 @@ G.abilities[14] =[
 
 	activate: function() {
 		// Do nothing; ability is passive buff only
+	},
+
+	_getModifiedStats: function(stats) {
+		// This ability modifies the creature's stats when damage is applied
+		// Bonus points to pierce, slash and crush based on remaining health
+		var healthBonusDivisor = this.isUpgraded() ? 5 : 10;
+		var bonus = Math.floor(stats.health / healthBonusDivisor);
+		var statsToApplyBonus = ['pierce', 'slash', 'crush'];
+		for (var i = 0; i < statsToApplyBonus.length; i++) {
+			var key = statsToApplyBonus[i];
+			stats[key] = stats[key] + bonus;
+		}
+		return stats;
 	}
 },
 

--- a/development/src/abilities/Headless.js
+++ b/development/src/abilities/Headless.js
@@ -96,7 +96,6 @@ G.abilities[39] =[
 
 		var damage = new Damage(
 			ability.creature, //Attacker
-			"target", //Attack Type
 			d, //Damage Type
 			1, //Area
 			[]	//Effects
@@ -312,7 +311,6 @@ G.abilities[39] =[
 
 		ability.areaDamage(
 			ability.creature, //Attacker
-			"zone", //Attack Type
 			damages, //Damage Type
 			[],	//Effects
 			ability.getTargets(hexs), //Targets
@@ -321,7 +319,6 @@ G.abilities[39] =[
 
 		ability.areaDamage(
 			ability.creature, //Attacker
-			"zone", //Attack Type
 			damages, //Damage Type
 			[],	//Effects
 			ability.getTargets(hexs) //Targets

--- a/development/src/abilities/Ice Demon.js
+++ b/development/src/abilities/Ice Demon.js
@@ -154,7 +154,6 @@ G.abilities[6] =[
 
 		var damage = new Damage(
 			ability.creature, //Attacker
-			"target", //Attack Type
 			d, //Damage Type
 			1, //Area
 			[]	//Effects
@@ -242,7 +241,6 @@ G.abilities[6] =[
 				choice[i].creature.takeDamage(
 					new Damage(
 						ability.creature, // Attacker
-						"area", // Attack Type
 						ability.damages1, // Damage Type
 						1, // Area
 						[]	// Effects
@@ -330,7 +328,6 @@ G.abilities[6] =[
 
 		// var damage = new Damage(
 		// 	ability.creature, //Attacker
-		// 	"target", //Attack Type
 		// 	ability.damages, //Damage Type
 		// 	1, //Area
 		// 	[]	//Effects
@@ -353,7 +350,6 @@ G.abilities[6] =[
 
 		ability.areaDamage(
 			ability.creature,
-			"area",
 			ability.damages,
 			[effect], // Effects
 			trgs

--- a/development/src/abilities/Impaler.js
+++ b/development/src/abilities/Impaler.js
@@ -114,7 +114,6 @@ G.abilities[5] =[
 
 		var damage = new Damage(
 			ability.creature, // Attacker
-			"target", // Attack Type
 			finalDmg, // Damage Type
 			1, // Area
 			[] // Effects
@@ -219,7 +218,6 @@ G.abilities[5] =[
 
 			var damage = new Damage(
 				ability.creature, // Attacker
-				"target", // Attack Type
 				nextdmg, // Damage Type
 				1, // Area
 				[] // Effects

--- a/development/src/abilities/Lava Mollusk.js
+++ b/development/src/abilities/Lava Mollusk.js
@@ -29,7 +29,6 @@ G.abilities[22] =[
 
 		this.areaDamage(
 			this.creature, // Attacker
-			"area retaliation", // Attack Type
 			this.damages, // Damage Type
 			[],	// Effects
 			targets
@@ -90,7 +89,6 @@ G.abilities[22] =[
 
 		var damage = new Damage(
 			ability.creature, //Attacker
-			"target", //Attack Type
 			ability.damages, //Damage Type
 			1, //Area
 			[]	//Effects
@@ -268,7 +266,6 @@ G.abilities[22] =[
 		if(hex.creature instanceof Creature){
 			hex.creature.takeDamage(new Damage(
 				ability.creature, //Attacker
-				"area", //Attack Type
 				ability.damages1, //Damage Type
 				1, //Area
 				[]	//Effects
@@ -278,7 +275,6 @@ G.abilities[22] =[
 
 		ability.areaDamage(
 			ability.creature,
-			"area",
 			ability.damages2,
 			[],	//Effects
 			targets

--- a/development/src/abilities/Magma Spawn.js
+++ b/development/src/abilities/Magma Spawn.js
@@ -18,7 +18,7 @@ G.abilities[4] =[
 		var ability = this;
 
 		var effectFn = function(effect,crea) {
-			crea.takeDamage(new Damage( effect.attacker, "effect", ability.damages , 1,[] ));
+			crea.takeDamage(new Damage( effect.attacker, ability.damages , 1,[] ));
 			this.trap.destroy();
 		};
 
@@ -94,7 +94,6 @@ G.abilities[4] =[
 
 		var damage = new Damage(
 			ability.creature, // Attacker
-			"target", // Attack Type
 			d, // Damage Type
 			1, // Area
 			[]	// Effects
@@ -165,7 +164,6 @@ G.abilities[4] =[
 		// Basic Attack all nearby creatures
 		ability.areaDamage(
 			ability.creature, // Attacker
-			"zone", //Attack Type
 			ability.damages1, // Damage Type
 			[],	// Effects
 			ability.getTargets(hexs) // Targets
@@ -253,7 +251,6 @@ G.abilities[4] =[
 		// Damage
 		var damage = new Damage(
 			ability.creature, // Attacker
-			"target", // Attack Type
 			ability.damages, // Damage Type
 			1, // Area
 			[]	// Effects

--- a/development/src/abilities/Nightmare.js
+++ b/development/src/abilities/Nightmare.js
@@ -83,7 +83,6 @@ G.abilities[9] =[
 
 		var damage = new Damage(
 			ability.creature, // Attacker
-			"target", // Attack Type
 			ability.damages, // Damage Type
 			1, //Area
 			[
@@ -140,7 +139,6 @@ G.abilities[9] =[
 
 		var damage = new Damage(
 			ability.creature, //Attacker
-			"target", //Attack Type
 			ability.damages, //Damage Type
 			1, //Area
 			[]	//Effects
@@ -221,7 +219,6 @@ G.abilities[9] =[
 				//Damage
 				var damage = new Damage(
 					ability.creature, //Attacker
-					"target", //Attack Type
 					d, //Damage Type
 					1, //Area
 					[]	//Effects

--- a/development/src/abilities/Nutcase.js
+++ b/development/src/abilities/Nutcase.js
@@ -124,7 +124,6 @@ G.abilities[40] =[
 
 		var damage = new Damage(
 			ability.creature, // Attacker
-			"target", // Attack Type
 			ability.damages, // Damage Type
 			1, // Area
 			[effect]	// Effects
@@ -175,7 +174,6 @@ G.abilities[40] =[
 
 		var damage = new Damage(
 			crea, // Attacker
-			"target", // Attack Type
 			ability.damages, // Damage Type
 			1, // Area
 			[]	// Effects

--- a/development/src/abilities/Scavenger.js
+++ b/development/src/abilities/Scavenger.js
@@ -77,7 +77,6 @@ G.abilities[44] =[
 
 		var damage = new Damage(
 			ability.creature, // Attacker
-			"target", // Attack Type
 			ability.damages, // Damage Type
 			1, // Area
 			[]	// Effects
@@ -286,7 +285,6 @@ G.abilities[44] =[
 
 		var damage = new Damage(
 			ability.creature, //Attacker
-			"target", //Attack Type
 			damages, //Damage Type
 			1, //Area
 			[]	//Effects
@@ -300,7 +298,7 @@ G.abilities[44] =[
 			effectFn: function(effect, creature) {
 				G.log("%CreatureName" + creature.id + "% is affected by " + ability.title);
 				creature.takeDamage(new Damage(
-					effect.owner, "effect", {poison: ability.damages.poison}, 1, []
+					effect.owner, {poison: ability.damages.poison}, 1, []
 				));
 			}
 		});

--- a/development/src/abilities/Snow Bunny.js
+++ b/development/src/abilities/Snow Bunny.js
@@ -131,7 +131,6 @@ G.abilities[12] = [
 
 		var damage = new Damage(
 			ability.creature, // Attacker
-			"target", // Attack Type
 			ability.damages, // Damage Type
 			1, // Area
 			[]	// Effects
@@ -290,11 +289,10 @@ G.abilities[12] = [
 
 		var damage = new Damage(
 			ability.creature, // Attacker
-			"target", // Attack Type
 			dmg, // Damage Type
 			1, // Area
 			[]	// Effects
-		)
+		);
 
 		crea.takeDamage(damage);
 	},

--- a/development/src/abilities/Swine Thug.js
+++ b/development/src/abilities/Swine Thug.js
@@ -104,7 +104,6 @@ G.abilities[37] =[
 
 		var damage = new Damage(
 			ability.creature, // Attacker
-			"target", // Attack Type
 			ability.damages, // Damage Type
 			1, // Area
 			[]	// Effects
@@ -234,7 +233,6 @@ G.abilities[37] =[
 
 		var damage = new Damage(
 			ability.creature, // Attacker
-			"target", // Attack Type
 			ability.damages, // Damage Type
 			1, // Area
 			[]	// Effects

--- a/development/src/abilities/Uncle Fungus.js
+++ b/development/src/abilities/Uncle Fungus.js
@@ -106,7 +106,6 @@ G.abilities[3] =[
 
 		var damage = new Damage(
 			ability.creature, // Attacker
-			"target", // Attack Type
 			ability.damages, // Damage type
 			1, // Area
 			[]	// Effects
@@ -314,7 +313,6 @@ G.abilities[3] =[
 
 		var damage = new Damage(
 			ability.creature, // Attacker
-			"target", // Attack Type
 			ability.damages, // Damage Type
 			1, // Area
 			[]	// Effects

--- a/development/src/creature.js
+++ b/development/src/creature.js
@@ -159,6 +159,17 @@ var Creature = Class.create( {
 
 	},
 
+	/**
+	 * Get creature stats for the purpose of damage calculation
+	 * Some passive abilities may modify this creature's stats; apply them all
+	 */
+	getModifiedStats: function() {
+		var stats = $j.extend({}, this.stats);
+		for (var i = 0; i < this.abilities.length; i++) {
+			stats = this.abilities[i].getModifiedStats(stats);
+		}
+		return stats;
+	},
 
 	/*	summon()
 	*

--- a/development/src/creature.js
+++ b/development/src/creature.js
@@ -159,17 +159,6 @@ var Creature = Class.create( {
 
 	},
 
-	/**
-	 * Get creature stats for the purpose of damage calculation
-	 * Some passive abilities may modify this creature's stats; apply them all
-	 */
-	getModifiedStats: function() {
-		var stats = $j.extend({}, this.stats);
-		for (var i = 0; i < this.abilities.length; i++) {
-			stats = this.abilities[i].getModifiedStats(stats);
-		}
-		return stats;
-	},
 
 	/*	summon()
 	*

--- a/development/src/creature.js
+++ b/development/src/creature.js
@@ -807,7 +807,7 @@ var Creature = Class.create( {
 			G.log("%CreatureName" + this.id + "% loses " + amount + " health");
 		}
 
-
+		G.triggersFn.onHeal(this, amount);
 	},
 
 
@@ -965,9 +965,7 @@ var Creature = Class.create( {
 
 	/**
 	 * Add effect, but if the effect is already attached, replace it with the new
-	 * effect. This is useful in team games where the same effect is used twice on
-	 * the same creature, and the effect shouldn't stack; the new effect should
-	 * belong to the last player to add it.
+	 * effect.
 	 * Note that for stackable effects, this is the same as addEffect()
 	 *
 	 * @param {Effect} effect - the effect to add

--- a/development/src/game.js
+++ b/development/src/game.js
@@ -991,14 +991,6 @@ var Game = Class.create( {
 		return ret;
 	},
 
-
-	/*	Regex Test for damage type */
-	dmgType : {
-		area : new RegExp('area', 'i'),
-		target : new RegExp('target', 'i'),
-		retaliation : new RegExp('retaliation', 'i'),
-	},
-
 	clearOncePerDamageChain: function() {
 		for (var i = this.creatures.length - 1; i >= 0; i--) {
 			if(this.creatures[i] instanceof Creature) {

--- a/development/src/game.js
+++ b/development/src/game.js
@@ -758,6 +758,7 @@ var Game = Class.create( {
 		onMovement : /\bonMovement\b/,
 		onUnderAttack : /\bonUnderAttack\b/,
 		onDamage : /\bonDamage\b/,
+		onHeal: /\bonHeal\b/,
 		onAttack : /\bonAttack\b/,
 		onCreatureMove : /\bonCreatureMove\b/,
 		onCreatureDeath : /\bonCreatureDeath\b/,
@@ -770,6 +771,7 @@ var Game = Class.create( {
 		onMovement_other : /\bonOtherMovement\b/,
 		onAttack_other : /\bonOtherAttack\b/,
 		onDamage_other : /\bonOtherDamage\b/,
+		onHeal_other : /\bonOtherHeal\b/,
 		onUnderAttack_other : /\bonOtherUnderAttack\b/,
 		onCreatureMove_other : /\bonOtherCreatureMove\b/,
 		onCreatureDeath_other : /\bonOtherCreatureDeath\b/,
@@ -938,6 +940,11 @@ var Game = Class.create( {
 		onDamage : function( creature, damage ) {
 			G.triggerAbility("onDamage", arguments);
 			G.triggerEffect("onDamage", arguments);
+		},
+
+		onHeal: function(creature, amount) {
+			G.triggerAbility("onHeal", arguments);
+			G.triggerEffect("onHeal", arguments);
 		},
 
 		onAttack : function( creature, damage ) {

--- a/development/src/utility/hexagons.js
+++ b/development/src/utility/hexagons.js
@@ -226,6 +226,7 @@ var HexGrid = Class.create( {
 			choices : [],
 			hexsDashed : [],
 			isDirectionsQuery : false,
+			hideNonTarget: true
 		};
 
 		o = $j.extend(defaultOpt, o);
@@ -278,10 +279,10 @@ var HexGrid = Class.create( {
 						if(hex.pos == args.opt.choices[i][j].pos) {
 							args.opt.args.direction = hex.direction;
 							args.opt.fnOnConfirm(args.opt.choices[i], args.opt.args);
-							break;
+							return;
 						}
-					};
-				};
+					}
+				}
 			},
 			fnOnSelect : function(hex, args) {
 				// Determine which set of hexs (choice) the hex is part of
@@ -290,17 +291,17 @@ var HexGrid = Class.create( {
 						if(hex.pos==args.opt.choices[i][j].pos) {
 							args.opt.args.direction = hex.direction;
 							args.opt.fnOnSelect(args.opt.choices[i], args.opt.args);
-							break;
+							return;
 						}
-					};
-				};
+					}
+				}
 			},
 			fnOnCancel : o.fnOnCancel,
 			args : { opt : o },
 			hexs : hexs,
 			hexsDashed : o.hexsDashed,
 			flipped : o.flipped,
-			hideNonTarget : true,
+			hideNonTarget: o.hideNonTarget,
 			id : o.id
 		});
 	},

--- a/development/src/utility/hexagons.js
+++ b/development/src/utility/hexagons.js
@@ -201,7 +201,6 @@ var HexGrid = Class.create( {
 	*	fnOnSelect : 		Function : 	Function applied when clicking on one of the available hexs.
 	*	fnOnConfirm : 		Function : 	Function applied when clicking again on the same hex.
 	*	fnOnCancel : 		Function : 	Function applied when clicking a non reachable hex
-	*	team : 				Integer : 	0 = enemies, 1 = allies, 2 = same team, 3 = both
 	*	requireCreature : 	Boolean : 	Disable a choice if it does not contain a creature matching the team argument
 	* 	args : 				Object : 	Object given to the events function (to easily pass variable for these function)
 	*/

--- a/units/data.json
+++ b/units/data.json
@@ -1213,7 +1213,7 @@
 				"info": "16 crush damage done to 7 hexagons.",
 				"upgrade" : "Does half damage to allies.",
 				"damages": {
-					"crush": 15
+					"crush": 16
 				},
 				"costs": {
 					"energy": 30
@@ -1228,7 +1228,7 @@
 					"special": "%movement% is set to 0 for a turn."
 				}],
 				"costs": {
-					"energy": 31
+					"energy": 20
 				}
             },
 			{
@@ -1243,7 +1243,7 @@
 					"special": "One hexagon knockback."
 				}],
 				"costs": {
-					"energy": 32
+					"energy": 30
 				}
             }
         ]


### PR DESCRIPTION
Apart from the ability tweaks, there are some changes to the base game:

- onHeal trigger
- if queryChoice has choices with overlapping hexes, selecting those hexes no longer highlight both choices
- Traps can now apply alterations; this is implemented via .addEffect() which has the side effect of adding trap effects to the log