### PR TITLE
AD_1296: Removing previous change and adding support for parameter ta…

### DIFF
--- a/src/abilities/Abolished.js
+++ b/src/abilities/Abolished.js
@@ -148,6 +148,7 @@ G.abilities[7] = [
 
 			// Teleport to any hex within range except for the current hex
 			crea.queryMove({
+			    targeting:true,
 				noPath: true,
 				isAbility: true,
 				range: G.grid.getFlyingRange(crea.x, crea.y, this.range, crea.size, crea.id),

--- a/src/abilities/Abolished.js
+++ b/src/abilities/Abolished.js
@@ -241,6 +241,8 @@ G.abilities[7] = [
 		//	Type : Can be "onQuery", "onStartPhase", "onDamage"
 		trigger: "onQuery",
 
+        directions: [1, 1, 1, 1, 1, 1],
+
 		// 	require() :
 		require: function() {
 			return this.testRequirements();
@@ -253,25 +255,19 @@ G.abilities[7] = [
 
 			// var inRangeCreatures = crea.hexagons[1].adjacentHex(1);
 
-			var range = crea.adjacentHexes(1);
+			var range = [];
+			range[0] = crea.adjacentHexes(1);
 
-			G.grid.queryHexes({
-				fnOnConfirm: function() {
-					ability.animation.apply(ability, arguments);
-				},
-				fnOnSelect: function(hex, args) {
-					range.forEach(function(item) {
-						if (item.creature) {
-							item.overlayVisualState("creature selected weakDmg player" + item.creature.team);
-						}
-					});
-					hex.cleanOverlayVisualState();
-					hex.overlayVisualState("creature selected player" + G.activeCreature.team);
-				},
-				id: this.creature.id,
-				hexes: range,
-				hideNonTarget: true,
-			});
+            G.grid.queryChoice({
+                fnOnConfirm: function() {
+                    ability.animation.apply(ability, arguments);
+                },
+                flipped: crea.player.flipped,
+                team: this._targetTeam,
+                id: this.creature.id,
+                requireCreature: false,
+                choices:range
+            });
 		},
 
 

--- a/src/abilities/Dark Priest.js
+++ b/src/abilities/Dark Priest.js
@@ -235,7 +235,6 @@ G.abilities[0] = [
 		// 	query() :
 		query: function() {
 			var ability = this;
-			G.grid.updateDisplay(); // Retrace players creatures
 
 			if (this.isUpgraded()) this.summonRange = 6;
 

--- a/src/abilities/Lava Mollusk.js
+++ b/src/abilities/Lava Mollusk.js
@@ -121,6 +121,7 @@ G.abilities[22] = [
 			var crea = this.creature;
 
 			crea.queryMove({
+			    targeting:true,
 				noPath: true,
 				isAbility: true,
 				range: G.grid.getFlyingRange(crea.x, crea.y, 50, crea.size, crea.id),

--- a/src/abilities/Nutcase.js
+++ b/src/abilities/Nutcase.js
@@ -488,7 +488,6 @@ G.abilities[40] = [
 					ignoreMovementPoint: true,
 					callback: function() {
 						crea.updateHex();
-						G.grid.updateDisplay();
 						crea.queryMove();
 					}
 				}
@@ -500,7 +499,6 @@ G.abilities[40] = [
 					ignoreMovementPoint: true,
 					callback: function() {
 						target.updateHex();
-						G.grid.updateDisplay();
 						target.takeDamage(damage);
 					}
 				}

--- a/src/abilities/Scavenger.js
+++ b/src/abilities/Scavenger.js
@@ -239,7 +239,6 @@ G.abilities[44] = [
 				animation: "fly",
 				callback: function() {
 					trg.updateHex();
-					G.grid.updateDisplay();
 				},
 				ignoreMovementPoint: true
 			});
@@ -248,7 +247,6 @@ G.abilities[44] = [
 				animation: "fly",
 				callback: function() {
 					ability.creature.updateHex();
-					G.grid.updateDisplay();
 					ability.creature.queryMove();
 				},
 				ignoreMovementPoint: true,

--- a/src/abilities/Scavenger.js
+++ b/src/abilities/Scavenger.js
@@ -168,7 +168,7 @@ G.abilities[44] = [
 			var select = function(hex, args) {
 			    for(var i =0 ; i < trg.hexagons.length;i++){
 			        G.grid.cleanHex(trg.hexagons[i])
-			        trg.hexagons[i].overlayVisualState("hover h_player" + trg.team);
+			        trg.hexagons[i].displayVisualState("dashed");
 			    }
 			    for(var i =0 ; i < crea.hexagons.length;i++){
 			        G.grid.cleanHex(crea.hexagons[i])
@@ -214,7 +214,7 @@ G.abilities[44] = [
 				callbackAfterQueryHexes: () => {
                     for(var i =0 ; i < trg.hexagons.length;i++){
                         G.grid.cleanHex(trg.hexagons[i])
-                        trg.hexagons[i].overlayVisualState("hover h_player" + trg.team);
+                        trg.hexagons[i].displayVisualState("dashed");
                     }
                 },
 				fillHexOnHover: false

--- a/src/abilities/Scavenger.js
+++ b/src/abilities/Scavenger.js
@@ -175,6 +175,7 @@ G.abilities[44] = [
 					} else {
 						color = i > 1 ? trg.team : crea.team;
 					}
+					G.grid.cleanHex(h);
 					h.overlayVisualState("creature moveto selected player" + color);
 				}
 			};
@@ -200,7 +201,8 @@ G.abilities[44] = [
 				args: {
 					trg: trg.id,
 					trgIsInfront: trgIsInfront
-				}
+				},
+				fillHexOnHover: false
 			});
 		},
 

--- a/src/abilities/Scavenger.js
+++ b/src/abilities/Scavenger.js
@@ -166,6 +166,14 @@ G.abilities[44] = [
 			var trgIsInfront = (G.grid.getHexMap(crea.x - matrices.inlinefront2hex.origin[0], crea.y - matrices.inlinefront2hex.origin[1], 0, false, matrices.inlinefront2hex)[0].creature == trg);
 
 			var select = function(hex, args) {
+			    for(var i =0 ; i < trg.hexagons.length;i++){
+			        G.grid.cleanHex(trg.hexagons[i])
+			        trg.hexagons[i].overlayVisualState("hover h_player" + trg.team);
+			    }
+			    for(var i =0 ; i < crea.hexagons.length;i++){
+			        G.grid.cleanHex(crea.hexagons[i])
+			        crea.hexagons[i].overlayVisualState("hover h_player" + crea.team);
+			    }
 				for (var i = 0; i < size; i++) {
 					if (!G.grid.hexExists(hex.y, hex.x - i)) continue;
 					var h = G.grid.hexes[hex.y][hex.x - i];
@@ -176,7 +184,8 @@ G.abilities[44] = [
 						color = i > 1 ? trg.team : crea.team;
 					}
 					G.grid.cleanHex(h);
-					h.overlayVisualState("creature moveto selected player" + color);
+					h.overlayVisualState("active creature player" + color);
+                    h.displayVisualState("creature player" + color);
 				}
 			};
 
@@ -202,6 +211,12 @@ G.abilities[44] = [
 					trg: trg.id,
 					trgIsInfront: trgIsInfront
 				},
+				callbackAfterQueryHexes: () => {
+                    for(var i =0 ; i < trg.hexagons.length;i++){
+                        G.grid.cleanHex(trg.hexagons[i])
+                        trg.hexagons[i].overlayVisualState("hover h_player" + trg.team);
+                    }
+                },
 				fillHexOnHover: false
 			});
 		},

--- a/src/animations.js
+++ b/src/animations.js
@@ -216,7 +216,6 @@ let Animations = class Animations {
 			creature.remainingMove = this.movementPoints;
 		}
 
-		game.grid.updateDisplay();
 		// TODO: Turn around animation
 		if (opts.turnAroundOnComplete) {
 			creature.facePlayerDefault();

--- a/src/creature.js
+++ b/src/creature.js
@@ -194,7 +194,6 @@ var Creature = class Creature {
 		game.queue.addByInitiative(this);
 		game.updateQueueDisplay();
 
-		game.grid.updateDisplay(); // Retrace players creatures
 		game.grid.orderCreatureZ();
 
 		if (game.grid.materialize_overlay) {
@@ -332,7 +331,6 @@ var Creature = class Creature {
 
 		this.hasWait = this.delayed = !!wait;
 		this.stats.frozen = false;
-		game.grid.updateDisplay(); // Retrace players creatures
 
 		// Effects triggers
 		if (!wait) {
@@ -408,6 +406,7 @@ var Creature = class Creature {
 		}
 
 		o = $j.extend({
+			targeting:false,
 			noPath: false,
 			isAbility: false,
 			ownCreatureHexShade: true,
@@ -449,7 +448,6 @@ var Creature = class Creature {
 			game.UI.updateQueueDisplay();
 		}
 
-		game.grid.updateDisplay(); //Retrace players creatures
 		game.grid.orderCreatureZ();
 		this.facePlayerDefault();
 		this.updateHealth();
@@ -491,7 +489,8 @@ var Creature = class Creature {
 				flipped: this.player.flipped,
 				id: this.id,
 				hexes:  o.range,
-				ownCreatureHexShade: o.ownCreatureHexShade
+				ownCreatureHexShade: o.ownCreatureHexShade,
+				targeting: o.targeting
 			});
 		}
 	}
@@ -514,8 +513,7 @@ var Creature = class Creature {
 		this.tracePosition({
 			x: hex.x,
 			y: hex.y,
-			overlayClass: "hover h_player" + this.team,
-			updateDisplayClean: false
+			overlayClass: "hover h_player" + this.team
 		});
 	}
 
@@ -694,8 +692,6 @@ var Creature = class Creature {
 			y = hex.y,
 			path = this.calculatePath(x, y); // Store path in grid to be able to compare it later
 
-		game.grid.updateDisplay(); // Retrace players creatures
-
 		if (path.length === 0) {
 			return; // Break if empty path
 		}
@@ -704,8 +700,7 @@ var Creature = class Creature {
 			this.tracePosition({
 				x: item.x,
 				y: item.y,
-				displayClass: "adj",
-				updateDisplayClean: false
+				displayClass: "adj"
 			});
 		}); // Trace path
 
@@ -717,7 +712,6 @@ var Creature = class Creature {
 			x: last.x,
 			y: last.y,
 			overlayClass: "creature moveto selected player" + this.team,
-			updateDisplayClean: false
 		});
 	}
 
@@ -728,17 +722,13 @@ var Creature = class Creature {
 			y: this.y,
 			overlayClass: "",
 			displayClass: "",
-			updateDisplayClean: true
 		};
 
 		args = $j.extend(defaultArgs, args);
 
-        if (args.updateDisplayClean) {
-            this.game.grid.updateDisplay();
-        }
-
 		for (let i = 0; i < this.size; i++) {
 			let hex = this.game.grid.hexes[args.y][args.x - i];
+			this.game.grid.cleanHex(hex);
 			hex.overlayVisualState(args.overlayClass);
 			hex.displayVisualState(args.displayClass);
 		}

--- a/src/creature.js
+++ b/src/creature.js
@@ -700,7 +700,8 @@ var Creature = class Creature {
 			this.tracePosition({
 				x: item.x,
 				y: item.y,
-				displayClass: "adj"
+				displayClass: "adj",
+				drawOverCreatureTiles: false
 			});
 		}); // Trace path
 
@@ -712,6 +713,7 @@ var Creature = class Creature {
 			x: last.x,
 			y: last.y,
 			overlayClass: "creature moveto selected player" + this.team,
+			drawOverCreatureTiles: false
 		});
 	}
 
@@ -722,15 +724,28 @@ var Creature = class Creature {
 			y: this.y,
 			overlayClass: "",
 			displayClass: "",
+			drawOverCreatureTiles: true
 		};
 
 		args = $j.extend(defaultArgs, args);
 
 		for (let i = 0; i < this.size; i++) {
-			let hex = this.game.grid.hexes[args.y][args.x - i];
-			this.game.grid.cleanHex(hex);
-			hex.overlayVisualState(args.overlayClass);
-			hex.displayVisualState(args.displayClass);
+		    let canDraw = true;
+
+            if(!args.drawOverCreatureTiles){ // then check to ensure this is not a creature tile
+                for(let j = 0; j < this.hexagons.length;j++){
+                    if(this.hexagons[j].x == args.x-i && this.hexagons[j].y == args.y){
+                        canDraw = false;
+                        break;
+                    }
+                }
+            }
+            if(canDraw){
+                let hex = this.game.grid.hexes[args.y][args.x - i];
+                this.game.grid.cleanHex(hex);
+                hex.overlayVisualState(args.overlayClass);
+                hex.displayVisualState(args.displayClass);
+			}
 		}
 	}
 

--- a/src/player.js
+++ b/src/player.js
@@ -82,7 +82,6 @@ var Player = class Player {
 		creature = new Creature(data, game);
 		this.creatures.push(creature);
 		creature.summon();
-		game.grid.updateDisplay(); // Retrace players creatures
 		game.onCreatureSummon(creature);
 	}
 

--- a/src/utility/hexagons.js
+++ b/src/utility/hexagons.js
@@ -836,8 +836,8 @@ var HexGrid = class HexGrid {
 	}
 
     cleanHex (hex) {
-   	hex.cleanDisplayVisualState()
-    	hex.cleanOverlayVisualState()
+   	    hex.cleanDisplayVisualState();
+    	hex.cleanOverlayVisualState();
     }
 
 	/* updateDisplay()

--- a/src/utility/hexagons.js
+++ b/src/utility/hexagons.js
@@ -651,6 +651,7 @@ var HexGrid = class HexGrid {
 				if (hex.materialize_overlay) {
 					hex.materialize_overlay.alpha = 0;
 				}
+				hex.overlayVisualState("hover");
 			} else { // Reachable hex
 				//Offset Pos
 				let offset = (o.flipped) ? o.size - 1 : 0,

--- a/src/utility/hexagons.js
+++ b/src/utility/hexagons.js
@@ -474,6 +474,7 @@ var HexGrid = class HexGrid {
 	 * fnOnCancel : 	Function : 	Function applied when clicking a non reachable hex
 	 * args : 			Object : 	Object given to the events function (to easily pass variable for these function)
 	 * hexes : 		Array : 	Reachable hexes
+	 * callbackAfterQueryHexes : 		Function : 	empty function to be overridden with custom logic to execute after queryHexes
 	 */
 	queryHexes(o) {
 		let game = this.game,
@@ -487,6 +488,9 @@ var HexGrid = class HexGrid {
 				},
 				fnOnCancel: (hex, args) => {
 					game.activeCreature.queryMove();
+				},
+				callbackAfterQueryHexes: () => {
+				    // empty function to be overridden with custom logic to execute after queryHexes
 				},
 				args: {},
 				hexes: [],
@@ -565,6 +569,10 @@ var HexGrid = class HexGrid {
                 }
 			}
 		});
+
+        if(o.callbackAfterQueryHexes){
+            o.callbackAfterQueryHexes();
+        }
 
 		// ONCLICK
 		let onConfirmFn = (hex) => {


### PR DESCRIPTION
AD_1296: Removing previous change and adding support for parameter targeting highlighting. By default now all query hexes always highlights the selected hexs by default. Only creature movement sets it to false, so you get the dark path. Selecting a choice path, like Grumble's Boom Box will not highlight the entire path as specified in 1296, and so should any other ability using the same targeting method queryChoice.

updateDisplay was being abused, and was being called everywhere and now it should only be called by queryHexes() and die(). It shouldn't be abused as it was, it made it very hard to keep the UI in a consistent state. Hexegons should be controlling cleaning the display. Now whenever a hex needs to be changed, cleanHex should be called instead to clean only that hex and then apply the changes directly to it, instead of clearing the entire screen.

I think this should resolve #1296 #1295 #1294  and some other stuff. 

I have changed alot of code here, especially how things work by default. But its in an effort to get some more consistency across how hexagons works. It will probably break a few abilities, let me know if it does, and why it does and I can try and change them.

If your pull request tries to address a specific issue from the repository, please reference to it.
Don't forget to include a description of the changes proposes. https://discord.me/AncientBeast