### PR TITLE
Removed the creature player style from inactive creatures so they sim…

### DIFF
--- a/src/utility/hexagons.js
+++ b/src/utility/hexagons.js
@@ -818,8 +818,6 @@ var HexGrid = Class.create({
 					if (item.creature.id == G.activeCreature.id) {
 						item.overlayVisualState("active creature player" + item.creature.team);
 						item.displayVisualState("creature player" + item.creature.team);
-					} else {
-						item.displayVisualState("creature player" + item.creature.team);
 					}
 				}
 			});


### PR DESCRIPTION
Removed the creature player style from inactive creatures so they simply have a colored hex, clear center. #1239 

Change is simple, by not setting a hex displayVisualState the hex is naturally clear.