### PR TITLE
Fixed the closing of the music player (issue #1519)

### DIFF
--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -58,10 +58,9 @@ export class UI {
 					// if dash is open and audio player is visible, just show creatures
 					if (this.dashopen && $j('#musicplayerwrapper').is(':visible')) {
 						$j('#musicplayerwrapper').hide();
-						this.showCreature(game.activeCreature.type, game.activeCreature.team);
-					} else {
-						this.toggleDash();
 					}
+
+					this.toggleDash();
 				}
 			},
 			game


### PR DESCRIPTION
Fixes #1519

The closing button had bad `onClick` function which opened creature list if music player was opened. Just deleted this and rewrite `if else` condition
