### PR TITLE
show log by default on game start

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -645,6 +645,7 @@ export default class Game {
 						this.log('Use the last one to materialize a unit');
 						this.log('Making units drains your plasma points');
 						this.log('Press the hourglass icon to skip the turn');
+						this.log('Press Enter/Return to toggle this log');
 						this.log(
 							'%CreatureName' + this.activeCreature.id + '%, press here to toggle tutorial!'
 						);

--- a/src/ui/chat.js
+++ b/src/ui/chat.js
@@ -22,6 +22,8 @@ export class Chat {
 		$j('#combatwrapper, #toppanel, #dash, #endscreen').bind('click', () => {
 			game.UI.chat.hide();
 		});
+
+		this.show();
 	}
 
 	show() {


### PR DESCRIPTION
issue #1107 

- [x] show chat/log by default
- [x] add "return/enter" hotkey help message to log