### PR TITLE
Addressing #1252: drops offer score points 

### DIFF
--- a/src/drops.js
+++ b/src/drops.js
@@ -46,6 +46,9 @@ var Drop = class Drop {
 			creature.energy += this.energy;
 			game.log("%CreatureName" + creature.id + "% gains " + this.energy + " energy");
 		}
+		creature.player.score.push({
+		    type: "pickupDrop"
+		});
 
 		creature.updateAlteration(); // Will cap the stats
 

--- a/src/player.js
+++ b/src/player.js
@@ -160,6 +160,9 @@ var Player = class Player {
 				case "immortal":
 					points += 100;
 					break;
+				case "pickupDrop":
+					points += 2;
+					break;
 			}
 
 			totalScore[s.type] += points;


### PR DESCRIPTION
In response to #1252. Added a score case for pickupDrop, pushed this score type to player score when creature picks up a drop.