### PR TITLE
feat: Cancel selected ability hotkey

### DIFF
--- a/src/ui/chat.js
+++ b/src/ui/chat.js
@@ -17,6 +17,7 @@ export class Chat {
 			game.UI.chat.toggle();
 		});
 		this.messages = [];
+		this.isOpen = false;
 
 		$j('#combatwrapper, #toppanel, #dash, #endscreen').bind('click', () => {
 			game.UI.chat.hide();
@@ -25,15 +26,18 @@ export class Chat {
 
 	show() {
 		this.$chat.addClass('focus');
+		this.isOpen = true;
 	}
 
 	hide() {
 		this.$chat.removeClass('focus');
+		this.isOpen = false;
 	}
 
 	toggle() {
 		this.$chat.toggleClass('focus');
 		this.$content.parent().scrollTop(this.$content.height());
+		this.isOpen = !this.isOpen;
 	}
 
 	getCurrentTime() {

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -252,6 +252,8 @@ export class UI {
 
 			let prevD = false;
 			let modifierPressed = e.metaKey || e.altKey || e.ctrlKey;
+			let activeAbilityBool =
+				this.activeAbility && !this.$scoreboard.is(':visible') && !this.chat.isOpen;
 
 			$j.each(hotkeys, (k, v) => {
 				if (!modifierPressed && v == keypressed) {
@@ -279,6 +281,17 @@ export class UI {
 								break;
 							case 'dash_right':
 								this.gridSelectRight();
+								break;
+						}
+						/* Check to see if scoreboard or chat is open first before
+						 * cancelling the active ability when using Esc hotkey
+             */
+					} else if (activeAbilityBool) {
+						switch (k) {
+							case 'close':
+								game.grid.clearHexViewAlterations();
+								game.activeCreature.queryMove();
+								this.selectAbility(-1);
 								break;
 						}
 					} else {
@@ -951,8 +964,10 @@ export class UI {
 		if (i > -1) {
 			this.showAbilityCosts(i);
 			this.abilitiesButtons[i].changeState('active');
+			this.activeAbility = true;
 		} else {
 			this.hideAbilityCosts();
+			this.activeAbility = false;
 		}
 	}
 


### PR DESCRIPTION
issue #1393 

Implemented the `Esc` key to cancel the active ability. I added some logic so that if the chat window or scoreboard is open, `Esc` will not cancel the active ability, before it closes the open windows.
