### PR TITLE
remove cursor loading state once setup is complete

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -340,6 +340,8 @@ export default class Game {
 			setTimeout(() => {
 				this.gameState = 'loaded';
 
+				$j('body').css('cursor', 'default');
+
 				// Do not call setup if we are not active.
 				if (!this.preventSetup) {
 					this.setup(this.playerMode);


### PR DESCRIPTION
issue #1358 

essentially the cursor loading state is set before loading the game, and it was not removed once loading was finished. this adds the code to remove the loading state once setup is complete.