### PR TITLE
Priest no longer turns after getting hit

### DIFF
--- a/src/abilities.js
+++ b/src/abilities.js
@@ -225,7 +225,7 @@ var Ability = Class.create({
 		p2 += (this.creature.player.flipped) ? -5 : 5;
 
 		// Force creatures to face towards their target
-		if (args[0]) {
+		if (args[0] && args[0].hasOwnProperty(name)) {
 			var hexToFace = (args[0] instanceof Array) ? args[0][0] : args[0];
 			this.creature.faceHex(hexToFace);
 		}

--- a/src/abilities.js
+++ b/src/abilities.js
@@ -225,9 +225,8 @@ var Ability = Class.create({
 		p2 += (this.creature.player.flipped) ? -5 : 5;
 
 		// Force creatures to face towards their target
-		if (args[0] && args[0].hasOwnProperty(name)) {
-			var hexToFace = (args[0] instanceof Array) ? args[0][0] : args[0];
-			this.creature.faceHex(hexToFace);
+		if (args[0] instanceof Creature) {
+			this.creature.faceHex(args[0]);
 		}
 		// Play animations and sounds only for active abilities
 		if (this.getTrigger() === 'onQuery') {


### PR DESCRIPTION
For #1232 

Note that when using the gamelog replay in the Issue, the Abolished doesn't turn around when using Fiery Touch. This looks like an issue with the gamelog replay, as I can't get that to reproduce through normal gameplay. I think that the teleport and Fiery Touch happen so quickly using the replay that the faceHex function gets confused as to where Abolished actually is.