### PR TITLE
Fixes #1098 - this may not be the best fix, but it appears typeOver f…

### DIFF
--- a/src/abilities/Impaler.js
+++ b/src/abilities/Impaler.js
@@ -177,7 +177,6 @@ G.abilities[5] = [
 						fullTurnLifetime: true,
 						ownerCreature: ability.creature,
 						destroyOnActivate: true,
-						typeOver: 'poisonous-vine',
 						destroyAnimation: 'shrinkDown'
 					}
 				);


### PR DESCRIPTION
this may not be the best fix, but it appears typeOver forces the trap code to leverage the wrong display layer group for poisonous vine
