### PR TITLE
Removed 'Canceled' after selecting creature for materialization

### DIFF
--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -864,7 +864,7 @@ var UI = Class.create({
 		}, this.dashAnimSpeed, "linear", function () {
 			G.UI.$dash.hide();
 		});
-		if (this.materializeToggled && G.activeCreature) {
+		if (this.materializeToggled && G.activeCreature && G.UI.selectedCreature === "--") {
 			G.activeCreature.queryMove();
 		}
 		this.dashopen = false;


### PR DESCRIPTION
Prevent 'Canceled' text from appearing over the Dark Priest if a creature is selected from the materialization screen.

For #1208 