### PR TITLE
don't animate active unit's UI on kill

### DIFF
--- a/src/creature.js
+++ b/src/creature.js
@@ -1620,10 +1620,6 @@ export class Creature {
 
 		// As hex occupation changes, path must be recalculated for the current creature not the dying one
 		game.activeCreature.queryMove();
-
-		// Queue cleaning
-		game.UI.updateActivebox();
-		game.UI.updateQueueDisplay(); // Just in case
 	}
 
 	isFatigued() {


### PR DESCRIPTION
issue #1091 

another example of code that appears to be unnecessary? :man_shrugging: the UI is fully refreshed on unit death - but the UI seems to update without the removed code.

here is my test case:

> "AB-0.3:eyJjb25maWciOnsicGxheWVyTW9kZSI6MiwiY3JlYUxpbWl0TmJyIjozLCJ1bml0RHJvcHMiOjEsImFiaWxpdHlVcGdyYWRlcyI6MywicGxhc21hX2Ftb3VudCI6MzAsInR1cm5UaW1lUG9vbCI6LTEsInRpbWVQb29sIjotNjAsImJhY2tncm91bmRfaW1hZ2UiOiJTaGFkb3cgQ2F2ZSJ9LCJsb2ciOlt7ImFjdGlvbiI6ImFiaWxpdHkiLCJ0YXJnZXQiOnsidHlwZSI6ImhleCIsIngiOjQsInkiOjR9LCJpZCI6MywiYXJncyI6eyIxIjp7ImNyZWF0dXJlIjoiRzMiLCJjb3N0Ijo1fX19LHsiYWN0aW9uIjoibW92ZSIsInRhcmdldCI6eyJ4IjoyLCJ5Ijo0fX0seyJhY3Rpb24iOiJza2lwIn0seyJhY3Rpb24iOiJhYmlsaXR5IiwidGFyZ2V0Ijp7InR5cGUiOiJoZXgiLCJ4IjoxMSwieSI6NX0sImlkIjozLCJhcmdzIjp7IjEiOnsiY3JlYXR1cmUiOiJBMSIsImNvc3QiOjJ9fX0seyJhY3Rpb24iOiJza2lwIn0seyJhY3Rpb24iOiJtb3ZlIiwidGFyZ2V0Ijp7IngiOjYsInkiOjR9fSx7ImFjdGlvbiI6ImFiaWxpdHkiLCJ0YXJnZXQiOnsidHlwZSI6ImhleCIsIngiOjksInkiOjR9LCJpZCI6MiwiYXJncyI6eyIxIjp7fX19LHsiYWN0aW9uIjoic2tpcCJ9LHsiYWN0aW9uIjoibW92ZSIsInRhcmdldCI6eyJ4Ijo0LCJ5Ijo0fX0seyJhY3Rpb24iOiJza2lwIn0seyJhY3Rpb24iOiJza2lwIn0seyJhY3Rpb24iOiJtb3ZlIiwidGFyZ2V0Ijp7IngiOjEwLCJ5Ijo0fX0seyJhY3Rpb24iOiJza2lwIn0seyJhY3Rpb24iOiJhYmlsaXR5IiwidGFyZ2V0Ijp7InR5cGUiOiJjcmVhdHVyZSIsImNyZWEiOjR9LCJpZCI6MywiYXJncyI6eyIxIjp7fX19LHsiYWN0aW9uIjoiYWJpbGl0eSIsInRhcmdldCI6eyJ0eXBlIjoiY3JlYXR1cmUiLCJjcmVhIjo0fSwiaWQiOjEsImFyZ3MiOnsiMSI6e319fSx7ImFjdGlvbiI6InNraXAifSx7ImFjdGlvbiI6Im1vdmUiLCJ0YXJnZXQiOnsieCI6NiwieSI6NH19LHsiYWN0aW9uIjoic2tpcCJ9LHsiYWN0aW9uIjoic2tpcCJ9LHsiYWN0aW9uIjoic2tpcCJ9XX0="