### PR TITLE
do not apply Scavenger's Deadly Toxin effect when unit shields the attack

### DIFF
--- a/src/abilities/Scavenger.js
+++ b/src/abilities/Scavenger.js
@@ -358,35 +358,39 @@ export default G => {
 					G
 				);
 
-				target.takeDamage(damage);
+				let result = target.takeDamage(damage);
 
-				// Add poison damage debuff
-				let effect = new Effect(
-					this.title,
-					this.creature,
-					target,
-					'onStartPhase',
-					{
-						stackable: false,
-						effectFn: function(effect, creature) {
-							G.log('%CreatureName' + creature.id + '% is affected by ' + ability.title);
-							creature.takeDamage(
-								new Damage(
-									effect.owner,
-									{
-										poison: ability.damages.poison
-									},
-									1,
-									[],
-									G
-								)
-							);
-						}
-					},
-					G
-				);
-				target.replaceEffect(effect);
-				G.log('%CreatureName' + target.id + '% is poisoned by ' + this.title);
+				if (result.damageObj.status !== 'Shielded') {
+					// Add poison damage debuff
+					let effect = new Effect(
+						this.title,
+						this.creature,
+						target,
+						'onStartPhase',
+						{
+							stackable: false,
+							effectFn: function(effect, creature) {
+								G.log('%CreatureName' + creature.id + '% is affected by ' + ability.title);
+								creature.takeDamage(
+									new Damage(
+										effect.owner,
+										{
+											poison: ability.damages.poison
+										},
+										1,
+										[],
+										G
+									)
+								);
+							}
+						},
+						G
+					);
+
+					target.replaceEffect(effect);
+
+					G.log('%CreatureName' + target.id + '% is poisoned by ' + this.title);
+				}
 
 				G.UI.checkAbilities();
 			}


### PR DESCRIPTION
issue #1119 

the root issue here is that the effect is always applied, no matter what the outcome of the attack. so this PR adds a check to see if the initial damage was shielded before applying the recurring toxin effect.

the condition could be changed to checking for the damage actually applied, in case other abilities can block damage but not "shield" it. 