### PR TITLE
Fix: #warning google link shadow and text color

### DIFF
--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -1418,6 +1418,11 @@ span.pure {
 	padding-top: 10px;
 }
 
+#warning a {
+	color: red;
+	text-decoration: none;
+}
+
 #version {
 	font-weight: bold;
 	text-shadow: 2px 2px black;


### PR DESCRIPTION
issue #1432 

Got rid of the underline and changed the google link text color to red.