### PR TITLE
fix: Hotkeys disabled while targeting

### DIFF
--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -283,20 +283,19 @@ export class UI {
 								this.gridSelectRight();
 								break;
 						}
-						/* Check to see if scoreboard or chat is open first before
-						 * cancelling the active ability when using Esc hotkey
-             */
-					} else if (activeAbilityBool) {
-						switch (k) {
-							case 'close':
-								game.grid.clearHexViewAlterations();
-								game.activeCreature.queryMove();
-								this.selectAbility(-1);
-								break;
-						}
 					} else {
 						switch (k) {
 							case 'close':
+								/* Check to see if scoreboard or chat is open first before
+								 * cancelling the active ability when using Esc hotkey
+								 */
+								if (activeAbilityBool) {
+									game.grid.clearHexViewAlterations();
+									game.activeCreature.queryMove();
+									this.selectAbility(-1);
+									break;
+								}
+
 								this.chat.hide();
 								this.$scoreboard.hide();
 								break; // Close chat and/or scoreboard if opened


### PR DESCRIPTION
issue #1400 

This fixes the code that was a feature added from issue #1393, that broke the ability to use the other hotkeys while targeting. Simply moving the logic check to the original `Esc`/close case... Sorry!