### PR TITLE
Fixes #1272

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -35,7 +35,8 @@ var Game = class Game {
 	 * creatureData :		Array :		Array containing all data for the creatures
 	 *
 	 */
-	constructor() {
+	constructor(version) {
+		this.version = version || "dev";
 		this.abilities = [];
 		this.players = [];
 		this.creatures = [];

--- a/src/game.js
+++ b/src/game.js
@@ -45,6 +45,7 @@ var Game = class Game {
 			id: 0
 		};
 
+		this.preventSetup = true;
 		this.animations = new Animations(this);
 		this.turn = 0;
 		this.queue = new CreatureQueue(this);
@@ -313,10 +314,13 @@ var Game = class Game {
 
 		if (progress == 100) {
 			setTimeout(() => {
-				$j("#loader").hide();
-				$j("body").css("cursor", "default");
-				this.setup(this.playerMode);
-			}, 1000)
+				this.gameState = "loaded";
+
+				// Do not call setup if we are not active.
+				if (!this.preventSetup) {
+					this.setup(this.playerMode);
+				}
+			}, 100)
 		}
 	}
 
@@ -333,6 +337,33 @@ var Game = class Game {
 		for (i = 1; i < count; i++) {
 			//G.Phaser.debug.renderSpriteBounds(G.creatures[i].sprite);
 		}
+	}
+
+	// Catch the browser being made inactive to prevent initial rendering bugs.
+	onBlur() {
+		this.preventSetup = true;
+	}
+
+	// Catch the browser coming back into focus so we can render the game board.
+	onFocus() {
+		this.preventSetup = false;
+		// If loaded, call maybeSetup with a tiny delay to prevent rendering issues.
+		if (this.gameState == "loaded") {
+			setTimeout(() => {
+				this.maybeSetup();
+			}, 100);
+		}
+	}
+
+	// If no red flags, remove the loading bar and begin rendering the game.
+	maybeSetup() {
+		if (this.preventSetup) {
+			return;
+		}
+
+		$j("#loader").hide();
+		$j("body").css("cursor", "default");
+		this.setup(this.playerMode);
 	}
 
 	/* Setup(playerMode)

--- a/src/script.js
+++ b/src/script.js
@@ -2,24 +2,28 @@
 var G = new Game("0.3");
 /*****************************************/
 
-$j(document).ready(function() {
+$j(document).ready(() => {
 	$j(".typeRadio").buttonset();
 	$j("#startButton").button();
 
-	$j("form#gameSetup").submit(function(e) {
+	// Disable initial game setup until browser tab has focus
+	window.addEventListener("blur", G.onBlur.bind(G), false);
+	window.addEventListener("focus", G.onFocus.bind(G), false);
+	$j("form#gameSetup").submit((e) => {
 		e.preventDefault(); // Prevent submit
 		var gameconfig = getGameConfig();
 
 
 		if (gameconfig.background_image == "random") {
-			var index = Math.floor(Math.random() * ($j('input[name="combatLocation"]').length - 1)) + 1; // nth-child indices start at 1
+			// nth-child indices start at 1
+			var index = Math.floor(Math.random() * ($j('input[name="combatLocation"]').length - 1)) + 1;
 			gameconfig.background_image = $j('input[name="combatLocation"]').slice(index, index + 1).attr("value");
 		}
+
 		G.loadGame(gameconfig);
 		return false; // Prevent submit
 	});
 });
-
 
 function getGameConfig() {
 	let defaultConfig = {

--- a/src/script.js
+++ b/src/script.js
@@ -1,5 +1,5 @@
 /** Initialize the game global variable */
-var G = new Game();
+var G = new Game("0.3");
 /*****************************************/
 
 $j(document).ready(function() {
@@ -22,7 +22,7 @@ $j(document).ready(function() {
 
 
 function getGameConfig() {
-	return {
+	let defaultConfig = {
 			playerMode: $j('input[name="playerMode"]:checked').val() - 0,
 			creaLimitNbr: $j('input[name="activeUnits"]:checked').val() - 0, // DP counts as One
 			unitDrops: $j('input[name="unitDrops"]:checked').val() - 0,
@@ -31,14 +31,16 @@ function getGameConfig() {
 			turnTimePool: $j('input[name="turnTime"]:checked').val() - 0,
 			timePool: $j('input[name="timePool"]:checked').val() * 60,
 			background_image: $j('input[name="combatLocation"]:checked').val(),
+		},
+		config = G.gamelog.gameConfig || defaultConfig;
 
-		};
+	return config;
 }
 
 function isEmpty(obj) {
-    for(var key in obj) {
-        if(obj.hasOwnProperty(key))
-            return false;
-    }
-    return true;
+	for (var key in obj) {
+		if (obj.hasOwnProperty(key))
+			return false;
+	}
+	return true;
 }

--- a/src/utility/gamelog.js
+++ b/src/utility/gamelog.js
@@ -4,7 +4,8 @@ var GameLog = class GameLog {
 		this.data = [];
 		this.playing = false;
 		this.timeCursor = -1;
-		this.gameConfig = {};
+		// Set this to null so we can properly decide between form based config or log based config.
+		this.gameConfig = null;
 	}
 
 	add(action) {

--- a/src/utility/gamelog.js
+++ b/src/utility/gamelog.js
@@ -39,6 +39,12 @@ var GameLog = class GameLog {
 			config = log.config;
 			this.data = data;
 			return this.config(config);
+		} else if (typeof log == "string") {
+			let results = log.match(/^AB-(dev|[0-9.]+):(.+)$/);
+			if (results) {
+				log = JSON.parse(atob(results[2]));
+				return this.play(log);
+			}
 		}
 
 		if (log) {
@@ -101,14 +107,29 @@ var GameLog = class GameLog {
 		}, 100);
 	}
 
-	get() {
+	get(state) {
 		let config = isEmpty(this.gameConfig) ? getGameConfig() : this.gameConfig,
-			output = {
+			dict = {
 				config: config,
 				log: this.data
-			};
+			},
+			json = JSON.stringify(dict),
+			hash = "AB-" + this.game.version + ":" + btoa(JSON.stringify(dict)),
+			output,
+			strOutput;
 
-		console.log('GameData :' + JSON.stringify(output));
+		switch (state) {
+			case "json":
+				output = dict;
+				strOutput = json;
+				break;
+			case "hash":
+			default:
+				output = hash;
+				strOutput = hash;
+		}
+
+		console.log("GameData: " + strOutput);
 		return output;
 	}
 };


### PR DESCRIPTION
Fixes #1272 - Add a bit of intelligence to the game setup routines so we only begin rendering Phaser stuff if the browser is active. Otherwise it will just pause at 100% and wait for focus to return to the game tab before rendering.

This relies on #1262 to work, so merge it first.