### PR TITLE
allow units to walk back a single hex

### DIFF
--- a/src/utility/hexgrid.js
+++ b/src/utility/hexgrid.js
@@ -665,7 +665,9 @@ export class HexGrid {
 			if (hex.creature instanceof Creature) {
 				// If creature
 				onCreatureHover(hex.creature, game.UI.xrayQueue.bind(game.UI), hex);
-			} else if (hex.reachable) {
+			}
+
+			if (hex.reachable) {
 				if (o.fillHexOnHover) {
 					this.cleanHex(hex);
 					hex.displayVisualState('creature player' + this.game.activeCreature.team);


### PR DESCRIPTION
issue #1378 

when hovering a hex with a creature on it, no walk logic is processed. this is resolved by separating the creature hover check from the walkable check - allowing units to walk one hex back.

