### PR TITLE
when mouse leaves hex, return cursor to default state

### DIFF
--- a/src/utility/hexgrid.js
+++ b/src/utility/hexgrid.js
@@ -648,6 +648,8 @@ export class HexGrid {
 					creature.updateHealth();
 				}
 			}
+
+			$j('canvas').css('cursor', 'default');
 		};
 
 		// ONMOUSEOVER


### PR DESCRIPTION
issue #1389 

this seems to do the trick! add a call to reset the cursor state on hover out. 