### PR TITLE
Chat window peek 3 lines on hover feature

### DIFF
--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -873,10 +873,23 @@ div.section.info {
 	bottom: 310px;
 }
 
-#chat.focus #chatbox {
-	height: 305px;
+#chat.peek {
+	height: 100px;
+	bottom: 110px;
+}
+
+#chat.focus #chatbox,
+#chat.peek #chatbox {
 	overflow: hidden;
 	overflow-y: scroll;
+}
+
+#chat.focus #chatbox {
+	height: 305px;
+}
+
+#chat.peek #chatbox {
+	height: 105px;
 }
 
 #chat #chatbox {
@@ -893,7 +906,8 @@ div.section.info {
 	/* Safari and Chrome */
 }
 
-#chat.focus #chatbox #chatcontent {
+#chat.focus #chatbox #chatcontent,
+#chat.peek #chatbox #chatcontent {
 	position: relative;
 }
 

--- a/src/ui/chat.js
+++ b/src/ui/chat.js
@@ -16,6 +16,12 @@ export class Chat {
 		this.$chat.bind('click', () => {
 			game.UI.chat.toggle();
 		});
+		this.$chat.bind('mouseenter', () => {
+			game.UI.chat.peekOpen();
+		});
+		this.$chat.bind('mouseleave', () => {
+			game.UI.chat.peekClose();
+		});
 		this.messages = [];
 		this.isOpen = false;
 
@@ -36,8 +42,25 @@ export class Chat {
 
 	toggle() {
 		this.$chat.toggleClass('focus');
+		if (this.$chat.hasClass('peek')) {
+			this.$chat.removeClass('peek');
+		}
 		this.$content.parent().scrollTop(this.$content.height());
 		this.isOpen = !this.isOpen;
+	}
+
+	peekOpen() {
+		if (this.$chat.hasClass('focus') === false) {
+			this.$chat.addClass('peek');
+			this.$content.parent().scrollTop(this.$content.height());
+			this.isOpen = !this.isOpen;
+		}
+	}
+
+	peekClose() {
+		if (this.$chat.hasClass('peek')) {
+			this.$chat.removeClass('peek');
+		}
 	}
 
 	getCurrentTime() {


### PR DESCRIPTION
Adding feature which allows user to see 3 last lines of chat window on mouse hoover. After clicking on chat window it expands as previously did. Collapsing window works as before.