### PR TITLE
Fixed game crashing when the active creature dies

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -619,8 +619,10 @@ export default class Game {
 
 						let last = this.activeCreature;
 						this.activeCreature = next; // Set new activeCreature
-						// Update health display due to active creature change
-						last.updateHealth();
+
+						if (!last.dead) {
+							last.updateHealth(); // Update health display due to active creature change
+						}
 					}
 
 					if (this.activeCreature.player.hasLost) {


### PR DESCRIPTION
Fixes #1416 

the problem was that when a creature dies his health indicator its destroyed([Line 1625 on creature.js](https://github.com/FreezingMoon/AncientBeast/blob/c3b1a018f250eaca35bc47e2ca0eeec318b56968/src/creature.js#L1625)) but later on the game tries to update the health of the last creature that move which is the dead creature so the game crashed.