### PR TITLE
fixed bug that caused traps being constantly removed if they were on an hex that had a trap before

### DIFF
--- a/src/utility/trap.js
+++ b/src/utility/trap.js
@@ -77,7 +77,7 @@ export class Trap {
 						)
 						.start();
 					tween.onComplete.add(() => {
-						this.destroy();
+						sprite.destroy();
 					}, sprite);
 				} else {
 					sprite.destroy();


### PR DESCRIPTION
fixes #1431 

the line changed ( this.destroy() ) was causing the destroy method to loop and keep destroying traps on that hex, but im not sure if my solution is the intended behavior for that line so if anyone has a better idea i would like to hear it.