### PR TITLE
Godlet Dashboard Toggle

### DIFF
--- a/src/abilities/Dark Priest.js
+++ b/src/abilities/Dark Priest.js
@@ -238,7 +238,7 @@ G.abilities[0] = [
 
 			// Ask the creature to summon
 			G.UI.materializeToggled = true;
-			G.UI.toggleDash('godlet');
+			G.UI.toggleDash('randomize');
 		},
 
 		fnOnSelect: function(hex, args) {

--- a/src/abilities/Dark Priest.js
+++ b/src/abilities/Dark Priest.js
@@ -238,7 +238,7 @@ G.abilities[0] = [
 
 			// Ask the creature to summon
 			G.UI.materializeToggled = true;
-			G.UI.toggleDash();
+			G.UI.godletToggle();
 		},
 
 		fnOnSelect: function(hex, args) {

--- a/src/abilities/Dark Priest.js
+++ b/src/abilities/Dark Priest.js
@@ -238,7 +238,7 @@ G.abilities[0] = [
 
 			// Ask the creature to summon
 			G.UI.materializeToggled = true;
-			G.UI.godletToggle();
+			G.UI.toggleDash('godlet');
 		},
 
 		fnOnSelect: function(hex, args) {

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -847,36 +847,31 @@ var UI = Class.create({
 	 *	Show the dash and hide some buttons
 	 *
 	 */
-	toggleDash: function () {
+	toggleDash: function (toggledByGodlet) {
 		if (!this.$dash.hasClass("active")) {
-			this.showCreature(G.activeCreature.type, G.activeCreature.team);
-		} else {
-			this.closeDash();
-		}
-	},
-
-	godletToggle: function() {
-		if (!this.$dash.hasClass("active")) {
-			const activePlayer = G.players[G.activeCreature.player.id];
-			const typeMap = activePlayer.availableCreatures.filter(el => el.length);
-			const deadOrSummonedTypes = activePlayer.creatures.map(creature => creature.type)
-			const availableTypes = typeMap.filter(el => !deadOrSummonedTypes.includes(el))
-			// optional: randomize array, grab a new creature every toggle
-			for (let i = availableTypes.length - 1; i > 0; i--) {
-				let j = Math.floor(Math.random() * (i + 1));
-				let temp = availableTypes[i];
-				availableTypes[i] = availableTypes[j];
-				availableTypes[j] = temp;
+			if (toggledByGodlet) {
+				const activePlayer = G.players[G.activeCreature.player.id];
+				const deadOrSummonedTypes = activePlayer.creatures.map(creature => creature.type)
+				const availableTypes = activePlayer.availableCreatures.filter(el => !deadOrSummonedTypes.includes(el))
+				// Optional: randomize array to grab a new creature every toggle
+				for (let i = availableTypes.length - 1; i > 0; i--) {
+					let j = Math.floor(Math.random() * (i + 1));
+					let temp = availableTypes[i];
+					availableTypes[i] = availableTypes[j];
+					availableTypes[j] = temp;
+				}
+				// Grab the first creature we can afford (if none, default to priest)
+				let typeToPass = "--";
+				availableTypes.some(creature => {
+					const lvl = creature.substring(1, 2) - 0;
+					const size = G.retreiveCreatureStats(creature).size - 0;
+					const plasmaCost = lvl + size;
+					return plasmaCost <= activePlayer.plasma ? ((typeToPass = creature), true) : false;
+				});
+				this.showCreature(typeToPass, G.activeCreature.team);
+			} else {
+				this.showCreature(G.activeCreature.type, G.activeCreature.team);
 			}
-			// grab the first creature we can afford (if none, default to priest)
-			let typeToPass = "--";
-			availableTypes.some(creature => {
-				const lvl = creature.substring(1, 2) - 0;
-				const size = G.retreiveCreatureStats(creature).size - 0;
-				const plasmaCost = lvl + size;
-				return plasmaCost <= activePlayer.plasma ? ((typeToPass = creature), true) : false;
-			});
-			this.showCreature(typeToPass, G.activeCreature.team);
 		} else {
 			this.closeDash();
 		}

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -873,7 +873,7 @@ var UI = Class.create({
 			availableTypes.some(creature => {
 				const lvl = creature.substring(1, 2) - 0;
 				const size = G.retreiveCreatureStats(creature).size - 0;
-				plasmaCost = lvl + size;
+				const plasmaCost = lvl + size;
 				return plasmaCost <= activePlayer.plasma ? ((typeToPass = creature), true) : false;
 			});
 			this.showCreature(typeToPass, G.activeCreature.team);

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -847,9 +847,9 @@ var UI = Class.create({
 	 *	Show the dash and hide some buttons
 	 *
 	 */
-	toggleDash: function (toggledByGodlet) {
+	toggleDash: function (randomize) {
 		if (!this.$dash.hasClass("active")) {
-			if (toggledByGodlet) {
+			if (randomize) {
 				const activePlayer = G.players[G.activeCreature.player.id];
 				const deadOrSummonedTypes = activePlayer.creatures.map(creature => creature.type)
 				const availableTypes = activePlayer.availableCreatures.filter(el => !deadOrSummonedTypes.includes(el))

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -885,7 +885,7 @@ var UI = Class.create({
 		}, this.dashAnimSpeed, "linear", function () {
 			G.UI.$dash.hide();
 		});
-		if (this.materializeToggled && G.activeCreature && G.UI.selectedCreature === "--") {
+		if (this.materializeToggled && G.activeCreature && G.activeCreature.type === "--") {
 			G.activeCreature.queryMove();
 		}
 		this.dashopen = false;

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -853,7 +853,33 @@ var UI = Class.create({
 		} else {
 			this.closeDash();
 		}
+	},
 
+	godletToggle: function() {
+		if (!this.$dash.hasClass("active")) {
+			const activePlayer = G.players[G.activeCreature.player.id];
+			const typeMap = activePlayer.availableCreatures.filter(el => el.length);
+			const deadOrSummonedTypes = activePlayer.creatures.map(creature => creature.type)
+			const availableTypes = typeMap.filter(el => !deadOrSummonedTypes.includes(el))
+			// optional: randomize array, grab a new creature every toggle
+			for (let i = availableTypes.length - 1; i > 0; i--) {
+				let j = Math.floor(Math.random() * (i + 1));
+				let temp = availableTypes[i];
+				availableTypes[i] = availableTypes[j];
+				availableTypes[j] = temp;
+			}
+			// grab the first creature we can afford (if none, default to priest)
+			let typeToPass = "--";
+			availableTypes.some(creature => {
+				const lvl = creature.substring(1, 2) - 0;
+				const size = G.retreiveCreatureStats(creature).size - 0;
+				plasmaCost = lvl + size;
+				return plasmaCost <= activePlayer.plasma ? ((typeToPass = creature), true) : false;
+			});
+			this.showCreature(typeToPass, G.activeCreature.team);
+		} else {
+			this.closeDash();
+		}
 	},
 
 	closeDash: function () {


### PR DESCRIPTION
Referencing #1147 

Adds new function to the UI class, godletToggle. godletToggle behaves similarly to toggleDash but calls showCreature with a random, available, affordable creature. 

The Dark Priest's Godlet Scanner now calls godletToggle instead of toggleDash.