### PR TITLE
autofocus the first form element to enable "press enter to start the game" functionality

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -79,6 +79,10 @@ $j(document).ready(() => {
 	// Disable initial game setup until browser tab has focus
 	window.addEventListener('blur', G.onBlur.bind(G), false);
 	window.addEventListener('focus', G.onFocus.bind(G), false);
+
+	// Focus the form to enable "press enter to start the game" functionality
+	$j('#p2').focus();
+
 	$j('form#gameSetup').submit(e => {
 		e.preventDefault(); // Prevent submit
 


### PR DESCRIPTION
issue #1392 

i think this solution will please @ktiedt and @DreadKnight : "press enter to submit form" is expected web behavior. this PR connects the dots by autofocusing the first form element so that pressing enter will submit the form, causing the game to launch.

the only downside is that clicking outside the form will not cause enter to work, but i think it's a fair compromise for now.