### PR TITLE
remove grey line from active unit in unit queue

### DIFF
--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -804,6 +804,7 @@ div.section.info {
 
 .vignette.active .stats {
 	height: 0;
+	border: 0;
 }
 
 #playeravatar.vignette,


### PR DESCRIPTION
issue #1354 

the active unit "stats" box still had its border, making the appearance of a small grey line when the height was set to zero.