### PR TITLE
UI issues #1249 #1246 #1238

### DIFF
--- a/src/abilities/Dark Priest.js
+++ b/src/abilities/Dark Priest.js
@@ -308,6 +308,7 @@ G.abilities[0] = [
 			ability.end();
 
 			ability.creature.player.summon(creature, pos);
+			ability.creature.queryMove(); 
 		},
 	}
 

--- a/src/creature.js
+++ b/src/creature.js
@@ -1099,6 +1099,22 @@ var Creature = Class.create({
 			G.UI.healthBar.animSize(this.health / this.stats.health);
 		}
 
+		// Dark Priest plasma shield when inactive
+ 		if (this.type == "--") {
+			if(this.hasCreaturePlayerGotPlasma() && this !== G.activeCreature){
+				this.displayPlasmaShield();
+			}
+			else{
+				this.displayHealthStats()
+			}
+		}
+		else{
+			this.displayHealthStats();
+		}
+		
+	},
+	
+	displayHealthStats: function(){
 		if (this.stats.frozen) {
 			this.healthIndicatorSprite.loadTexture("p" + this.team + "_frozen");
 		} else {
@@ -1107,11 +1123,13 @@ var Creature = Class.create({
 		this.healthIndicatorText.setText(this.health);
 	},
 	
-	displayPlasma: function(){
-		if (this.type == "--" && this.player.plasma > 0) {
-			this.healthIndicatorSprite.loadTexture("p" + this.team + "_plasma");
-			this.healthIndicatorText.setText(this.player.plasma);
-		}
+	displayPlasmaShield: function(){
+		this.healthIndicatorSprite.loadTexture("p" + this.team + "_plasma");
+		this.healthIndicatorText.setText(this.player.plasma);
+	},
+	
+	hasCreaturePlayerGotPlasma : function(){
+		return this.player.plasma > 0;
 	},
 	
 	addFatigue: function(dmgAmount) {

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -1517,22 +1517,38 @@ var UI = Class.create({
 			}
 
 			var creaID = $j(this).attr("creatureid") - 0;
-			G.grid.showMovementRange(creaID);
+			
 			G.creatures.forEach(function (creature) {
 				if (creature instanceof Creature) {
 					creature.xray(false);
 					if (creature.id != creaID) {
 						creature.xray(true);
+						creature.hexagons.forEach(function(hex) {
+							hex.cleanOverlayVisualState();
+						});
+					}
+					else{
+						creature.hexagons.forEach(function(hex) {
+							hex.overlayVisualState("hover h_player" + creature.team);
+						});
 					}
 				}
 			});
-
+			G.grid.showMovementRange(creaID);
 			G.UI.xrayQueue(creaID);
 		}).bind("mouseleave", function () { // On mouseleave cancel effect
 			if (G.freezedInput) {
 				return;
 			}
 
+			G.creatures.forEach(function (creature) { // the mouse over adds a coloured hex to the creature, so when we mouse leave we have to remove them
+				if (creature instanceof Creature) {
+					creature.hexagons.forEach(function(hex) {
+						hex.cleanOverlayVisualState();
+					});
+				}
+			});
+			
 			G.grid.redoLastQuery();
 			G.creatures.forEach(function (creature) {
 				if (creature instanceof Creature) {

--- a/src/utility/hexagons.js
+++ b/src/utility/hexagons.js
@@ -604,7 +604,7 @@ var HexGrid = Class.create({
 			var hex = this;
 			if (hex.creature instanceof Creature) { // toggle hover off event
 				var crea = hex.creature;
-				if(crea.type == "--" && crea === G.activeCreature){ // the plasma would have been displayed so now display the health again
+				if(crea.type == "--"){ // the plasma would have been displayed so now display the health again
 					crea.updateHealth();
 				}
 			}
@@ -628,8 +628,15 @@ var HexGrid = Class.create({
 				if (G.grid.materialize_overlay) G.grid.materialize_overlay.alpha = 0;
 				if (hex.creature instanceof Creature) { // If creature
 					var crea = hex.creature;
-					if(crea.type == "--" && crea === G.activeCreature){
-						crea.displayPlasma();
+					if(crea.type == "--"){ // this should probably be extracted outside of the not reachable condition
+						if(crea === G.activeCreature){
+							if(crea.hasCreaturePlayerGotPlasma()){
+								crea.displayPlasmaShield();
+							}
+						}
+						else{ // inactive priest, so display his health on hover
+							crea.displayHealthStats();
+						}
 					}
 					crea.hexagons.forEach(function(hex) {
 						hex.overlayVisualState("hover h_player" + crea.team);


### PR DESCRIPTION
#1249 resolved by displaying the creatures team colour under them when queue item highlighted.

#1246 Added call to the summoner creatures queryMove to update their movable hex's as suggested by dread.

#1238 inactive dark priests now display shields if they have plasma. And health when hovered. 
Active dark priests display health by default, and plasma when hovered.
