### PR TITLE
Issue_1250

### DIFF
--- a/src/utility/hexagons.js
+++ b/src/utility/hexagons.js
@@ -566,7 +566,7 @@ var HexGrid = class HexGrid {
 			if (!hex.reachable) {
 				this.lastClickedHex = [];
 				if (hex.creature instanceof Creature) { // If creature
-					onCreatureHover(hex.creature, (game.activeCreature !== hex.creature) ? game.UI.bouncexrayQueue.bind(game.UI) : game.UI.xrayQueue.bind(game.UI),hex);
+					onCreatureHover(hex.creature, (game.activeCreature !== hex.creature) ? game.UI.bouncexrayQueue.bind(game.UI) : game.UI.xrayQueue.bind(game.UI), hex );
 				} else { // If nothing
 					o.fnOnCancel(hex, o.args); // ON CANCEL
 				}
@@ -629,7 +629,7 @@ var HexGrid = class HexGrid {
 			$j("canvas").css("cursor", "pointer");
 
             if (hex.creature instanceof Creature) { // If creature
-                onCreatureHover(hex.creature, game.UI.xrayQueue.bind(game.UI),hex);
+                onCreatureHover(hex.creature, game.UI.xrayQueue.bind(game.UI), hex );
             } else { // If nothing
                 hex.overlayVisualState("hover");
             }
@@ -687,12 +687,11 @@ var HexGrid = class HexGrid {
 			creature.hexagons.forEach((hex) => {
                 hex.overlayVisualState("hover h_player" + creature.team);
             });
-			if (creature !== game.activeCreature) {
-			    if(!hex.reachable){
+			if ( creature !== game.activeCreature ) {
+			    if( !hex.reachable ) {
 			        $j("canvas").css("cursor", "n-resize");
-			    }
-			    else{
-			        hex.displayVisualState("creature player" + hex.creature.team);
+			    } else {
+			        hex.displayVisualState( "creature player" + hex.creature.team );
 			    }
 			}
 			queueEffect(creature.id);
@@ -842,11 +841,11 @@ var HexGrid = class HexGrid {
 		});
 
 		// targeting for abilities
-		if(this.lastQueryOpt && this.lastQueryOpt.hexes){
-		    this.lastQueryOpt.hexes.forEach((hex) => {
+		if (this.lastQueryOpt && this.lastQueryOpt.hexes) {
+		    this.lastQueryOpt.hexes.forEach( (hex) => {
                 if (hex.creature instanceof Creature) {
-                    if (hex.creature.id != this.game.activeCreature.id) {
-                        hex.overlayVisualState("hover h_player" + hex.creature.team);
+                    if (hex.creature.id != this.game.activeCreature.id ) {
+                        hex.overlayVisualState( "hover h_player" + hex.creature.team );
                     }
                 }
             });

--- a/src/utility/hexagons.js
+++ b/src/utility/hexagons.js
@@ -504,6 +504,7 @@ var HexGrid = class HexGrid {
 		// Save the last Query
 		this.lastQueryOpt = $j.extend({}, o); // Copy Obj
 
+        this.updateDisplay();
 		// Block all hexes
 		this.forEachHex((hex) => {
 			hex.unsetReachable();
@@ -565,7 +566,7 @@ var HexGrid = class HexGrid {
 			if (!hex.reachable) {
 				this.lastClickedHex = [];
 				if (hex.creature instanceof Creature) { // If creature
-					onCreatureHover(hex.creature, (game.activeCreature !== hex.creature) ? game.UI.bouncexrayQueue.bind(game.UI) : game.UI.xrayQueue.bind(game.UI));
+					onCreatureHover(hex.creature, (game.activeCreature !== hex.creature) ? game.UI.bouncexrayQueue.bind(game.UI) : game.UI.xrayQueue.bind(game.UI),hex);
 				} else { // If nothing
 					o.fnOnCancel(hex, o.args); // ON CANCEL
 				}
@@ -628,7 +629,7 @@ var HexGrid = class HexGrid {
 			$j("canvas").css("cursor", "pointer");
 
             if (hex.creature instanceof Creature) { // If creature
-                onCreatureHover(hex.creature, game.UI.xrayQueue.bind(game.UI));
+                onCreatureHover(hex.creature, game.UI.xrayQueue.bind(game.UI),hex);
             } else { // If nothing
                 hex.overlayVisualState("hover");
             }
@@ -673,7 +674,7 @@ var HexGrid = class HexGrid {
 			}
 		};
 		
-		let onCreatureHover = (creature, queueEffect) => {
+		let onCreatureHover = (creature, queueEffect, hex) => {
 			if (creature.type == "--") {
 				if (creature === game.activeCreature) {
 					if (creature.hasCreaturePlayerGotPlasma()) {
@@ -683,12 +684,17 @@ var HexGrid = class HexGrid {
 					creature.displayHealthStats();
 				}
 			}
-			if (creature !== game.activeCreature) {
-			    $j("canvas").css("cursor", "n-resize");
-			}
 			creature.hexagons.forEach((hex) => {
-				hex.overlayVisualState("hover h_player" + creature.team);
-			});
+                hex.overlayVisualState("hover h_player" + creature.team);
+            });
+			if (creature !== game.activeCreature) {
+			    if(!hex.reachable){
+			        $j("canvas").css("cursor", "n-resize");
+			    }
+			    else{
+			        hex.displayVisualState("creature player" + hex.creature.team);
+			    }
+			}
 			queueEffect(creature.id);
 		}
 
@@ -834,6 +840,17 @@ var HexGrid = class HexGrid {
 				}
 			});
 		});
+
+		// targeting for abilities
+		if(this.lastQueryOpt && this.lastQueryOpt.hexes){
+		    this.lastQueryOpt.hexes.forEach((hex) => {
+                if (hex.creature instanceof Creature) {
+                    if (hex.creature.id != this.game.activeCreature.id) {
+                        hex.overlayVisualState("hover h_player" + hex.creature.team);
+                    }
+                }
+            });
+		}
 	}
 
 	/* hexExists(y, x)


### PR DESCRIPTION
colored hexagon outlines for targets #1250 : resolved by making the reachable creatures have a hallow hex when chosen as targets, and a filled hex when hovered.

Also resolved #1289 as part of the same change, by making the onHover check if the target tile is reachable. If it is its a pointer, because u can execute an action on them, else its the arrow cursor because the hex is not reachable. 

So if you have a creature with a 1 range attack, and a creature is within one hex but the creature has multiple hex's, only the closest hex will have a hallow hex colored, and when you hover on it should have pointer cursor. If you hover on the other hex they should have the arrow cursor because they are not selectable. 

let me know what you think.