### PR TITLE
fixes issue #1610

### DIFF
--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -68,6 +68,8 @@ export class UI {
 				click: () => {
 					// if dash is open and audio player is visible, just show creatures
 					if (this.dashopen && $j('#musicplayerwrapper').is(':visible')) {
+						$j('#playertabswrapper').show();
+						$j('#playertabswrapper .playertabs .infos').hide();
 						$j('#musicplayerwrapper').hide();
 					}
 
@@ -735,10 +737,12 @@ export class UI {
 		// Set dash active
 		this.$dash.addClass('active');
 		this.$dash.children('#tooltip').removeClass('active');
+		this.$dash.children('#playertabswrapper').addClass('active');
 		this.changePlayerTab(game.activeCreature.team);
 		this.resizeDash();
 
 		this.$dash
+			.children('#playertabswrapper')
 			.children('.playertabs')
 			.unbind('click')
 			.bind('click', e => {
@@ -1062,6 +1066,8 @@ export class UI {
 			.addClass('locked');
 
 		$j('#tabwrapper').show();
+		$j('#playertabswrapper').show();
+		$j('#playertabswrapper .playertabs .infos').hide();
 		$j('#musicplayerwrapper').hide();
 
 		// Change creature status

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -735,12 +735,10 @@ export class UI {
 		// Set dash active
 		this.$dash.addClass('active');
 		this.$dash.children('#tooltip').removeClass('active');
-		this.$dash.children('#playertabswrapper').addClass('active');
 		this.changePlayerTab(game.activeCreature.team);
 		this.resizeDash();
 
 		this.$dash
-			.children('#playertabswrapper')
 			.children('.playertabs')
 			.unbind('click')
 			.bind('click', e => {

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -69,7 +69,6 @@ export class UI {
 					// if dash is open and audio player is visible, just show creatures
 					if (this.dashopen && $j('#musicplayerwrapper').is(':visible')) {
 						$j('#playertabswrapper').show();
-						$j('#playertabswrapper .playertabs .infos').hide();
 						$j('#musicplayerwrapper').hide();
 					}
 
@@ -1067,7 +1066,6 @@ export class UI {
 
 		$j('#tabwrapper').show();
 		$j('#playertabswrapper').show();
-		$j('#playertabswrapper .playertabs .infos').hide();
 		$j('#musicplayerwrapper').hide();
 
 		// Change creature status


### PR DESCRIPTION
fixes issue #1610
dashboard in mobile view with player info overlapping the close button.
player info has been removed from the dashboard active view

<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1611"><img src="https://gitpod.io/api/apps/github/pbs/github.com/classicmatsuo/AncientBeast.git/a5dccd728f4bf4a63536fdecbcf809346c7881d6.svg" /></a>



<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1611"><img src="https://gitpod.io/api/apps/github/pbs/github.com/classicmatsuo/AncientBeast.git/20ed3e20ea69e72ac007d6f1bed9be80d5b54ced.svg" /></a>

