### PR TITLE
This removes the excessive copy rules from the Gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,4 @@
-module.exports = function (grunt) {
+module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-contrib-watch');
 	//grunt.loadNpmTasks('grunt-contrib-connect');
 	grunt.loadNpmTasks('grunt-contrib-concat');
@@ -6,6 +6,7 @@ module.exports = function (grunt) {
 	grunt.loadNpmTasks('grunt-contrib-less');
 	grunt.loadNpmTasks('grunt-open');
 	grunt.loadNpmTasks('grunt-express-server');
+	grunt.loadNpmTasks('main-bower-files');
 	// grunt.loadNpmTasks('grunt-uncss');
 
 	grunt.initConfig({
@@ -50,88 +51,15 @@ module.exports = function (grunt) {
 			}
 
 		},
+		bower: {
+			flat: { /* flat folder/file structure */
+				dest: 'deploy/scripts/libs',
+				options: {
+					env: process.env.NODE_ENV || "development"
+				}
+			}
+		},
 		copy: {
-			// Copies the customized build of Phaser into the game
-			// http://phaser.io/tutorials/creating-custom-phaser-builds
-			phaser: {
-				files: [{
-					expand: true,
-					src: ['bower_components/phaser-ce/build/phaser*.js'],
-					dest: 'deploy/scripts/libs/',
-					filter: 'isFile',
-					flatten: true
-				}]
-			},
-			// Copy jquery to the libs folder
-			jquery: {
-				files: [{
-					expand: true,
-					src: ['bower_components/jquery/jquery*.js'],
-					dest: 'deploy/scripts/libs/',
-					filter: 'isFile',
-					flatten: true
-				}]
-			},
-			// Copy jquery-ui to the libs folder
-			jquery_ui: {
-				files: [{
-					expand: true,
-					src: ['bower_components/jquery-ui/jquery-ui*.js'],
-					dest: 'deploy/scripts/libs/',
-					filter: 'isFile',
-					flatten: true
-				}]
-			},
-			// Copy jquery-mousewheel to the libs folder
-			jquery_mousewheel: {
-				files: [{
-					expand: true,
-					src: ['bower_components/jquery-mousewheel/jquery*.js'],
-					dest: 'deploy/scripts/libs/',
-					filter: 'isFile',
-					flatten: true
-				}]
-			},
-			// Copy jquery kinetic to the libs folder
-			jquery_kinectic: {
-				files: [{
-					expand: true,
-					src: ['bower_components/jquery.kinetic/jquery*.js'],
-					dest: 'deploy/scripts/libs/',
-					filter: 'isFile',
-					flatten: true
-				}]
-			},
-			// Copy jquery transit to the libs folder
-			jquery_transit: {
-				files: [{
-					expand: true,
-					src: ['bower_components/jquery.transit/jquery*.js'],
-					dest: 'deploy/scripts/libs/',
-					filter: 'isFile',
-					flatten: true
-				}]
-			},
-			// Copy Prototype  to the libs folder
-			prototypejs: {
-				files: [{
-					expand: true,
-					src: ['bower_components/prototypejs/dist/prototype*.js'],
-					dest: 'deploy/scripts/libs/',
-					filter: 'isFile',
-					flatten: true
-				}]
-			},
-			// Copy socket-io to the libs folder
-			socket_io: {
-				files: [{
-					expand: true,
-					src: ['bower_components/socket.io-client/socket*.js'],
-					dest: 'deploy/scripts/libs/',
-					filter: 'isFile',
-					flatten: true
-				}]
-			},
 			// Copies CSS files into deploy/css, these were previously in deploy/css
 			// but were moved to enabled gitignore to work more cleanly on that path.
 			css: {
@@ -158,7 +86,7 @@ module.exports = function (grunt) {
 						// new(require('less-plugin-autoprefix'))({
 						// 	browsers: ["last 2 versions"]
 						// }),
-						new (require('less-plugin-clean-css'))({
+						new(require('less-plugin-clean-css'))({
 							inline: ['local', 'remote']
 						})
 					],
@@ -181,5 +109,5 @@ module.exports = function (grunt) {
 		// }
 	});
 
-	grunt.registerTask('default', ['concat', 'less', 'copy', /* 'uncss', */ 'express', 'open', 'watch']);
+	grunt.registerTask('default', ['concat', 'less', 'copy', 'bower', /* 'uncss', */ 'express', 'open', 'watch']);
 };

--- a/bower.json
+++ b/bower.json
@@ -1,33 +1,77 @@
 {
-  "name": "ancientbeast",
-  "description": "Ancient Beast Game",
-  "main": "deploy/index.html",
-  "authors": [
-    "Dread Knight <dk.vali@gmail.com>"
-  ],
-  "license": "(CC-BY-SA-3.0 OR AGPL-3.0)",
-  "keywords": [
-    "game",
-    "strategy",
-    "phaser"
-  ],
-  "homepage": "https://github.com/FreezingMoon/AncientBeast",
-  "private": true,
-  "ignore": [
-    "**/.*",
-    "node_modules",
-    "bower_components",
-    "test",
-    "tests"
-  ],
-  "dependencies": {
-    "phaser-ce": "~2.7.0",
-    "jquery": "~1.7.2",
-    "jquery.transit": "~0.9.12",
-    "jquery.kinetic": "^1.5.0",
-    "jquery-mousewheel": "~3.1.13",
-    "prototypejs": "~1.7.1",
-    "jquery-ui": "~1.11.1",
-    "socket.io-client": "~1.3.5"
-  }
+	"name": "ancientbeast",
+	"description": "Ancient Beast Game",
+	"main": "deploy/index.html",
+	"authors": [
+		"Dread Knight <dk.vali@gmail.com>"
+	],
+	"license": "(CC-BY-SA-3.0 OR AGPL-3.0)",
+	"keywords": [
+		"game",
+		"strategy",
+		"phaser"
+	],
+	"homepage": "https://github.com/FreezingMoon/AncientBeast",
+	"private": true,
+	"ignore": [
+		"**/.*",
+		"node_modules",
+		"bower_components",
+		"test",
+		"tests"
+	],
+	"dependencies": {
+		"phaser-ce": "~2.7.0",
+		"jquery": "~1.7.2",
+		"jquery.transit": "~0.9.12",
+		"jquery.kinetic": "^1.5.0",
+		"jquery-mousewheel": "~3.1.13",
+		"prototypejs": "~1.7.1",
+		"jquery-ui": "~1.11.1",
+		"socket.io-client": "~1.3.5"
+	},
+	"overrides": {
+		"phaser-ce": {
+			"main": {
+				"development": "build/phaser.min.js",
+				"production": "build/phaser.min.js"
+			}
+		},
+		"jquery": {
+			"main": {
+				"development": "./jquery.min.js",
+				"production": "./jquery.min.js"
+			}
+		},
+		"jquery.kinetic": {
+			"main": {
+				"development": "jquery.kinetic.min.js",
+				"production": "jquery.kinetic.min.js"
+			}
+		},
+		"jquery-mousewheel": {
+			"main": {
+				"development": "jquery.mousewheel.min.js",
+				"production": "jquery.mousewheel.min.js"
+			}
+		},
+		"jquery-ui": {
+			"main": {
+				"development": "jquery-ui.min.js",
+				"production": "jquery-ui.min.js"
+			}
+		},
+		"prototypejs": {
+			"main": {
+				"development": "dist/prototype.min.js",
+				"production": "dist/prototype.min.js"
+			}
+		},
+		"socket.io-client": {
+			"main": {
+				"development": "socket.io.js",
+				"production": "socket.io.js"
+			}
+		}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"grunt-contrib-copy": "^0.8.2",
 		"grunt-contrib-less": "^1.4.1",
 		"less-plugin-clean-css": "^1.5.1",
+		"main-bower-files": "^2.13.1",
 		"socket.io": "^1.3.5"
 	},
 	"devDependencies": {
@@ -36,7 +37,7 @@
 		"grunt-open": "~0.2.3"
 	},
 	"scripts": {
-		"postinstall": "bower cache clean && bower install && grunt concat less copy",
+		"postinstall": "bower cache clean && bower install && grunt concat less copy bower",
 		"test": "echo 'Error: no test specified' && exit 1"
 	}
 }


### PR DESCRIPTION
Moves copy rules to a module that serves that purpose w/bower components, added overrides to bower.json so we always get minified files for now... once we moved to a better dev vs production setup we can switch the overrides to insuring dev is never minified and production always is.