### PR TITLE
prevent massive performance drop on canvas mouseout by ignoring…

### DIFF
--- a/src/utility/hex.js
+++ b/src/utility/hex.js
@@ -103,8 +103,8 @@ export class Hex {
 				this.onSelectFn(this);
 			}, this);
 
-			this.input.events.onInputOut.add(() => {
-				if (game.freezedInput || game.UI.dashopen) {
+			this.input.events.onInputOut.add((_, pointer) => {
+				if (game.freezedInput || game.UI.dashopen || !pointer.withinGame) {
 					return;
 				}
 


### PR DESCRIPTION
… events that take place out of game

issue #1352 

to test, use chrome's devtools to monitor performance when moving mouse between UI and game canvas. you should note a sharp performance decrease when doing so. then, check the same on this PR and note that the performance drop has disappeared!