### PR TITLE
tentacle bush shouldn't trigger for DOTs

### DIFF
--- a/src/abilities/Scavenger.js
+++ b/src/abilities/Scavenger.js
@@ -379,7 +379,8 @@ export default G => {
 										1,
 										[],
 										G
-									)
+									),
+									{ isFromTrap: true }
 								);
 							}
 						},


### PR DESCRIPTION
issue #1409 

this bug is caused by the game's poor "melee" check, which only requires the "source" unit (source of the damage) be _one hex away_ from the target.

the only flag to bypass this is to consider the damage `from a trap`.