### PR TITLE
don't display tooltips offscreen #1508

### DIFF
--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -287,7 +287,7 @@
 	position: fixed;
 	top: 0;
 	width: 100%;
-	z-index: 2;
+	z-index: 3;
 }
 
 #bottompanel {

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -1706,12 +1706,13 @@ export class UI {
 							if (this.selectedAbility == -1) {
 								this.showAbilityCosts(btn.abilityId);
 							}
-							(function(){ // Ensure tooltip stays in window - adjust top
+							(function(){ // Ensure tooltip stays in window - adjust
 								var rect = $desc[0].getBoundingClientRect();
 								const margin = 20;
 								if(rect.bottom > (window.innerHeight - margin)) {
-									let value = (window.innerHeight - rect.bottom - margin) + "px";
-									$desc[0].style.top = value;
+									let value = (window.innerHeight - rect.bottom - margin);
+									$desc[0].style.top = value + "px";
+									$desc.find(".arrow")[0].style.top = 27 - value + "px"; //27 is the offset in CSS, -value keeps the position of the arrow
 								}
 							})();
 						};
@@ -1720,8 +1721,9 @@ export class UI {
 							if (this.selectedAbility == -1) {
 								this.hideAbilityCosts();
 							}
-							(function() { // Ensure tooltip stays in window - reset top after
+							(function() { // Ensure tooltip stays in window - reset
 								$desc[0].style.top = "0px";
+								$desc.find(".arrow")[0].style.top = "27px";
 							})();
 						};
 

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -1706,12 +1706,12 @@ export class UI {
 							if (this.selectedAbility == -1) {
 								this.showAbilityCosts(btn.abilityId);
 							}
-							(function(){//ensure tooltip stays in window - adjust top
+							(function(){ // Ensure tooltip stays in window - adjust top
 								var rect = $desc[0].getBoundingClientRect();
-								const margin=20;
-								if(rect.bottom > (window.innerHeight-margin)){
-									let value=(window.innerHeight-rect.bottom-margin)+"px";
-									$desc[0].style.top=value;
+								const margin = 20;
+								if(rect.bottom > (window.innerHeight - margin)) {
+									let value = (window.innerHeight - rect.bottom - margin) + "px";
+									$desc[0].style.top = value;
 								}
 							})();
 						};
@@ -1720,8 +1720,8 @@ export class UI {
 							if (this.selectedAbility == -1) {
 								this.hideAbilityCosts();
 							}
-							(function(){//ensure tooltip stays in window - reset top after
-								$desc[0].style.top="0px";
+							(function() { // Ensure tooltip stays in window - reset top after
+								$desc[0].style.top = "0px";
 							})();
 						};
 

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -1665,7 +1665,7 @@ export class UI {
 						let $desc = btn.$button.next('.desc');
 						$desc.find('span.title').text(ab.title);
 						$desc.find('p').html(ab.desc);
-
+						
 						btn.click = () => {
 							if (this.selectedAbility != btn.abilityId) {
 								if (this.dashopen) {
@@ -1706,12 +1706,23 @@ export class UI {
 							if (this.selectedAbility == -1) {
 								this.showAbilityCosts(btn.abilityId);
 							}
+							(function(){//ensure tooltip stays in window - adjust top
+								var rect = $desc[0].getBoundingClientRect();
+								const margin=20;
+								if(rect.bottom > (window.innerHeight-margin)){
+									let value=(window.innerHeight-rect.bottom-margin)+"px";
+									$desc[0].style.top=value;
+								}
+							})();
 						};
 
 						btn.mouseleave = () => {
 							if (this.selectedAbility == -1) {
 								this.hideAbilityCosts();
 							}
+							(function(){//ensure tooltip stays in window - reset top after
+								$desc[0].style.top="0px";
+							})();
 						};
 
 						btn.changeState(); // Apply changes

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -1712,7 +1712,7 @@ export class UI {
 								if(rect.bottom > (window.innerHeight - margin)) {
 									let value = (window.innerHeight - rect.bottom - margin);
 									$desc[0].style.top = value + "px";
-									$desc.find(".arrow")[0].style.top = 27 - value + "px"; //27 is the offset in CSS, -value keeps the position of the arrow
+									$desc.find(".arrow")[0].style.top = 27 - value + "px"; // Keep arrow position
 								}
 							})();
 						};


### PR DESCRIPTION
> On mobile devices (where the screen is small), the in-game tooltips for the side icon should be displayed in the UI gap closest to the respective upper right corners to ensure that their visible.

Addressed by stopping them from going below the window height.

<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1609"><img src="https://gitpod.io/api/apps/github/pbs/github.com/oddthread/AncientBeast.git/6a747ee0730401c817f513925b88578a69e47891.svg" /></a>

