### PR TITLE
Added support for hover off handler in the hex to allow toggle of info

### DIFF
--- a/src/creature.js
+++ b/src/creature.js
@@ -1099,21 +1099,21 @@ var Creature = Class.create({
 			G.UI.healthBar.animSize(this.health / this.stats.health);
 		}
 
-		// Dark Priest plasma shield when inactive
-		if (this.type == "--" && this.player.plasma > 0 &&
-			this !== G.activeCreature) {
+		if (this.stats.frozen) {
+			this.healthIndicatorSprite.loadTexture("p" + this.team + "_frozen");
+		} else {
+			this.healthIndicatorSprite.loadTexture("p" + this.team + "_health");
+		}
+		this.healthIndicatorText.setText(this.health);
+	},
+	
+	displayPlasma: function(){
+		if (this.type == "--" && this.player.plasma > 0) {
 			this.healthIndicatorSprite.loadTexture("p" + this.team + "_plasma");
 			this.healthIndicatorText.setText(this.player.plasma);
-		} else {
-			if (this.stats.frozen) {
-				this.healthIndicatorSprite.loadTexture("p" + this.team + "_frozen");
-			} else {
-				this.healthIndicatorSprite.loadTexture("p" + this.team + "_health");
-			}
-			this.healthIndicatorText.setText(this.health);
 		}
 	},
-
+	
 	addFatigue: function(dmgAmount) {
 		if (!this.stats.fatigueImmunity) {
 			this.endurance -= dmgAmount;

--- a/src/utility/hexagons.js
+++ b/src/utility/hexagons.js
@@ -599,6 +599,17 @@ var HexGrid = Class.create({
 			}
 		};
 
+		
+		var onHoverOffFn = function() {
+			var hex = this;
+			if (hex.creature instanceof Creature) { // toggle hover off event
+				var crea = hex.creature;
+				if(crea.type == "--" && crea === G.activeCreature){ // the plasma would have been displayed so now display the health again
+					crea.updateHealth();
+				}
+			}
+		}
+		
 		// ONMOUSEOVER
 		var onSelectFn = function() {
 			var hex = this;
@@ -611,12 +622,15 @@ var HexGrid = Class.create({
 			// Clear display and overlay
 			G.grid.updateDisplay();
 			G.UI.xrayQueue(-1);
-
+			
 			// Not reachable hex
 			if (!hex.reachable) {
 				if (G.grid.materialize_overlay) G.grid.materialize_overlay.alpha = 0;
 				if (hex.creature instanceof Creature) { // If creature
 					var crea = hex.creature;
+					if(crea.type == "--" && crea === G.activeCreature){
+						crea.displayPlasma();
+					}
 					crea.hexagons.forEach(function(hex) {
 						hex.overlayVisualState("hover h_player" + crea.team);
 					});
@@ -668,6 +682,7 @@ var HexGrid = Class.create({
 
 		this.forEachHex(function() {
 			this.onSelectFn = onSelectFn;
+			this.onHoverOffFn = onHoverOffFn;
 			this.onConfirmFn = onConfirmFn;
 			this.onRightClickFn = onRightClickFn;
 		});
@@ -1260,6 +1275,7 @@ var Hex = Class.create({
 				G.grid.redoLastQuery();
 				G.grid.xray(new Hex(-1, -1)); // Clear Xray
 				G.UI.xrayQueue(-1); // Clear Xray Queue
+				this.onHoverOffFn();
 			}, this);
 
 			this.input.events.onInputUp.add(function(Sprite, Pointer) {
@@ -1284,6 +1300,7 @@ var Hex = Class.create({
 		this.displayPos.y = this.displayPos.y * .75 + 30;
 
 		this.onSelectFn = function() {};
+		this.onHoverOffFn = function() {};
 		this.onConfirmFn = function() {};
 		this.onRightClickFn = function() {};
 


### PR DESCRIPTION
Added support for hover off handler in the hex to allow toggle of info. #1118 

At present when you hover on an Active Dark Priest it will toggle from its Health to Player Plasma.
Then when you hover off, the new function onHoverOffFn will be triggered, and it can be used to toggle a creatures displayed information. At present all it does is display the Dark priests Health again.


If your pull request tries to address a specific issue from the repository, please reference to it.
Don't forget to include a description of the changes proposes. https://discord.me/AncientBeast