### PR TITLE
feat: show disabled cursor for cancel action

### DIFF
--- a/src/utility/hexgrid.js
+++ b/src/utility/hexgrid.js
@@ -665,22 +665,13 @@ export class HexGrid {
 			if (hex.creature instanceof Creature) {
 				// If creature
 				onCreatureHover(hex.creature, game.UI.xrayQueue.bind(game.UI), hex);
-			} else if (o.fillHexOnHover && hex.reachable) {
-				this.cleanHex(hex);
-				hex.displayVisualState('creature player' + this.game.activeCreature.team);
-			}
-
-			// Not reachable hex
-			if (!hex.reachable) {
-				if (hex.materialize_overlay) {
-					hex.materialize_overlay.alpha = 0;
+			} else if (hex.reachable) {
+				if (o.fillHexOnHover) {
+					this.cleanHex(hex);
+					hex.displayVisualState('creature player' + this.game.activeCreature.team);
 				}
-				hex.overlayVisualState('hover');
 
-				$j('canvas').css('cursor', 'not-allowed');
-			} else {
-				// Reachable hex
-				//Offset Pos
+				// Offset Pos
 				let offset = o.flipped ? o.size - 1 : 0,
 					mult = o.flipped ? 1 : -1, // For flipped player
 					availablePos = false;
@@ -700,6 +691,13 @@ export class HexGrid {
 
 				hex = this.hexes[y][x]; // New coords
 				o.fnOnSelect(hex, o.args);
+			} else if (!hex.reachable) {
+				if (hex.materialize_overlay) {
+					hex.materialize_overlay.alpha = 0;
+				}
+				hex.overlayVisualState('hover');
+
+				$j('canvas').css('cursor', 'not-allowed');
 			}
 		};
 

--- a/src/utility/hexgrid.js
+++ b/src/utility/hexgrid.js
@@ -676,6 +676,8 @@ export class HexGrid {
 					hex.materialize_overlay.alpha = 0;
 				}
 				hex.overlayVisualState('hover');
+
+				$j('canvas').css('cursor', 'not-allowed');
 			} else {
 				// Reachable hex
 				//Offset Pos


### PR DESCRIPTION
#1224 

with this change, the pointer shows a circle with a dash through it, symbolizing that the action cannot take place. if the user persists and clicks, then the action is cancelled.

the mouse cursor state is very buggy, constantly changing to/from the loading state. this change works out pretty well even so!