### PR TITLE
fixes issue #1568

### DIFF
--- a/src/style/grid.less
+++ b/src/style/grid.less
@@ -42,19 +42,23 @@
 
 #creaturegrid .vignette.dead div.overlay {
 	background-image: url('~assets/icons/dead.svg');
+	background-color: rgba(0, 0, 0, 0.55);
 }
 
 #creaturegrid .vignette.notsummonable div.overlay {
 	background-image: url('~assets/icons/plasma.svg');
+	background-color: rgba(0, 0, 0, 0.55);
 }
 
 #creaturegrid .vignette.locked div.overlay {
 	background-image: url('~assets/icons/locked.svg');
+	background-color: rgba(0, 0, 0, 0.55);
 }
 
 #creaturegrid .vignette.queued div.overlay {
 	background-image: url('~assets/icons/queue.svg');
 	animation: pulse0106 750ms infinite alternate;
+	background-color: rgba(0, 0, 0, 0.55);
 }
 
 #creaturegrid .vignette .tooltip {


### PR DESCRIPTION
fixes issue #1568 for transparent black background on dead, notsummonable, locked, and queued icons in the creature grid

<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1607"><img src="https://gitpod.io/api/apps/github/pbs/github.com/classicmatsuo/AncientBeast.git/d678f54bbbb9232d1fc538e1c047e85e070db127.svg" /></a>

