### PR TITLE
Fix Windows build issue

### DIFF
--- a/manifestGenerator.js
+++ b/manifestGenerator.js
@@ -103,6 +103,8 @@ function writeToString(tree, root = false) {
 readDirectory(path.join(__dirname, "assets"))
     // Generate the javascript
     .then(result => `export default ${writeToString(result, true)}`)
+    // Add path fix for windows
+    .then(result => result.replace(/\\/g,'\\\\'))
     // Format the javascript so it"s readable
     .then(prettier.format)
     // We only need to write one file so it doesnt matter that it"s sync

--- a/src/index.html
+++ b/src/index.html
@@ -305,7 +305,7 @@
 										<div><span class="icon movement"></span> Movement : Any creature can move a certain number of hexagons every turn.</div>
 									</div>
 									<div class="card_info masteries_desc">
-										<span>There are 9 common types of damage and a rare one called Pure damage that bypasses the formula bellow, doing a fixed non-variable amount of harm no matter what.</span><br><br>
+										<span>There are 9 common types of damage and a rare one called Pure damage that bypasses the formula below, doing a fixed non-variable amount of harm no matter what.</span><br><br>
 										<span><u>Damage Formula</u><br>attack damage +<br>attack damage / 100 *<br>(offense of attacking unit -<br>defense of unit attacked /<br>number of hexagons hit +<br>source stat of attacker -<br>source stat of defender)</span><br><br>
 										<span>Minimum damage is usually 1<br>unless the hit is being avoided.</span>
 									</div>


### PR DESCRIPTION
Hello, it's Nysari from Discord! I noticed the project was failing to build on Windows due to the use of '\' on Windows paths causing a syntax error in the bash. I did a simple string.replace() and worked with GamesMaxed on Discord to apply the solution in a way that matches his existing styling. It now builds and loads successfully on Windows.

I also changed a little type on index.html