### PR TITLE
#1298: Unit names changed from red to white in the dash (in-game) section

### DIFF
--- a/src/less/styles.less
+++ b/src/less/styles.less
@@ -1427,10 +1427,6 @@ span.pure {
 }
 
 a {
-	color: red;
-}
-
-a:hover {
 	color: white;
 }
 


### PR DESCRIPTION
Unit names colour changed from red to white in dash section

Fix for issue 1298