### PR TITLE
issue 730 self highlight resolved by always calling creature highligh…

### DIFF
--- a/src/utility/hexagons.js
+++ b/src/utility/hexagons.js
@@ -627,16 +627,16 @@ var HexGrid = class HexGrid {
 			game.UI.xrayQueue(-1);
 			$j("canvas").css("cursor", "pointer");
 
+            if (hex.creature instanceof Creature) { // If creature
+                onCreatureHover(hex.creature, game.UI.xrayQueue.bind(game.UI));
+            } else { // If nothing
+                hex.overlayVisualState("hover");
+            }
+
 			// Not reachable hex
 			if (!hex.reachable) {
 				if (hex.materialize_overlay) {
 					hex.materialize_overlay.alpha = 0;
-				}
-
-				if (hex.creature instanceof Creature) { // If creature
-					onCreatureHover(hex.creature, game.UI.xrayQueue.bind(game.UI));
-				} else { // If nothing
-					hex.overlayVisualState("hover");
 				}
 			} else { // Reachable hex
 				//Offset Pos


### PR DESCRIPTION
#730 self highlight resolved by always calling creature highlight, not just on non reachable hexes.

I started messing with the hex range methods, but those hexes need to be reachable for creatures with size > 1. So i have moved the creature highlighting outside of the not reachable if. I wanted to this earlier, the first time I came across it, but I was less familiar with the code then, but now I am confident the code should be outside the !reachable. 

I did some playing around, and the game seems ok to me, and the issue of #730  seems to be resolved. but please try and break it and let me know if there is a us case that no longer works.