### PR TITLE
invisible Abolished wildfire traps

### DIFF
--- a/src/abilities/Abolished.js
+++ b/src/abilities/Abolished.js
@@ -192,6 +192,7 @@ export default G => {
 						isFromTrap: true
 					});
 					this.trap.destroy();
+					effect.deleteEffect();
 				};
 
 				let requireFn = function() {


### PR DESCRIPTION
issue #1403 

this PR changes the wild fire _effect_ to "self destruct" after dealing damage.

@DreadKnight please confirm this is the expected behavior! the in-game doc is light on details :)