### PR TITLE
Fixes #1262 - Added support for hashes and made it the default output…

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -35,7 +35,8 @@ var Game = class Game {
 	 * creatureData :		Array :		Array containing all data for the creatures
 	 *
 	 */
-	constructor() {
+	constructor(version) {
+		this.version = version || "dev";
 		this.abilities = [];
 		this.players = [];
 		this.creatures = [];

--- a/src/script.js
+++ b/src/script.js
@@ -1,5 +1,5 @@
 /** Initialize the game global variable */
-var G = new Game();
+var G = new Game("0.3");
 /*****************************************/
 
 $j(document).ready(function() {
@@ -22,7 +22,7 @@ $j(document).ready(function() {
 
 
 function getGameConfig() {
-	return {
+	let defaultConfig = {
 			playerMode: $j('input[name="playerMode"]:checked').val() - 0,
 			creaLimitNbr: $j('input[name="activeUnits"]:checked').val() - 0, // DP counts as One
 			unitDrops: $j('input[name="unitDrops"]:checked').val() - 0,
@@ -31,14 +31,16 @@ function getGameConfig() {
 			turnTimePool: $j('input[name="turnTime"]:checked').val() - 0,
 			timePool: $j('input[name="timePool"]:checked').val() * 60,
 			background_image: $j('input[name="combatLocation"]:checked').val(),
+		},
+		config = G.gamelog.gameConfig || defaultConfig;
 
-		};
+	return config;
 }
 
 function isEmpty(obj) {
-    for(var key in obj) {
-        if(obj.hasOwnProperty(key))
-            return false;
-    }
-    return true;
+	for (var key in obj) {
+		if (obj.hasOwnProperty(key))
+			return false;
+	}
+	return true;
 }

--- a/src/utility/gamelog.js
+++ b/src/utility/gamelog.js
@@ -39,6 +39,12 @@ var GameLog = class GameLog {
 			config = log.config;
 			this.data = data;
 			return this.config(config);
+		} else if (typeof log == "string") {
+			let results = log.match(/^AB-(dev|[0-9.]+):(.+)$/);
+			if (results) {
+				log = JSON.parse(atob(results[2]));
+				return this.play(log);
+			}
 		}
 
 		if (log) {
@@ -101,14 +107,29 @@ var GameLog = class GameLog {
 		}, 100);
 	}
 
-	get() {
+	get(state) {
 		let config = isEmpty(this.gameConfig) ? getGameConfig() : this.gameConfig,
-			output = {
+			dict = {
 				config: config,
 				log: this.data
-			};
+			},
+			json = JSON.stringify(dict),
+			hash = "AB-" + this.game.version + ":" + btoa(JSON.stringify(dict)),
+			output,
+			strOutput;
 
-		console.log('GameData :' + JSON.stringify(output));
+		switch (state) {
+			case "json":
+				output = dict;
+				strOutput = json;
+				break;
+			case "hash":
+			default:
+				output = hash;
+				strOutput = hash;
+		}
+
+		console.log("GameData: " + strOutput);
 		return output;
 	}
 };


### PR DESCRIPTION
… of gamelog.get() - Can still get JSON by passing 'json' as an argument

G.gamelog.play(....) will detect hashes or objects and handle them appropriately.
G.gamelog.get() will return a prefixed hash where prefix is "AB-[ver]:" - [ver] is passed into new Game() from script.js now, currently set to 0.3 -- if no version is passed in it will default to 'dev'

G.gamelog.get("json") will output the original config + data JSON object.
G.gamelog.get("hash") will guarantee the config as a hash (currently the default).