### PR TITLE
Fixed bug on triggerDeleteEffect function that crashed the game

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -955,6 +955,7 @@ var Game = class Game {
 				}
 
 				i--;
+				totalEffects--;
 			}
 		}
 	}


### PR DESCRIPTION
An easy way to reproduce this bug is to summon a Nutcase and then hit him with a meele attack to trigger Tentacle bush, trying to skip turn after that would crash the game.

the fix was to update the totalEffects variable after deleting an effect.