### PR TITLE
Round all corners of card background on hover

### DIFF
--- a/src/style/cards.less
+++ b/src/style/cards.less
@@ -232,13 +232,13 @@
 #dash .stats:hover .stat {
 	border-top-left-radius: 10px;
 	border-top-right-radius: 10px;
-	border-bottom-left-radius: 0;
-	border-bottom-right-radius: 0;
+	border-bottom-left-radius: 10px;
+	border-bottom-right-radius: 10px;
 }
 
 #dash .masteries:hover .stat {
-	border-top-left-radius: 0;
-	border-top-right-radius: 0;
+	border-top-left-radius: 10px;
+	border-top-right-radius: 10px;
 	border-bottom-left-radius: 10px;
 	border-bottom-right-radius: 10px;
 }


### PR DESCRIPTION
Make all border radius corners of stats/masteries card backgrounds
on hover 10px.

Resolves: [#1620](https://github.com/FreezingMoon/AncientBeast/issues/1620)

If your pull request tries to address a specific issue from the repository, please reference to it.
Don't forget to include a description of the changes proposes. https://discord.me/AncientBeast


<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1622"><img src="https://gitpod.io/api/apps/github/pbs/github.com/raynathanlow/AncientBeast.git/989066004ebfcdb0e166437622c848a889fe4dd3.svg" /></a>

