### PR TITLE
initialize Headless unit abilities to fix issue where unit does not spawn

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -25,6 +25,7 @@ import scavengerAbilitiesGenerator from './abilities/Scavenger';
 import snowBunnyAbilitiesGenerator from './abilities/Snow-Bunny';
 import swineThugAbilitiesGenerator from './abilities/Swine-Thug';
 import uncleFungusAbilitiesGenerator from './abilities/Uncle-Fungus';
+import headlessAbilitiesGenerator from './abilities/Headless';
 
 // Generic object we can decorate with helper methods to simply dev and user experience.
 // TODO: Expose this in a less hacky way.
@@ -55,7 +56,8 @@ const abilitiesGenerators = [
 	scavengerAbilitiesGenerator,
 	snowBunnyAbilitiesGenerator,
 	swineThugAbilitiesGenerator,
-	uncleFungusAbilitiesGenerator
+	uncleFungusAbilitiesGenerator,
+	headlessAbilitiesGenerator
 ];
 abilitiesGenerators.forEach(generator => generator(G));
 


### PR DESCRIPTION
issue #1365 

in debugging, i noticed that the headless unit has ID 39. the game abilities object did not have an entry for 39, so i checked the initialization and noticed that headless abilities were not loaded into the game.