### PR TITLE
broken Chimera ultimate

### DIFF
--- a/src/abilities/Chimera.js
+++ b/src/abilities/Chimera.js
@@ -265,7 +265,8 @@ export default G => {
 							crush: _crush
 						}, // Damage Type
 						1, // Area
-						[] // Effects
+						[], // Effects
+						G
 					);
 					let result = _target.takeDamage(damage);
 					// Knock the target back if they are still alive and there is enough range


### PR DESCRIPTION
issue #1305 

turns out @yfzdq was correct: the issue was in fact that `this.game` was undefined because one of the Damage constructor calls was missing the game parameter, so when it was added to match the other Damage constructor calls - voila, no undefined access and the ability functions normally.