### PR TITLE
basic upgrade bonus

### DIFF
--- a/src/ability.js
+++ b/src/ability.js
@@ -167,8 +167,25 @@ export class Ability {
 	postActivate() {
 		this.timesUsed++;
 		this.timesUsedThisTurn++;
+
 		// Update upgrade information
 		this.game.UI.updateAbilityButtonsContent();
+
+		// Configure score update for player
+		// When the ability is upgraded, add a single score bonus unique to that ability
+		if (this.isUpgraded()) {
+			// Upgrade bonus uniqueness managed by preventing multiple bonuses
+			// with the same ability ID
+			const bonus ={
+				type: 'upgrade',
+				ability: this.id
+			};
+
+			// Only add the bonus when it has not already been awarded
+			if (!this.creature.player.score.find(b => b.type === bonus.type && b.ability === bonus.ability)) {
+				this.creature.player.score.push(bonus);
+			}
+		}
 	}
 
 	/**

--- a/src/ability.js
+++ b/src/ability.js
@@ -175,14 +175,19 @@ export class Ability {
 		// When the ability is upgraded, add a single score bonus unique to that ability
 		if (this.isUpgraded()) {
 			// Upgrade bonus uniqueness managed by preventing multiple bonuses
-			// with the same ability ID
+			// with the same ability ID (which is an index 0,1,2,3 into the creature's abilities) and the creature ID
 			const bonus ={
 				type: 'upgrade',
-				ability: this.id
+				ability: this.id,
+				creature: this.creature.id
 			};
 
+			const find = scorePart => scorePart.type === bonus.type &&
+			      scorePart.ability === bonus.ability &&
+			      scorePart.creature === bonus.creature;
+
 			// Only add the bonus when it has not already been awarded
-			if (!this.creature.player.score.find(b => b.type === bonus.type && b.ability === bonus.ability)) {
+			if (!this.creature.player.score.find(find)) {
 				this.creature.player.score.push(bonus);
 			}
 		}

--- a/src/index.html
+++ b/src/index.html
@@ -220,6 +220,13 @@
 							<td>--</td>
 							<td>--</td>
 						</tr>
+						<tr class="upgrade">
+						    <td>Ability Upgrades</td>
+						    <td>--</td>
+						    <td>--</td>
+						    <td>--</td>
+						    <td>--</td>
+						</tr>
 						<tr class="total">
 							<td>Total</td>
 							<td>--</td>

--- a/src/player.js
+++ b/src/player.js
@@ -131,7 +131,8 @@ export class Player {
 				darkpriestbonus: 0,
 				immortal: 0,
 				total: 0,
-				pickupDrop: 0
+				pickupDrop: 0,
+				upgrade: 0
 			};
 
 		for (let i = 0; i < total; i++) {
@@ -175,6 +176,9 @@ export class Player {
 				case 'pickupDrop':
 					points += 2;
 					break;
+			case 'upgrade':
+				points += 1;
+				break;
 			}
 
 			totalScore[s.type] += points;

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -1582,7 +1582,7 @@ a {
 
 #scoreboard {
 	width: 450px;
-	height: 420px;
+	height: 450px;
 	color: white;
 	margin: 30px auto 0;
 	background: black;

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -1157,6 +1157,10 @@ export class UI {
 				title: 'Immortal'
 			},
 			{
+				cls: 'upgrade',
+				title: 'Ability Upgrades'
+			},
+			{
 				cls: 'total',
 				title: 'Total'
 			}
@@ -1166,7 +1170,7 @@ export class UI {
 			$table
 				.find(`tr.${row.cls}`)
 				.empty()
-				.html(`<td>${row.title}`);
+				.html(`<td>${row.title}</td>`);
 
 			// Add cells for each player
 			for (let i = 0; i < game.playerMode; i++) {


### PR DESCRIPTION
issue #1251 

this PR:

- adds the table row for the ability upgrade score
  - and increases the element height to compensate
- attempts to increase the ability upgrade score on ability upgrade
  - note: this is incomplete

I don't understand how to properly check if an ability is upgraded. currently, this PR will correctly identify an upgraded "Godlet Printer" ability, but _will not_ detect an upgraded Abolished's `Greater Pyre` ability (despite it being upgraded!). I don't understand the `isUpgraded` / `hasUpgrade` / etc code.