### PR TITLE
Fixes Issue #1573

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
 	"rules": {
 		"prettier/prettier": "error",
 		"no-undef": "error",
-		"array-element-newline": "error"
+		"array-element-newline": "consistent"
 	},
 	"parserOptions": {
 		"ecmaVersion": 2017,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
 	"rules": {
 		"prettier/prettier": "error",
 		"no-undef": "error",
-		"array-element-newline": "consistent"
+		"array-element-newline": "error"
 	},
 	"parserOptions": {
 		"ecmaVersion": 2017,

--- a/src/game.js
+++ b/src/game.js
@@ -138,6 +138,12 @@ export default class Game {
 			ui: {
 				dash: {
 					materializeOverload: 'Overload! Maximum number of units controlled',
+					selectUnit: 'Please select an available unit from the left grid',
+					lowPlasma: 'Low Plasma! Cannot materialize the selected unit',
+					// plasmaCost :    String :    plasma cost of the unit to materialize
+					materializeUnit: plasmaCost => { return 'Materialize unit at target location for ' + plasmaCost + ' plasma'; },
+					materializeUsed: 'Materialization has already been used this round',
+					heavyDev: 'This unit is currently under heavy development'
 				},
 			},
 		};

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -901,7 +901,7 @@ export class UI {
 
 			let activeCreature = game.activeCreature;
 			if (activeCreature.player.getNbrOfCreatures() > game.creaLimitNbr) {
-				$j('#materialize_button p').text(game.msg.dash.materializeOverload);
+				$j('#materialize_button p').text(game.msg.ui.dash.materializeOverload);
 			} else if (
 				!summonedOrDead &&
 				activeCreature.player.id === player &&
@@ -914,14 +914,12 @@ export class UI {
 
 				// Messages (TODO: text strings in a new language file)
 				if (plasmaCost > activeCreature.player.plasma) {
-					$j('#materialize_button p').text('Low Plasma! Cannot materialize the selected unit');
+					$j('#materialize_button p').text(game.msg.ui.dash.lowPlasma);
 				} else {
 					if (creatureType == '--') {
-						$j('#materialize_button p').text('Please select an available unit from the left grid');
+						$j('#materialize_button p').text(game.msg.ui.dash.selectUnit);
 					} else {
-						$j('#materialize_button p').text(
-							'Materialize unit at target location for ' + plasmaCost + ' plasma',
-						);
+						$j('#materialize_button p').text(game.msg.ui.dash.materializeUnit(plasmaCost.toString()));
 
 						// Bind button
 						this.materializeButton.click = () => {
@@ -941,14 +939,14 @@ export class UI {
 				}
 			} else {
 				if (creatureType == '--' && !activeCreature.abilities[3].used) {
-					//Figure out if the player has enough plasma to summon anything
-					const activePlayer = this.game.players[this.game.activeCreature.player.id];
+					// Figure out if the player has enough plasma to summon any available creatures
+					const activePlayer = game.players[game.activeCreature.player.id];
 					const deadOrSummonedTypes = activePlayer.creatures.map(creature => creature.type);
 					const availableTypes = activePlayer.availableCreatures.filter(
 						el => !deadOrSummonedTypes.includes(el),
 					);
-					//Assume we can't afford anything
-					//Check one available creature at a time until we see something we can afford
+					// Assume we can't afford anything
+					// Check one available creature at a time until we see something we can afford
 					let can_afford_a_unit = false;
 					availableTypes.forEach(type => {
 						const lvl = type.substring(1, 2) - 0;
@@ -958,48 +956,21 @@ export class UI {
 							can_afford_a_unit = true;
 						}
 					});
-					//If we can't afford anything, tell the player
+					// If we can't afford anything, tell the player and disable the materialize button
 					if (!can_afford_a_unit) {
-						$j('#materialize_button p').text(this.game.msg.abilities.noPlasma);
+						$j('#materialize_button p').text(game.msg.abilities.noPlasma);
 						this.materializeButton.changeState('disabled');
 					}
-					//Otherwise, let's assign it a random selection on click
+					// Otherwise, let's have it show a random creature on click
 					else {
-						$j('#materialize_button p').text('Please select an available unit from the left grid');
+						$j('#materialize_button p').text(game.msg.ui.dash.selectUnit);
 						// Bind button for random unit selection
 						this.materializeButton.click = () => {
-							const activePlayer = this.game.players[this.game.activeCreature.player.id];
-							const deadOrSummonedTypes = activePlayer.creatures.map(creature => creature.type);
-							const availableTypes = activePlayer.availableCreatures.filter(
-								el => !deadOrSummonedTypes.includes(el),
-							);
-							// Randomize array to grab a random creature
-							for (let i = availableTypes.length - 1; i > 0; i--) {
-								let j = Math.floor(Math.random() * (i + 1));
-								let temp = availableTypes[i];
-								availableTypes[i] = availableTypes[j];
-								availableTypes[j] = temp;
-							}
-							// Grab the first creature we can afford (if none, default to priest)
-							let typeToPass = '--';
-							availableTypes.some(creature => {
-								const lvl = creature.substring(1, 2) - 0;
-								const size = game.retrieveCreatureStats(creature).size - 0;
-								const plasmaCost = lvl + size;
-								return plasmaCost <= activePlayer.plasma ? ((typeToPass = creature), true) : false;
-							});
-							// Make sure we aren't materializing a Dark Priest
-							// We already checked that we can afford something, so Dark Priest should never appear here, but checking just in case
-							if (typeToPass != '--') {
-								this.materializeToggled = false;
-								this.selectAbility(3);
-								this.closeDash();
-								activeCreature.abilities[3].materialize(typeToPass);
-							}
+							this.showRandomCreature();
 						};
+						// Apply the changes
 						$j('#card .sideA').on('click', this.materializeButton.click);
 						$j('#card .sideA').removeClass('disabled');
-						// Apply the changes
 						this.materializeButton.changeState('glowing');
 					}
 				} else if (
@@ -1011,7 +982,7 @@ export class UI {
 					if (clickMethod == 'portrait' && creatureType != '--') {
 						$j('#materialize_button').hide();
 					} else {
-						$j('#materialize_button p').text('Materialization has already been used this round');
+						$j('#materialize_button p').text(game.msg.ui.dash.materializeUsed);
 						$j('#materialize_button').show();
 					}
 				} else {
@@ -1083,8 +1054,45 @@ export class UI {
 			$j('#card .sideA')
 				.addClass('disabled')
 				.unbind('click');
-			$j('#materialize_button p').text('This unit is currently under heavy development');
+			$j('#materialize_button p').text(game.msg.ui.dash.heavyDev);
 		}
+	}
+
+	/* showRandomCreature()
+	 *
+	 * Selects a random available unit and shows its card on the dash.
+	 *
+	 * Calls showCreature(chosenRandomUnit, activePlayerID, '') to handle opening the dash.
+	 * 
+	 * Called by toggleDash with the randomize option and by clicking the materialize button
+	 * when it reads "Please select..."
+	 */
+
+	showRandomCreature() {
+		let game = this.game;
+		// Figure out what the active player can summon
+		const activePlayer = game.players[this.game.activeCreature.player.id];
+		const deadOrSummonedTypes = activePlayer.creatures.map(creature => creature.type);
+		const availableTypes = activePlayer.availableCreatures.filter(
+			el => !deadOrSummonedTypes.includes(el),
+		);
+		// Randomize array to grab a random creature
+		for (let i = availableTypes.length - 1; i > 0; i--) {
+			let j = Math.floor(Math.random() * (i + 1));
+			let temp = availableTypes[i];
+			availableTypes[i] = availableTypes[j];
+			availableTypes[j] = temp;
+		}
+		// Grab the first creature we can afford (if none, default to priest)
+		let typeToPass = '--';
+		availableTypes.some(creature => {
+			const lvl = creature.substring(1, 2) - 0;
+			const size = game.retrieveCreatureStats(creature).size - 0;
+			const plasmaCost = lvl + size;
+			return plasmaCost <= activePlayer.plasma ? ((typeToPass = creature), true) : false;
+		});
+		// Show the random unit selected
+		this.showCreature(typeToPass, game.activeCreature.team, '');
 	}
 
 	selectAbility(i) {
@@ -1389,27 +1397,8 @@ export class UI {
 			}
 
 			if (randomize && this.lastViewedCreature == '') {
-				const activePlayer = game.players[game.activeCreature.player.id];
-				const deadOrSummonedTypes = activePlayer.creatures.map(creature => creature.type);
-				const availableTypes = activePlayer.availableCreatures.filter(
-					el => !deadOrSummonedTypes.includes(el),
-				);
-				// Optional: randomize array to grab a new creature every toggle
-				for (let i = availableTypes.length - 1; i > 0; i--) {
-					let j = Math.floor(Math.random() * (i + 1));
-					let temp = availableTypes[i];
-					availableTypes[i] = availableTypes[j];
-					availableTypes[j] = temp;
-				}
-				// Grab the first creature we can afford (if none, default to priest)
-				let typeToPass = '--';
-				availableTypes.some(creature => {
-					const lvl = creature.substring(1, 2) - 0;
-					const size = game.retrieveCreatureStats(creature).size - 0;
-					const plasmaCost = lvl + size;
-					return plasmaCost <= activePlayer.plasma ? ((typeToPass = creature), true) : false;
-				});
-				this.showCreature(typeToPass, game.activeCreature.team, '');
+				// Optional: select a random creature from the grid
+				this.showRandomCreature();
 			} else if (this.lastViewedCreature !== '') {
 				this.showCreature(this.lastViewedCreature, game.activeCreature.team, '');
 			} else {

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -61,52 +61,6 @@ export class UI {
 		this.buttons = [];
 		this.abilitiesButtons = [];
 
-		// TODO: REMOVE UNIT TESTS BEFORE COMMITTING
-		// Unit Tests Button
-		this.btnRunUnitTests = new Button(
-			{
-				$button: $j('#tests.button'),
-				click: () => {
-					this.game.log('Clicked Unit Tests button');
-					if (this.game.Phaser.input.keyboard.isDown(Phaser.Keyboard.ZERO)) {
-						this.game.runUnitTests(0);
-					}
-					else if (this.game.Phaser.input.keyboard.isDown(Phaser.Keyboard.ONE)) {
-						this.game.runUnitTests(1);
-					}
-					else if (this.game.Phaser.input.keyboard.isDown(Phaser.Keyboard.TWO)) {
-						this.game.runUnitTests(2);
-					}
-					else if (this.game.Phaser.input.keyboard.isDown(Phaser.Keyboard.THREE)) {
-						this.game.runUnitTests(3);
-					}
-					else if (this.game.Phaser.input.keyboard.isDown(Phaser.Keyboard.FOUR)) {
-						this.game.runUnitTests(4);
-					}
-					else if (this.game.Phaser.input.keyboard.isDown(Phaser.Keyboard.FIVE)) {
-						this.game.runUnitTests(5);
-					}
-					else if (this.game.Phaser.input.keyboard.isDown(Phaser.Keyboard.SIX)) {
-						this.game.runUnitTests(6);
-					}
-					else if (this.game.Phaser.input.keyboard.isDown(Phaser.Keyboard.SEVEN)) {
-						this.game.runUnitTests(7);
-					}
-					else if (this.game.Phaser.input.keyboard.isDown(Phaser.Keyboard.EIGHT)) {
-						this.game.runUnitTests(8);
-					}
-					else if (this.game.Phaser.input.keyboard.isDown(Phaser.Keyboard.NINE)) {
-						this.game.runUnitTests(9);
-					}
-					else if (this.game.Phaser.input.keyboard.isDown(Phaser.Keyboard.ALT)) {
-						this.game.runUnitTests(10);
-					}
-				}
-			},
-			game,
-		);
-		this.buttons.push(this.btnRunUnitTests);
-
 		// Dash Button
 		this.btnToggleDash = new Button(
 			{
@@ -1041,9 +995,6 @@ export class UI {
 								this.selectAbility(3);
 								this.closeDash();
 								activeCreature.abilities[3].materialize(typeToPass);
-								// For testing purposes, so we can catch the selectedCreature later
-								// TODO: DELETE BELOW LINE
-								this.selectedCreature = typeToPass;
 							}
 						};
 						$j('#card .sideA').on('click', this.materializeButton.click);


### PR DESCRIPTION
Added functionality to the materialize button when it reads "Please select an available unit from the left grid." The materialize button will now materialize a random available unit when the button displays this text. The materialize button will also now display "Not enough plasma." when the card shown in the grid is the Dark Priest and the player does not have enough plasma to summon any available unit. This should also fix the bug discussed in the comments of #1573 where this button would allow the player to materialize another Dark Priest. This was due to the materialize button having its click method be bound when we show any other unit's card and the click method not being reset in the case of showing the Dark Priest, so the materialize button could still summon the chosen creature. Now that we've overwritten the click method in this case, this bug shouldn't be present anymore.


<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1608"><img src="https://gitpod.io/api/apps/github/pbs/github.com/CameronFoss/AncientBeast.git/90f31a888280dc8c1c937166a1218fe875edafab.svg" /></a>

