### PR TITLE
Fix linting by removing useless rules and packages

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,8 +3,7 @@
 	"extends": ["prettier", "plugin:prettier/recommended"],
 	"rules": {
 		"prettier/prettier": "error",
-		"no-undef": "error",
-		"array-element-newline": "consistent"
+		"no-undef": "error"
 	},
 	"parserOptions": {
 		"ecmaVersion": 2017,

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,12 +59,6 @@
 				"any-observable": "^0.3.0"
 			}
 		},
-		"@types/eslint-visitor-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
-			"dev": true
-		},
 		"@types/events": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -81,12 +75,6 @@
 				"@types/minimatch": "*",
 				"@types/node": "*"
 			}
-		},
-		"@types/json-schema": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
-			"integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
-			"dev": true
 		},
 		"@types/minimatch": {
 			"version": "3.0.3",
@@ -105,47 +93,6 @@
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
 			"dev": true
-		},
-		"@typescript-eslint/experimental-utils": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
-			"integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
-			"dev": true,
-			"requires": {
-				"@types/json-schema": "^7.0.3",
-				"@typescript-eslint/typescript-estree": "1.13.0",
-				"eslint-scope": "^4.0.0"
-			}
-		},
-		"@typescript-eslint/parser": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.13.0.tgz",
-			"integrity": "sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==",
-			"dev": true,
-			"requires": {
-				"@types/eslint-visitor-keys": "^1.0.0",
-				"@typescript-eslint/experimental-utils": "1.13.0",
-				"@typescript-eslint/typescript-estree": "1.13.0",
-				"eslint-visitor-keys": "^1.0.0"
-			}
-		},
-		"@typescript-eslint/typescript-estree": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
-			"integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
-			"dev": true,
-			"requires": {
-				"lodash.unescape": "4.0.1",
-				"semver": "5.5.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-					"dev": true
-				}
-			}
 		},
 		"@webassemblyjs/ast": {
 			"version": "1.8.5",
@@ -478,12 +425,6 @@
 			"resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
 			"integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
 		},
-		"arrify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-			"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-			"dev": true
-		},
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -749,12 +690,6 @@
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
 			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
 		},
-		"boolify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/boolify/-/boolify-1.0.1.tgz",
-			"integrity": "sha1-tcCeF8rNET0Rt7s+04TMASmU2Gs=",
-			"dev": true
-		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -987,17 +922,6 @@
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 			"dev": true
-		},
-		"camelcase-keys": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.1.0.tgz",
-			"integrity": "sha512-43tBGDIs3SBDA5R5mYzkiBP3lt2IKhLDp1wVGS9XTq6SR3+7ZNdi/VwBJsk4NKgySoaziTrKM+N8hhT04NBVUA==",
-			"dev": true,
-			"requires": {
-				"camelcase": "^5.3.1",
-				"map-obj": "^4.0.0",
-				"quick-lru": "^4.0.1"
-			}
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -1258,12 +1182,6 @@
 			"version": "2.17.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
 			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
-		},
-		"common-tags": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-			"integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
-			"dev": true
 		},
 		"commondir": {
 			"version": "1.0.1",
@@ -1809,12 +1727,6 @@
 			"requires": {
 				"path-type": "^3.0.0"
 			}
-		},
-		"dlv": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-			"integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-			"dev": true
 		},
 		"doctrine": {
 			"version": "3.0.0",
@@ -4959,24 +4871,6 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
 			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 		},
-		"lodash.memoize": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-			"dev": true
-		},
-		"lodash.merge": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true
-		},
-		"lodash.unescape": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
-			"integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
-			"dev": true
-		},
 		"log-symbols": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
@@ -5010,49 +4904,6 @@
 				"wrap-ansi": "^3.0.1"
 			}
 		},
-		"loglevel": {
-			"version": "1.6.4",
-			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.4.tgz",
-			"integrity": "sha512-p0b6mOGKcGa+7nnmKbpzR6qloPbrgLcnio++E+14Vo/XffOGwZtRpUhr8dTH/x2oCMmEoIU0Zwm3ZauhvYD17g==",
-			"dev": true
-		},
-		"loglevel-colored-level-prefix": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0.tgz",
-			"integrity": "sha1-akAhj9x64V/HbD0PPmdsRlOIYD4=",
-			"dev": true,
-			"requires": {
-				"chalk": "^1.1.3",
-				"loglevel": "^1.4.1"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
-				}
-			}
-		},
 		"lower-case": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
@@ -5075,15 +4926,6 @@
 				"semver": "^5.6.0"
 			}
 		},
-		"make-plural": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
-			"integrity": "sha512-xTYd4JVHpSCW+aqDof6w/MebaMVNTVYBZhbB/vi513xXdiPT92JMVCo0Jq8W2UZnzYRFeVbQiQ+I25l13JuKvA==",
-			"dev": true,
-			"requires": {
-				"minimist": "^1.2.0"
-			}
-		},
 		"mamacro": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
@@ -5102,12 +4944,6 @@
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
 			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
-		},
-		"map-obj": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
-			"integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
-			"dev": true
 		},
 		"map-visit": {
 			"version": "1.0.0",
@@ -5175,29 +5011,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
 			"integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
-			"dev": true
-		},
-		"messageformat": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/messageformat/-/messageformat-2.3.0.tgz",
-			"integrity": "sha512-uTzvsv0lTeQxYI2y1NPa1lItL5VRI8Gb93Y2K2ue5gBPyrbJxfDi/EYWxh2PKv5yO42AJeeqblS9MJSh/IEk4w==",
-			"dev": true,
-			"requires": {
-				"make-plural": "^4.3.0",
-				"messageformat-formatters": "^2.0.1",
-				"messageformat-parser": "^4.1.2"
-			}
-		},
-		"messageformat-formatters": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/messageformat-formatters/-/messageformat-formatters-2.0.1.tgz",
-			"integrity": "sha512-E/lQRXhtHwGuiQjI7qxkLp8AHbMD5r2217XNe/SREbBlSawe0lOqsFb7rflZJmlQFSULNLIqlcjjsCPlB3m3Mg==",
-			"dev": true
-		},
-		"messageformat-parser": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.2.tgz",
-			"integrity": "sha512-7dWuifeyldz7vhEuL96Kwq1fhZXBW+TUfbnHN4UCrCxoXQTYjHnR78eI66Gk9LaLLsAvzPNVJBaa66DRfFNaiA==",
 			"dev": true
 		},
 		"methods": {
@@ -5356,12 +5169,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-		},
-		"mute-stream": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-			"dev": true
 		},
 		"nan": {
 			"version": "2.14.0",
@@ -5793,12 +5600,6 @@
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
-		"path-is-inside": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-			"dev": true
-		},
 		"path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
@@ -6002,484 +5803,6 @@
 			"integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
 			"dev": true
 		},
-		"prettier-eslint": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-9.0.0.tgz",
-			"integrity": "sha512-0dael2aMpMAxAwClnLi2Coc30v3BubsTX6clqseZ8NFCJZnbZlwxZGHHESYBlqTyN9lvZDHHv+XdeHW0fKhxJQ==",
-			"dev": true,
-			"requires": {
-				"@typescript-eslint/parser": "^1.10.2",
-				"common-tags": "^1.4.0",
-				"core-js": "^3.1.4",
-				"dlv": "^1.1.0",
-				"eslint": "^5.0.0",
-				"indent-string": "^4.0.0",
-				"lodash.merge": "^4.6.0",
-				"loglevel-colored-level-prefix": "^1.0.0",
-				"prettier": "^1.7.0",
-				"pretty-format": "^23.0.1",
-				"require-relative": "^0.8.7",
-				"typescript": "^3.2.1",
-				"vue-eslint-parser": "^2.0.2"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"chardet": {
-					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-					"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-					"dev": true
-				},
-				"core-js": {
-					"version": "3.3.5",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.5.tgz",
-					"integrity": "sha512-0J3K+Par/ZydhKg8pEiTcK/9d65/nqJOzY62uMkjeBmt05fDOt/khUVjDdh8TpeIuGQDy1yLDDCjiWN/8pFIuw==",
-					"dev": true
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"eslint": {
-					"version": "5.16.0",
-					"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
-					"integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"ajv": "^6.9.1",
-						"chalk": "^2.1.0",
-						"cross-spawn": "^6.0.5",
-						"debug": "^4.0.1",
-						"doctrine": "^3.0.0",
-						"eslint-scope": "^4.0.3",
-						"eslint-utils": "^1.3.1",
-						"eslint-visitor-keys": "^1.0.0",
-						"espree": "^5.0.1",
-						"esquery": "^1.0.1",
-						"esutils": "^2.0.2",
-						"file-entry-cache": "^5.0.1",
-						"functional-red-black-tree": "^1.0.1",
-						"glob": "^7.1.2",
-						"globals": "^11.7.0",
-						"ignore": "^4.0.6",
-						"import-fresh": "^3.0.0",
-						"imurmurhash": "^0.1.4",
-						"inquirer": "^6.2.2",
-						"js-yaml": "^3.13.0",
-						"json-stable-stringify-without-jsonify": "^1.0.1",
-						"levn": "^0.3.0",
-						"lodash": "^4.17.11",
-						"minimatch": "^3.0.4",
-						"mkdirp": "^0.5.1",
-						"natural-compare": "^1.4.0",
-						"optionator": "^0.8.2",
-						"path-is-inside": "^1.0.2",
-						"progress": "^2.0.0",
-						"regexpp": "^2.0.1",
-						"semver": "^5.5.1",
-						"strip-ansi": "^4.0.0",
-						"strip-json-comments": "^2.0.1",
-						"table": "^5.2.3",
-						"text-table": "^0.2.0"
-					}
-				},
-				"espree": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
-					"integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
-					"dev": true,
-					"requires": {
-						"acorn": "^6.0.7",
-						"acorn-jsx": "^5.0.0",
-						"eslint-visitor-keys": "^1.0.0"
-					}
-				},
-				"external-editor": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-					"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-					"dev": true,
-					"requires": {
-						"chardet": "^0.7.0",
-						"iconv-lite": "^0.4.24",
-						"tmp": "^0.0.33"
-					}
-				},
-				"iconv-lite": {
-					"version": "0.4.24",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-					"dev": true,
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				},
-				"ignore": {
-					"version": "4.0.6",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-					"dev": true
-				},
-				"import-fresh": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
-					"integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
-					"dev": true,
-					"requires": {
-						"parent-module": "^1.0.0",
-						"resolve-from": "^4.0.0"
-					}
-				},
-				"inquirer": {
-					"version": "6.5.2",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
-					"integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
-					"dev": true,
-					"requires": {
-						"ansi-escapes": "^3.2.0",
-						"chalk": "^2.4.2",
-						"cli-cursor": "^2.1.0",
-						"cli-width": "^2.0.0",
-						"external-editor": "^3.0.3",
-						"figures": "^2.0.0",
-						"lodash": "^4.17.12",
-						"mute-stream": "0.0.7",
-						"run-async": "^2.2.0",
-						"rxjs": "^6.4.0",
-						"string-width": "^2.1.0",
-						"strip-ansi": "^5.1.0",
-						"through": "^2.3.6"
-					},
-					"dependencies": {
-						"chalk": {
-							"version": "2.4.2",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^3.2.1",
-								"escape-string-regexp": "^1.0.5",
-								"supports-color": "^5.3.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^4.1.0"
-							}
-						}
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-							"dev": true
-						}
-					}
-				},
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-					"dev": true
-				}
-			}
-		},
-		"prettier-eslint-cli": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/prettier-eslint-cli/-/prettier-eslint-cli-5.0.0.tgz",
-			"integrity": "sha512-cei9UbN1aTrz3sQs88CWpvY/10PYTevzd76zoG1tdJ164OhmNTFRKPTOZrutVvscoQWzbnLKkviS3gu5JXwvZg==",
-			"dev": true,
-			"requires": {
-				"arrify": "^2.0.1",
-				"boolify": "^1.0.0",
-				"camelcase-keys": "^6.0.0",
-				"chalk": "^2.4.2",
-				"common-tags": "^1.8.0",
-				"core-js": "^3.1.4",
-				"eslint": "^5.0.0",
-				"find-up": "^4.1.0",
-				"get-stdin": "^7.0.0",
-				"glob": "^7.1.4",
-				"ignore": "^5.1.2",
-				"lodash.memoize": "^4.1.2",
-				"loglevel-colored-level-prefix": "^1.0.0",
-				"messageformat": "^2.2.1",
-				"prettier-eslint": "^9.0.0",
-				"rxjs": "^6.5.2",
-				"yargs": "^13.2.4"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"chardet": {
-					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-					"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-					"dev": true
-				},
-				"core-js": {
-					"version": "3.3.5",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.5.tgz",
-					"integrity": "sha512-0J3K+Par/ZydhKg8pEiTcK/9d65/nqJOzY62uMkjeBmt05fDOt/khUVjDdh8TpeIuGQDy1yLDDCjiWN/8pFIuw==",
-					"dev": true
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"eslint": {
-					"version": "5.16.0",
-					"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
-					"integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"ajv": "^6.9.1",
-						"chalk": "^2.1.0",
-						"cross-spawn": "^6.0.5",
-						"debug": "^4.0.1",
-						"doctrine": "^3.0.0",
-						"eslint-scope": "^4.0.3",
-						"eslint-utils": "^1.3.1",
-						"eslint-visitor-keys": "^1.0.0",
-						"espree": "^5.0.1",
-						"esquery": "^1.0.1",
-						"esutils": "^2.0.2",
-						"file-entry-cache": "^5.0.1",
-						"functional-red-black-tree": "^1.0.1",
-						"glob": "^7.1.2",
-						"globals": "^11.7.0",
-						"ignore": "^4.0.6",
-						"import-fresh": "^3.0.0",
-						"imurmurhash": "^0.1.4",
-						"inquirer": "^6.2.2",
-						"js-yaml": "^3.13.0",
-						"json-stable-stringify-without-jsonify": "^1.0.1",
-						"levn": "^0.3.0",
-						"lodash": "^4.17.11",
-						"minimatch": "^3.0.4",
-						"mkdirp": "^0.5.1",
-						"natural-compare": "^1.4.0",
-						"optionator": "^0.8.2",
-						"path-is-inside": "^1.0.2",
-						"progress": "^2.0.0",
-						"regexpp": "^2.0.1",
-						"semver": "^5.5.1",
-						"strip-ansi": "^4.0.0",
-						"strip-json-comments": "^2.0.1",
-						"table": "^5.2.3",
-						"text-table": "^0.2.0"
-					},
-					"dependencies": {
-						"ignore": {
-							"version": "4.0.6",
-							"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-							"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-							"dev": true
-						}
-					}
-				},
-				"espree": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
-					"integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
-					"dev": true,
-					"requires": {
-						"acorn": "^6.0.7",
-						"acorn-jsx": "^5.0.0",
-						"eslint-visitor-keys": "^1.0.0"
-					}
-				},
-				"external-editor": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-					"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-					"dev": true,
-					"requires": {
-						"chardet": "^0.7.0",
-						"iconv-lite": "^0.4.24",
-						"tmp": "^0.0.33"
-					}
-				},
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"get-stdin": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
-					"integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
-					"dev": true
-				},
-				"iconv-lite": {
-					"version": "0.4.24",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-					"dev": true,
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				},
-				"ignore": {
-					"version": "5.1.4",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-					"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
-					"dev": true
-				},
-				"import-fresh": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
-					"integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
-					"dev": true,
-					"requires": {
-						"parent-module": "^1.0.0",
-						"resolve-from": "^4.0.0"
-					}
-				},
-				"inquirer": {
-					"version": "6.5.2",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
-					"integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
-					"dev": true,
-					"requires": {
-						"ansi-escapes": "^3.2.0",
-						"chalk": "^2.4.2",
-						"cli-cursor": "^2.1.0",
-						"cli-width": "^2.0.0",
-						"external-editor": "^3.0.3",
-						"figures": "^2.0.0",
-						"lodash": "^4.17.12",
-						"mute-stream": "0.0.7",
-						"run-async": "^2.2.0",
-						"rxjs": "^6.4.0",
-						"string-width": "^2.1.0",
-						"strip-ansi": "^5.1.0",
-						"through": "^2.3.6"
-					},
-					"dependencies": {
-						"strip-ansi": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^4.1.0"
-							}
-						}
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-							"dev": true
-						}
-					}
-				},
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-					"dev": true
-				}
-			}
-		},
 		"prettier-linter-helpers": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
@@ -6496,24 +5819,6 @@
 			"requires": {
 				"renderkid": "^2.0.1",
 				"utila": "~0.4"
-			}
-		},
-		"pretty-format": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
-			"integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
-			"dev": true,
-			"requires": {
-				"ansi-regex": "^3.0.0",
-				"ansi-styles": "^3.2.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				}
 			}
 		},
 		"process": {
@@ -6632,12 +5937,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
 			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
-		},
-		"quick-lru": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-			"integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
-			"dev": true
 		},
 		"randombytes": {
 			"version": "2.1.0",
@@ -6829,12 +6128,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
 			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-			"dev": true
-		},
-		"require-relative": {
-			"version": "0.8.7",
-			"resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
-			"integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
 			"dev": true
 		},
 		"resolve": {
@@ -7927,12 +7220,6 @@
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 		},
-		"typescript": {
-			"version": "3.6.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-			"integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
-			"dev": true
-		},
 		"uglify-js": {
 			"version": "3.4.10",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.10.tgz",
@@ -8206,80 +7493,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
 			"integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw=="
-		},
-		"vue-eslint-parser": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz",
-			"integrity": "sha512-ZezcU71Owm84xVF6gfurBQUGg8WQ+WZGxgDEQu1IHFBZNx7BFZg3L1yHxrCBNNwbwFtE1GuvfJKMtb6Xuwc/Bw==",
-			"dev": true,
-			"requires": {
-				"debug": "^3.1.0",
-				"eslint-scope": "^3.7.1",
-				"eslint-visitor-keys": "^1.0.0",
-				"espree": "^3.5.2",
-				"esquery": "^1.0.0",
-				"lodash": "^4.17.4"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "5.7.3",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
-					"dev": true
-				},
-				"acorn-jsx": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-					"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-					"dev": true,
-					"requires": {
-						"acorn": "^3.0.4"
-					},
-					"dependencies": {
-						"acorn": {
-							"version": "3.3.0",
-							"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-							"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-							"dev": true
-						}
-					}
-				},
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"eslint-scope": {
-					"version": "3.7.3",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
-					"integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
-					"dev": true,
-					"requires": {
-						"esrecurse": "^4.1.0",
-						"estraverse": "^4.1.1"
-					}
-				},
-				"espree": {
-					"version": "3.5.4",
-					"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-					"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
-					"dev": true,
-					"requires": {
-						"acorn": "^5.5.0",
-						"acorn-jsx": "^3.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
-			}
 		},
 		"watchpack": {
 			"version": "1.6.0",
@@ -8579,58 +7792,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-		},
-		"yargs": {
-			"version": "13.3.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-			"integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
-			"dev": true,
-			"requires": {
-				"cliui": "^5.0.0",
-				"find-up": "^3.0.0",
-				"get-caller-file": "^2.0.1",
-				"require-directory": "^2.1.1",
-				"require-main-filename": "^2.0.0",
-				"set-blocking": "^2.0.0",
-				"string-width": "^3.0.0",
-				"which-module": "^2.0.0",
-				"y18n": "^4.0.0",
-				"yargs-parser": "^13.1.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"emoji-regex": {
-					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				}
-			}
 		},
 		"yargs-parser": {
 			"version": "13.1.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
 		"less-loader": "^5.0.0",
 		"lint-staged": "^9.4.2",
 		"prettier": "^1.18.2",
-		"prettier-eslint-cli": "^5.0.0",
 		"style-loader": "^1.0.0",
 		"uglifyjs-webpack-plugin": "^2.2.0",
 		"webpack-cli": "^3.3.9",
@@ -66,7 +65,6 @@
 		"assetLister": "node ./assetLister.js",
 		"lint": "eslint src/*.js src/**/*.js",
 		"lint-fix": "eslint --fix src/*.js src/**/*.js",
-		"format": "prettier-eslint --write \"src/**/*.js\"",
 		"eslint-check": "eslint --print-config .eslintrc.json | eslint-config-prettier-check",
 		"test": "npm run lint && npm run build"
 	},

--- a/src/abilities/Abolished.js
+++ b/src/abilities/Abolished.js
@@ -20,7 +20,7 @@ export default G => {
 				if (damage === undefined) {
 					damage = {
 						// NOTE : This code produce array with doubles.
-						type: 'target'
+						type: 'target',
 					}; // For the test function to work
 				}
 				return true;
@@ -38,11 +38,11 @@ export default G => {
 						'', // Trigger
 						{
 							alterations: {
-								burn: -1
-							}
+								burn: -1,
+							},
 						}, // Optional arguments
-						G
-					)
+						G,
+					),
 				);
 				target.stats.burn -= 1;
 				if (this.isUpgraded()) {
@@ -54,14 +54,14 @@ export default G => {
 							'', // Trigger
 							{
 								alterations: {
-									burn: 1
-								}
+									burn: 1,
+								},
 							}, // Optional arguments
-							G
-						)
+							G,
+						),
 					);
 				}
-			}
+			},
 		},
 		// Fiery touch
 		{
@@ -78,7 +78,7 @@ export default G => {
 					!this.testDirection({
 						team: this._targetTeam,
 						distance: this.distance,
-						sourceCreature: this.creature
+						sourceCreature: this.creature,
 					})
 				) {
 					return false;
@@ -104,7 +104,7 @@ export default G => {
 					x: crea.x,
 					y: crea.y,
 					distance: this.distance,
-					sourceCreature: crea
+					sourceCreature: crea,
 				});
 			},
 			activate(path, args) {
@@ -119,7 +119,7 @@ export default G => {
 					path,
 					args,
 					200,
-					-20
+					-20,
 				);
 				let tween = projectileInstance[0];
 				let sprite = projectileInstance[1];
@@ -130,13 +130,13 @@ export default G => {
 						ability.damages, // Damage Type
 						1, // Area
 						[], // Effects
-						G
+						G,
 					);
 					target.takeDamage(damage);
 
 					this.destroy();
 				}, sprite); // End tween.onComplete
-			}
+			},
 		},
 		// Wild Fire
 		{
@@ -163,7 +163,7 @@ export default G => {
 						}
 						delete arguments[1];
 						ability.animation(...arguments);
-					}
+					},
 				});
 			},
 			activate(hex) {
@@ -189,7 +189,7 @@ export default G => {
 						creature = creatureOrHex.creature;
 					}
 					creature.takeDamage(new Damage(effect.attacker, ability.damages, 1, [], G), {
-						isFromTrap: true
+						isFromTrap: true,
 					});
 					this.trap.destroy();
 					effect.deleteEffect();
@@ -218,17 +218,17 @@ export default G => {
 								{
 									requireFn: requireFn,
 									effectFn: effectFn,
-									attacker: crea
+									attacker: crea,
 								},
-								G
-							)
+								G,
+							),
 						],
 						crea.player,
 						{
 							turnLifetime: 1,
 							ownerCreature: crea,
-							fullTurnLifetime: true
-						}
+							fullTurnLifetime: true,
+						},
 					);
 				});
 
@@ -238,9 +238,9 @@ export default G => {
 					animation: 'teleport',
 					callback: function() {
 						G.activeCreature.queryMove();
-					}
+					},
 				});
-			}
+			},
 		},
 		// Greater Pyre
 		{
@@ -271,7 +271,7 @@ export default G => {
 					},
 					id: this.creature.id,
 					hexes: range,
-					hideNonTarget: true
+					hideNonTarget: true,
 				});
 			},
 			activate() {
@@ -293,11 +293,11 @@ export default G => {
 							ability.damages, // Damage Type
 							1, // Area
 							[], // Effects
-							G
-						)
+							G,
+						),
 					);
 				});
-			}
-		}
+			},
+		},
 	];
 };

--- a/src/abilities/Asher.js
+++ b/src/abilities/Asher.js
@@ -25,7 +25,7 @@ export default G => {
 				}
 				if (damage == undefined) {
 					damage = {
-						type: 'target'
+						type: 'target',
 					};
 				} // For the test function to work
 				//if( this.triggeredThisChain ) return false;
@@ -46,11 +46,11 @@ export default G => {
 					this.creature, // Attacker
 					this.damages, // Damage Type
 					[], // Effects
-					targets
+					targets,
 				);
 
 				return damage;
-			}
+			},
 		},
 
 		// 	Second Ability: Fiery Claw
@@ -70,7 +70,7 @@ export default G => {
 					!this.testDirection({
 						team: this._targetTeam,
 						distance: this.distance,
-						sourceCreature: this.creature
+						sourceCreature: this.creature,
 					})
 				) {
 					return false;
@@ -94,7 +94,7 @@ export default G => {
 					x: crea.x,
 					y: crea.y,
 					distance: this.distance,
-					sourceCreature: crea
+					sourceCreature: crea,
 				});
 			},
 
@@ -110,10 +110,10 @@ export default G => {
 					ability.damages, // Damage Type
 					1, // Area
 					[], // Effects
-					G
+					G,
 				);
 				target.takeDamage(damage);
-			}
+			},
 		},
 
 		// 	Thirt Ability: Burning Eye
@@ -140,7 +140,7 @@ export default G => {
 					callback: function() {
 						delete arguments[1];
 						ability.animation(...arguments);
-					}
+					},
 				});
 			},
 
@@ -161,8 +161,8 @@ export default G => {
 					if (isTeam(ability.creature, trg, item._targetTeam)) {
 						let optArg = {
 							alterations: {
-								burn: -1
-							}
+								burn: -1,
+							},
 						};
 
 						//Roasted effect
@@ -172,7 +172,7 @@ export default G => {
 							trg, //Target
 							'', //Trigger
 							optArg, //Optional arguments
-							G
+							G,
 						);
 						trg.addEffect(effect);
 					}
@@ -198,8 +198,8 @@ export default G => {
 							if (isTeam(ability.creature, trg, item._targetTeam)) {
 								let optArg = {
 									alterations: {
-										burn: -1
-									}
+										burn: -1,
+									},
 								};
 
 								//Roasted effect
@@ -209,17 +209,17 @@ export default G => {
 									trg, //Target
 									'', //Trigger
 									optArg, //Optional arguments
-									G
+									G,
 								);
 								trg.addEffect(
 									effect,
-									'%CreatureName' + trg.id + '% got roasted : -1 burn stat debuff'
+									'%CreatureName' + trg.id + '% got roasted : -1 burn stat debuff',
 								);
 							}
 						});
-					}
+					},
 				});
-			}
+			},
 		},
 
 		// 	Fourth Ability: Fire Ball
@@ -260,19 +260,19 @@ export default G => {
 												crea
 													.adjacentHexes(1)
 													.overlayVisualState(
-														'creature selected weakDmg player' + item2.creature.team
+														'creature selected weakDmg player' + item2.creature.team,
 													);
 												item2.overlayVisualState(
-													'creature selected weakDmg player' + item2.creature.team
+													'creature selected weakDmg player' + item2.creature.team,
 												);
 											} else {
 												item2.overlayVisualState(
-													'creature selected weakDmg player' + item2.creature.team
+													'creature selected weakDmg player' + item2.creature.team,
 												);
 											}
 										} else {
 											item2.overlayVisualState(
-												'creature selected weakDmg player' + G.activeCreature.team
+												'creature selected weakDmg player' + G.activeCreature.team,
 											);
 										}
 									});
@@ -293,7 +293,7 @@ export default G => {
 					},
 					id: this.creature.id,
 					hexes: range,
-					hideNonTarget: true
+					hideNonTarget: true,
 				});
 			},
 
@@ -313,8 +313,8 @@ export default G => {
 							ability.damages1, // Damage Type
 							1, // Area
 							[], // Effects
-							G
-						)
+							G,
+						),
 					);
 				}
 
@@ -322,9 +322,9 @@ export default G => {
 					ability.creature,
 					ability.damages2,
 					[], //Effects
-					targets
+					targets,
 				);
-			}
-		}
+			},
+		},
 	];
 };

--- a/src/abilities/Chimera.js
+++ b/src/abilities/Chimera.js
@@ -30,7 +30,7 @@ export default G => {
 				if (this.creature.stats.meditation > 0) {
 					this.creature.recharge(Math.floor(this.creature.stats.meditation / 2));
 				}
-			}
+			},
 		},
 
 		//	Second Ability: Tooth Fairy
@@ -53,11 +53,11 @@ export default G => {
 							this.creature.y - 2,
 							0,
 							false,
-							matrices.frontnback3hex
+							matrices.frontnback3hex,
 						),
 						{
-							team: this._targetTeam
-						}
+							team: this._targetTeam,
+						},
 					)
 				) {
 					return false;
@@ -78,7 +78,7 @@ export default G => {
 					team: this._targetTeam,
 					id: chimera.id,
 					flipped: chimera.flipped,
-					hexes: G.grid.getHexMap(chimera.x - 3, chimera.y - 2, 0, false, matrices.frontnback3hex)
+					hexes: G.grid.getHexMap(chimera.x - 3, chimera.y - 2, 0, false, matrices.frontnback3hex),
 				});
 			},
 
@@ -93,14 +93,14 @@ export default G => {
 					ability.damages, // Damage Type
 					1, // Area
 					[], // Effects
-					G
+					G,
 				);
 				target.takeDamage(damage);
 				if (this.isUpgraded()) {
 					// Second attack
 					target.takeDamage(damage);
 				}
-			}
+			},
 		},
 
 		//	Third Ability: Disturbing Sound
@@ -119,7 +119,7 @@ export default G => {
 				if (
 					!this.testDirection({
 						team: this._targetTeam,
-						sourceCreature: this.creature
+						sourceCreature: this.creature,
 					})
 				) {
 					return false;
@@ -142,7 +142,7 @@ export default G => {
 					requireCreature: true,
 					x: chimera.x,
 					y: chimera.y,
-					sourceCreature: chimera
+					sourceCreature: chimera,
 				});
 			},
 
@@ -160,7 +160,7 @@ export default G => {
 					ability.damages, // Damage Type
 					1, // Area
 					[], // Effects
-					G
+					G,
 				);
 				let result = target.takeDamage(damage);
 
@@ -184,15 +184,15 @@ export default G => {
 					damage = new Damage(
 						ability.creature, // Attacker
 						{
-							sonic: sonic
+							sonic: sonic,
 						}, // Damage Type
 						1, // Area
 						[], // Effects
-						G
+						G,
 					);
 					result = target.takeDamage(damage);
 				}
-			}
+			},
 		},
 
 		// Fourth Ability: Battering Ram
@@ -214,7 +214,7 @@ export default G => {
 					sourceCreature: this.creature,
 					directions: [1, 1, 1, 1, 1, 1],
 					includeCreature: true,
-					stopOnCreature: true
+					stopOnCreature: true,
 				});
 			},
 
@@ -250,7 +250,7 @@ export default G => {
 					requireCreature: true,
 					x: chimera.x,
 					y: chimera.y,
-					sourceCreature: chimera
+					sourceCreature: chimera,
 				});
 			},
 
@@ -262,11 +262,11 @@ export default G => {
 					let damage = new Damage(
 						ability.creature, // Attacker
 						{
-							crush: _crush
+							crush: _crush,
 						}, // Damage Type
 						1, // Area
 						[], // Effects
-						G
+						G,
 					);
 					let result = _target.takeDamage(damage);
 					// Knock the target back if they are still alive and there is enough range
@@ -320,7 +320,7 @@ export default G => {
 							ignoreMovementPoint: true,
 							ignorePath: true,
 							overrideSpeed: 400, // Custom speed for knockback
-							animation: 'push'
+							animation: 'push',
 						});
 					} else {
 						// No knockback distance, but there may be a creature behind the target
@@ -332,7 +332,7 @@ export default G => {
 				let crush = this.damages.crush;
 				let range = 3;
 				knockback(target, crush, range);
-			}
-		}
+			},
+		},
 	];
 };

--- a/src/abilities/Cyber-Wolf.js
+++ b/src/abilities/Cyber-Wolf.js
@@ -48,13 +48,13 @@ export default G => {
 					this.damages, // Damage Type
 					1, // Area
 					[], // Effects
-					G
+					G,
 				);
 				target.takeDamage(damage);
 
 				// Keep highlighted in UI
 				this.setUsed(false);
-			}
+			},
 		},
 
 		// 	Second Ability: Metal Hand
@@ -72,7 +72,7 @@ export default G => {
 
 				if (
 					!this.atLeastOneTarget(this.creature.getHexMap(matrices.frontnback2hex), {
-						team: this._targetTeam
+						team: this._targetTeam,
 					})
 				) {
 					return false;
@@ -92,7 +92,7 @@ export default G => {
 					team: this._targetTeam,
 					id: crea.id,
 					flipped: crea.player.flipped,
-					hexes: crea.getHexMap(matrices.frontnback2hex)
+					hexes: crea.getHexMap(matrices.frontnback2hex),
 				});
 			},
 
@@ -106,7 +106,7 @@ export default G => {
 					ability.damages, // Damage Type
 					1, // Area
 					[], // Effects
-					G
+					G,
 				);
 				target.takeDamage(damage);
 
@@ -122,10 +122,10 @@ export default G => {
 							energySteal +
 							' energy from %CreatureName' +
 							target.id +
-							'%'
+							'%',
 					);
 				}
-			}
+			},
 		},
 
 		// 	Third Ability: Rocket Launcher
@@ -137,17 +137,17 @@ export default G => {
 				// Recalculate energy requirements/costs based on whether this is ugpraded
 				if (this.isUpgraded()) {
 					this.requirements = {
-						energy: 30
+						energy: 30,
 					};
 					this.costs = {
-						energy: 30
+						energy: 30,
 					};
 				} else {
 					this.requirements = {
-						energy: 40
+						energy: 40,
 					};
 					this.costs = {
-						energy: 40
+						energy: 40,
 					};
 				}
 				return this.testRequirements();
@@ -168,21 +168,21 @@ export default G => {
 							G.grid.getHexMap(crea.x, crea.y - 2, 0, false, bellowrow),
 							true,
 							true,
-							crea.id
+							crea.id,
 						)
 						.concat(
 							arrayUtils.filterCreature(
 								G.grid.getHexMap(crea.x, crea.y, 0, false, straitrow),
 								true,
 								true,
-								crea.id
+								crea.id,
 							),
 							arrayUtils.filterCreature(
 								G.grid.getHexMap(crea.x, crea.y, 0, false, bellowrow),
 								true,
 								true,
-								crea.id
-							)
+								crea.id,
+							),
 						),
 					//Behind
 					arrayUtils
@@ -190,22 +190,22 @@ export default G => {
 							G.grid.getHexMap(crea.x - 1, crea.y - 2, 0, true, bellowrow),
 							true,
 							true,
-							crea.id
+							crea.id,
 						)
 						.concat(
 							arrayUtils.filterCreature(
 								G.grid.getHexMap(crea.x - 1, crea.y, 0, true, straitrow),
 								true,
 								true,
-								crea.id
+								crea.id,
 							),
 							arrayUtils.filterCreature(
 								G.grid.getHexMap(crea.x - 1, crea.y, 0, true, bellowrow),
 								true,
 								true,
-								crea.id
-							)
-						)
+								crea.id,
+							),
+						),
 				];
 
 				choices[0].choiceId = 0;
@@ -222,7 +222,7 @@ export default G => {
 					team: Team.both,
 					id: crea.id,
 					requireCreature: false,
-					choices: choices
+					choices: choices,
 				});
 			},
 
@@ -244,20 +244,20 @@ export default G => {
 							G.grid.getHexMap(crea.x, crea.y - 2, 0, false, bellowrow),
 							true,
 							true,
-							crea.id
+							crea.id,
 						),
 						arrayUtils.filterCreature(
 							G.grid.getHexMap(crea.x, crea.y, 0, false, straitrow),
 							true,
 							true,
-							crea.id
+							crea.id,
 						),
 						arrayUtils.filterCreature(
 							G.grid.getHexMap(crea.x, crea.y, 0, false, bellowrow),
 							true,
 							true,
-							crea.id
-						)
+							crea.id,
+						),
 					];
 				} else {
 					// Back
@@ -266,20 +266,20 @@ export default G => {
 							G.grid.getHexMap(crea.x - 1, crea.y - 2, 0, true, bellowrow),
 							true,
 							true,
-							crea.id
+							crea.id,
 						),
 						arrayUtils.filterCreature(
 							G.grid.getHexMap(crea.x - 1, crea.y, 0, true, straitrow),
 							true,
 							true,
-							crea.id
+							crea.id,
 						),
 						arrayUtils.filterCreature(
 							G.grid.getHexMap(crea.x - 1, crea.y, 0, true, bellowrow),
 							true,
 							true,
-							crea.id
-						)
+							crea.id,
+						),
 					];
 				}
 
@@ -297,7 +297,7 @@ export default G => {
 						ability.damages, //Damage Type
 						1, //Area
 						[], //Effects
-						G
+						G,
 					);
 					target.takeDamage(damage);
 				}
@@ -307,7 +307,7 @@ export default G => {
 				}
 
 				G.UI.checkAbilities();
-			}
+			},
 		},
 
 		// 	Fourth Ability: Target Locking
@@ -343,7 +343,7 @@ export default G => {
 					team: Team.enemy,
 					id: crea.id,
 					flipped: crea.player.flipped,
-					hexes: hexes
+					hexes: hexes,
 				});
 			},
 
@@ -376,10 +376,10 @@ export default G => {
 					damages, // Damage Type
 					1, // Area
 					[], // Effects
-					G
+					G,
 				);
 				target.takeDamage(damage);
-			}
-		}
+			},
+		},
 	];
 };

--- a/src/abilities/Golden-Wyrm.js
+++ b/src/abilities/Golden-Wyrm.js
@@ -29,7 +29,7 @@ export default G => {
 
 				if (
 					this.atLeastOneTarget(this.creature.adjacentHexes(1), {
-						team: this._targetTeam
+						team: this._targetTeam,
 					})
 				) {
 					this.end();
@@ -66,9 +66,9 @@ export default G => {
 								}
 							},
 							alterations: {
-								regrowth: -5
+								regrowth: -5,
 							},
-							turn: G.turn
+							turn: G.turn,
 						};
 
 						//Spore Contamination
@@ -78,7 +78,7 @@ export default G => {
 							trg, // Target
 							'onStartPhase', // Trigger
 							optArg, // Optional arguments
-							G
+							G,
 						);
 
 						let validTarget = true;
@@ -95,7 +95,7 @@ export default G => {
 						}
 					}
 				});
-			}
+			},
 		},
 
 		// 	Second Ability: Executioner Axe
@@ -104,7 +104,7 @@ export default G => {
 			trigger: 'onQuery',
 
 			damages: {
-				slash: 40
+				slash: 40,
 			},
 			_targetTeam: Team.enemy,
 
@@ -117,7 +117,7 @@ export default G => {
 				//At least one target
 				if (
 					!this.atLeastOneTarget(this.creature.adjacentHexes(1), {
-						team: this._targetTeam
+						team: this._targetTeam,
 					})
 				) {
 					return false;
@@ -134,7 +134,7 @@ export default G => {
 					[0, 0, 0, 0],
 					[0, 1, 0, 1],
 					[1, 0, 0, 1], //origin line
-					[0, 1, 0, 1]
+					[0, 1, 0, 1],
 				];
 
 				G.grid.queryCreature({
@@ -144,7 +144,7 @@ export default G => {
 					team: this._targetTeam,
 					id: wyrm.id,
 					flipped: wyrm.flipped,
-					hexes: G.grid.getHexMap(wyrm.x - 2, wyrm.y - 2, 0, false, map)
+					hexes: G.grid.getHexMap(wyrm.x - 2, wyrm.y - 2, 0, false, map),
 				});
 			},
 
@@ -158,7 +158,7 @@ export default G => {
 					ability.damages, // Damage Type
 					1, // Area
 					[], // Effects
-					G
+					G,
 				);
 
 				let dmg = target.takeDamage(damage);
@@ -176,11 +176,11 @@ export default G => {
 									effect.deleteEffect();
 								},
 								alterations: {
-									regrowth: Math.round(dmg.damages.total / 4)
-								}
+									regrowth: Math.round(dmg.damages.total / 4),
+								},
 							}, //Optional arguments
-							G
-						)
+							G,
+						),
 					);
 				}
 
@@ -190,7 +190,7 @@ export default G => {
 						this.deleteEffect();
 					}
 				});
-			}
+			},
 		},
 
 		// 	Third Ability: Dragon Flight
@@ -206,7 +206,7 @@ export default G => {
 				this.creature.tracePosition({
 					x: hex.x,
 					y: hex.y,
-					overlayClass: 'creature moveto selected player' + this.creature.team
+					overlayClass: 'creature moveto selected player' + this.creature.team,
 				});
 			},
 
@@ -229,7 +229,7 @@ export default G => {
 					size: wyrm.size,
 					flipped: wyrm.player.flipped,
 					id: wyrm.id,
-					hexes: range
+					hexes: range,
 				});
 			},
 
@@ -243,7 +243,7 @@ export default G => {
 					ignorePath: true,
 					callback: function() {
 						G.activeCreature.queryMove();
-					}
+					},
 				});
 
 				// Frogger Leap bonus
@@ -258,13 +258,13 @@ export default G => {
 								effect.deleteEffect();
 							},
 							alterations: {
-								offense: 25
-							}
+								offense: 25,
+							},
 						}, // Optional arguments
-						G
-					)
+						G,
+					),
 				);
-			}
+			},
 		},
 
 		// 	Fourth Ability: Battle Cry
@@ -275,7 +275,7 @@ export default G => {
 			damages: {
 				pierce: 15,
 				slash: 10,
-				crush: 5
+				crush: 5,
 			},
 			_targetTeam: Team.enemy,
 
@@ -290,12 +290,12 @@ export default G => {
 					this.creature.y - 2,
 					0,
 					false,
-					matrices.frontnback2hex
+					matrices.frontnback2hex,
 				);
 				// At least one target
 				if (
 					!this.atLeastOneTarget(map, {
-						team: this._targetTeam
+						team: this._targetTeam,
 					})
 				) {
 					return false;
@@ -315,7 +315,7 @@ export default G => {
 					team: this._targetTeam,
 					id: wyrm.id,
 					flipped: wyrm.flipped,
-					hexes: G.grid.getHexMap(wyrm.x - 2, wyrm.y - 2, 0, false, matrices.frontnback2hex)
+					hexes: G.grid.getHexMap(wyrm.x - 2, wyrm.y - 2, 0, false, matrices.frontnback2hex),
 				});
 			},
 
@@ -329,7 +329,7 @@ export default G => {
 					ability.damages, // Damage Type
 					1, // Area
 					[], // Effects
-					G
+					G,
 				);
 				target.takeDamage(damage);
 
@@ -339,7 +339,7 @@ export default G => {
 						item.deleteEffect();
 					}
 				});
-			}
-		}
+			},
+		},
 	];
 };

--- a/src/abilities/Gumble.js
+++ b/src/abilities/Gumble.js
@@ -28,7 +28,7 @@ export default G => {
 				// Attach a permanent effect that gives Gumble stat buffs
 				// Bonus points to pierce, slash and crush based on remaining health
 				let healthBonusDivisor = this.isUpgraded() ? 5 : 7;
-				let bonus = Math.floor(this.creature.health / healthBonusDivisor * 3);
+				let bonus = Math.floor((this.creature.health / healthBonusDivisor) * 3);
 				// Log whenever the bonus applied changes
 				let noLog = bonus == this._lastBonus;
 				this._lastBonus = bonus;
@@ -48,19 +48,19 @@ export default G => {
 							alterations: alterations,
 							deleteTrigger: '',
 							stackable: false,
-							noLog: noLog
+							noLog: noLog,
 						},
-						G
-					)
+						G,
+					),
 				);
 				if (!noLog) {
 					G.log(
-						'%CreatureName' + this.creature.id + '% receives ' + bonus + ' pierce, slash and crush'
+						'%CreatureName' + this.creature.id + '% receives ' + bonus + ' pierce, slash and crush',
 					);
 				}
 			},
 
-			_lastBonus: 0
+			_lastBonus: 0,
 		},
 
 		// 	Second Ability: Gummy Mallet
@@ -88,7 +88,7 @@ export default G => {
 					G.grid.getHexMap(this.creature.x + 1 + dx, this.creature.y + 2 + dy, 0, false, area), // down-right
 					G.grid.getHexMap(this.creature.x - 1 + dx, this.creature.y + 2 + dy, 0, false, area), // down-left
 					G.grid.getHexMap(this.creature.x - 2 + dx, this.creature.y + dy, 0, false, area), // back
-					G.grid.getHexMap(this.creature.x - 1 + dx, this.creature.y - 2 + dy, 0, false, area) // up-left
+					G.grid.getHexMap(this.creature.x - 1 + dx, this.creature.y - 2 + dy, 0, false, area), // up-left
 				];
 				// Reorder choices based on number of hexes
 				// This ensures that if a choice contains overlapping hexes only, that
@@ -107,7 +107,7 @@ export default G => {
 					team: Team.both,
 					id: this.creature.id,
 					requireCreature: false,
-					choices: choices
+					choices: choices,
 				});
 			},
 
@@ -141,10 +141,10 @@ export default G => {
 				if (kills > 1) {
 					this.creature.player.score.push({
 						type: 'combo',
-						kills: kills
+						kills: kills,
 					});
 				}
-			}
+			},
 		},
 
 		// 	Thirt Ability: Royal Seal
@@ -165,7 +165,7 @@ export default G => {
 				// Upgraded Royal Seal can target up to 3 hexagons range
 				let range = this.isUpgraded() ? 3 : 1;
 				let hexes = creature.hexagons.concat(
-					G.grid.getFlyingRange(creature.x, creature.y, range, creature.size, creature.id)
+					G.grid.getFlyingRange(creature.x, creature.y, range, creature.size, creature.id),
 				);
 
 				G.grid.queryHexes({
@@ -177,7 +177,7 @@ export default G => {
 					id: creature.id,
 					hexes: hexes,
 					ownCreatureHexShade: true,
-					hideNonTarget: true
+					hideNonTarget: true,
 				});
 			},
 
@@ -209,17 +209,17 @@ export default G => {
 							// Immobilize target so that they can't move and no
 							// abilities/effects can move them
 							alterations: {
-								moveable: false
+								moveable: false,
 							},
 							deleteTrigger: 'onStartPhase',
-							turnLifetime: 1
+							turnLifetime: 1,
 						},
-						G
+						G,
 					);
 
 					let trap = hex.createTrap('royal-seal', [effect], ability.creature.player, {
 						ownerCreature: ability.creature,
-						fullTurnLifetime: true
+						fullTurnLifetime: true,
 					});
 					trap.hide();
 				};
@@ -234,12 +234,12 @@ export default G => {
 						ignoreMovementPoint: true,
 						ignorePath: true,
 						overrideSpeed: 200, // Custom speed for jumping
-						animation: 'push'
+						animation: 'push',
 					});
 				} else {
 					makeSeal();
 				}
-			}
+			},
 		},
 
 		// 	Fourth Ability: Boom Box
@@ -259,7 +259,7 @@ export default G => {
 				if (
 					!this.testDirection({
 						team: this._targetTeam,
-						directions: this.directions
+						directions: this.directions,
 					})
 				) {
 					return false;
@@ -282,7 +282,7 @@ export default G => {
 					requireCreature: true,
 					x: crea.x,
 					y: crea.y,
-					directions: this.directions
+					directions: this.directions,
 				});
 			},
 
@@ -297,10 +297,10 @@ export default G => {
 				let d = melee
 					? {
 							sonic: 20,
-							crush: 10
+							crush: 10,
 					  }
 					: {
-							sonic: 20
+							sonic: 20,
 					  };
 
 				let dir = [];
@@ -346,11 +346,11 @@ export default G => {
 					d, // Damage Type
 					1, // Area
 					[], // Effects
-					G
+					G,
 				);
 
 				let result = target.takeDamage(damage, {
-					ignoreRetaliation: true
+					ignoreRetaliation: true,
 				});
 
 				if (result.kill) {
@@ -365,10 +365,10 @@ export default G => {
 						callback: function() {
 							G.activeCreature.queryMove();
 						},
-						animation: 'push'
+						animation: 'push',
 					});
 				}
-			}
-		}
+			},
+		},
 	];
 };

--- a/src/abilities/Headless.js
+++ b/src/abilities/Headless.js
@@ -23,7 +23,7 @@ export default G => {
 			require: function() {
 				if (
 					!this.atLeastOneTarget(this._getHexes(), {
-						team: this._targetTeam
+						team: this._targetTeam,
 					})
 				) {
 					return false;
@@ -38,7 +38,7 @@ export default G => {
 
 				if (
 					this.atLeastOneTarget(this._getHexes(), {
-						team: this._targetTeam
+						team: this._targetTeam,
 					})
 				) {
 					this.end();
@@ -81,25 +81,25 @@ export default G => {
 											deleteTrigger: '',
 											stackable: true,
 											alterations: {
-												endurance: -5
-											}
+												endurance: -5,
+											},
 										},
-										G
-									)
+										G,
+									),
 								);
 								// Note: effect activate by default adds the effect on the target,
 								// but target already has this effect, so remove the trigger to
 								// prevent infinite addition of this effect.
 								item.trigger = '';
 								item.deleteEffect();
-							}
+							},
 						},
-						G
+						G,
 					);
 
 					trg.addEffect(effect, '%CreatureName' + trg.id + '% has been infested');
 				});
-			}
+			},
 		},
 
 		// 	Second Ability: Cartilage Dagger
@@ -120,7 +120,7 @@ export default G => {
 				//At least one target
 				if (
 					!this.atLeastOneTarget(crea.getHexMap(matrices.frontnback2hex), {
-						team: this._targetTeam
+						team: this._targetTeam,
 					})
 				) {
 					return false;
@@ -140,7 +140,7 @@ export default G => {
 					team: this._targetTeam,
 					id: crea.id,
 					flipped: crea.flipped,
-					hexes: crea.getHexMap(matrices.frontnback2hex)
+					hexes: crea.getHexMap(matrices.frontnback2hex),
 				});
 			},
 
@@ -150,7 +150,7 @@ export default G => {
 				ability.end();
 
 				let d = {
-					pierce: 11
+					pierce: 11,
 				};
 				// Bonus for fatigued foe
 				d.pierce = target.endurance <= 0 ? d.pierce * 2 : d.pierce;
@@ -167,11 +167,11 @@ export default G => {
 					d, // Damage Type
 					1, // Area
 					[], // Effects
-					G
+					G,
 				);
 
 				target.takeDamage(damage);
-			}
+			},
 		},
 
 		// 	Third Ability: Whip Move
@@ -206,14 +206,14 @@ export default G => {
 						x: x,
 						directions: directions,
 						distance: this._minDistance,
-						sourceCreature: crea
+						sourceCreature: crea,
 					});
 					let testMax = this.testDirection({
 						team: this._targetTeam,
 						x: x,
 						directions: directions,
 						distance: this._getMaxDistance(),
-						sourceCreature: crea
+						sourceCreature: crea,
 					});
 					if (!testMin && testMax) {
 						// Target needs to be moveable
@@ -228,7 +228,7 @@ export default G => {
 							this.creature.x + fx,
 							this.creature.y,
 							i,
-							this.creature.player.flipped
+							this.creature.player.flipped,
 						);
 						if (this._getMaxDistance() > 0) {
 							dir = dir.slice(0, this._getMaxDistance() + 1);
@@ -285,7 +285,7 @@ export default G => {
 					x: crea.x,
 					y: crea.y,
 					directions: this._getValidDirections(),
-					distance: this._getMaxDistance()
+					distance: this._getMaxDistance(),
 				});
 			},
 
@@ -334,7 +334,7 @@ export default G => {
 									G.activeCreature.queryMove();
 								}
 							}, 100);
-						}
+						},
 					});
 				}
 				if (destinationTarget !== null) {
@@ -350,10 +350,10 @@ export default G => {
 									G.activeCreature.queryMove();
 								}
 							}, 100);
-						}
+						},
 					});
 				}
-			}
+			},
 		},
 
 		// 	Fourth Ability: Boomerang Tool
@@ -363,7 +363,7 @@ export default G => {
 
 			damages: {
 				slash: 10,
-				crush: 5
+				crush: 5,
 			},
 
 			_getHexes: function() {
@@ -398,13 +398,13 @@ export default G => {
 					requireCreature: 0,
 					id: crea.id,
 					flipped: crea.player.flipped,
-					choices: [crea.getHexMap(hexes), crea.getHexMap(hexes, true)]
+					choices: [crea.getHexMap(hexes), crea.getHexMap(hexes, true)],
 				});
 			},
 
 			activate: function(hexes) {
 				let damages = {
-					slash: 10
+					slash: 10,
 				};
 
 				let ability = this;
@@ -415,16 +415,16 @@ export default G => {
 					damages, //Damage Type
 					[], //Effects
 					ability.getTargets(hexes), //Targets
-					true //Notriggers avoid double retailiation
+					true, //Notriggers avoid double retailiation
 				);
 
 				ability.areaDamage(
 					ability.creature, //Attacker
 					damages, //Damage Type
 					[], //Effects
-					ability.getTargets(hexes) //Targets
+					ability.getTargets(hexes), //Targets
 				);
-			}
-		}
+			},
+		},
 	];
 };

--- a/src/abilities/Impaler.js
+++ b/src/abilities/Impaler.js
@@ -46,10 +46,10 @@ export default G => {
 						this.creature.id +
 						'% absorbs ' +
 						converted +
-						' shock damage into energy'
+						' shock damage into energy',
 				);
 				return damage;
-			}
+			},
 		},
 
 		// 	Second Ability: Hasted Javelin
@@ -67,7 +67,7 @@ export default G => {
 
 				if (
 					!this.atLeastOneTarget(this._getHexes(), {
-						team: this._targetTeam
+						team: this._targetTeam,
 					})
 				) {
 					return false;
@@ -87,7 +87,7 @@ export default G => {
 					team: this._targetTeam,
 					id: creature.id,
 					flipped: creature.flipped,
-					hexes: this._getHexes()
+					hexes: this._getHexes(),
 				});
 			},
 
@@ -98,9 +98,9 @@ export default G => {
 
 				let finalDmg = $j.extend(
 					{
-						poison: 0
+						poison: 0,
 					},
-					ability.damages1
+					ability.damages1,
 				);
 
 				// Poison Bonus if upgraded
@@ -115,7 +115,7 @@ export default G => {
 					finalDmg, // Damage Type
 					1, // Area
 					[], // Effects
-					G
+					G,
 				);
 				let result = target.takeDamage(damage);
 				// Recharge movement if any damage dealt
@@ -132,9 +132,9 @@ export default G => {
 					this.creature.y - 2,
 					0,
 					false,
-					matrices.frontnback3hex
+					matrices.frontnback3hex,
 				);
-			}
+			},
 		},
 
 		// 	Thirt Ability: Poisonous Vine
@@ -148,7 +148,7 @@ export default G => {
 			require: function() {
 				if (
 					!this.atLeastOneTarget(this._getHexes(), {
-						team: this._targetTeam
+						team: this._targetTeam,
 					})
 				) {
 					return false;
@@ -168,7 +168,7 @@ export default G => {
 					team: this._targetTeam,
 					id: creature.id,
 					flipped: creature.flipped,
-					hexes: this._getHexes()
+					hexes: this._getHexes(),
 				});
 			},
 
@@ -188,7 +188,7 @@ export default G => {
 						effectFn: function(eff) {
 							G.log('%CreatureName' + eff.target.id + '% is hit by ' + eff.name);
 							eff.target.takeDamage(new Damage(eff.owner, damages, 1, [], G), {
-								isFromTrap: true
+								isFromTrap: true,
 							});
 							// Hack: manually destroy traps so we don't activate multiple traps
 							// and see multiple logs etc.
@@ -196,9 +196,9 @@ export default G => {
 								hex.destroyTrap();
 							});
 							eff.deleteEffect();
-						}
+						},
 					},
-					G
+					G,
 				);
 				target.hexagons.forEach(function(hex) {
 					hex.createTrap('poisonous-vine', [effect], ability.creature.player, {
@@ -206,7 +206,7 @@ export default G => {
 						fullTurnLifetime: true,
 						ownerCreature: ability.creature,
 						destroyOnActivate: true,
-						destroyAnimation: 'shrinkDown'
+						destroyAnimation: 'shrinkDown',
 					});
 				});
 			},
@@ -215,7 +215,7 @@ export default G => {
 				// Target a creature within 2 hex radius
 				let hexes = G.grid.hexes[this.creature.y][this.creature.x].adjacentHex(2);
 				return arrayUtils.extendToLeft(hexes, this.creature.size, G.grid);
-			}
+			},
 		},
 
 		//	Fourth Ability: Chain Lightning
@@ -231,7 +231,7 @@ export default G => {
 				}
 				if (
 					!this.atLeastOneTarget(this._getHexes(), {
-						team: this._targetTeam
+						team: this._targetTeam,
 					})
 				) {
 					return false;
@@ -250,7 +250,7 @@ export default G => {
 					team: this._targetTeam,
 					id: this.creature.id,
 					flipped: this.creature.flipped,
-					hexes: this._getHexes()
+					hexes: this._getHexes(),
 				});
 			},
 
@@ -286,7 +286,7 @@ export default G => {
 											// be zero
 											if (dmg.total <= 0 || damage.damages.shock <= 0 || trg.health <= 1) {
 												damage.damages = {
-													shock: 0
+													shock: 0,
 												};
 												break;
 											} else if (dmg.total >= trg.health) {
@@ -298,10 +298,10 @@ export default G => {
 										}
 									},
 									deleteTrigger: 'onEndPhase',
-									noLog: true
+									noLog: true,
 								},
-								G
-							)
+								G,
+							),
 						);
 					}
 
@@ -310,7 +310,7 @@ export default G => {
 						nextdmg, // Damage Type
 						1, // Area
 						[], // Effects
-						G
+						G,
 					);
 					nextdmg = trg.takeDamage(damage);
 
@@ -350,8 +350,8 @@ export default G => {
 						size: 0,
 						stats: {
 							defense: -99999,
-							shock: -99999
-						}
+							shock: -99999,
+						},
 					};
 					for (let j = 0; j < nextTargets.length; j++) {
 						// For each creature
@@ -388,9 +388,9 @@ export default G => {
 					this.creature.y - 2,
 					0,
 					false,
-					matrices.frontnback3hex
+					matrices.frontnback3hex,
 				);
-			}
-		}
+			},
+		},
 	];
 };

--- a/src/abilities/Magma-Spawn.js
+++ b/src/abilities/Magma-Spawn.js
@@ -55,24 +55,24 @@ export default G => {
 								},
 								effectFn: function(effect, target) {
 									target.takeDamage(new Damage(effect.attacker, ability.damages, 1, [], G), {
-										isFromTrap: true
+										isFromTrap: true,
 									});
 									this.trap.destroy();
 									effect.deleteEffect();
 								},
-								attacker: this.creature
+								attacker: this.creature,
 							},
-							G
-						)
+							G,
+						),
 					],
 					this.creature.player,
 					{
 						turnLifetime: lifetime,
 						ownerCreature: this.creature,
-						fullTurnLifetime: true
-					}
+						fullTurnLifetime: true,
+					},
 				);
-			}
+			},
 		},
 
 		// 	Second Ability: Pulverizing Hit
@@ -92,7 +92,7 @@ export default G => {
 
 				if (
 					!this.atLeastOneTarget(this.creature.getHexMap(matrices.frontnback3hex), {
-						team: this._targetTeam
+						team: this._targetTeam,
 					})
 				) {
 					return false;
@@ -112,7 +112,7 @@ export default G => {
 					team: this._targetTeam,
 					id: magmaSpawn.id,
 					flipped: magmaSpawn.flipped,
-					hexes: this.creature.getHexMap(matrices.frontnback3hex)
+					hexes: this.creature.getHexMap(matrices.frontnback3hex),
 				});
 			},
 
@@ -123,7 +123,7 @@ export default G => {
 
 				let d = {
 					burn: this.damages.burn,
-					crush: this.damages.crush
+					crush: this.damages.crush,
 				};
 				// Deal extra burn damage based on number of stacks
 				let stacksExisting = 0;
@@ -139,7 +139,7 @@ export default G => {
 					d, // Damage Type
 					1, // Area
 					[], // Effects
-					G
+					G,
 				);
 				target.takeDamage(damage);
 
@@ -160,13 +160,13 @@ export default G => {
 							'',
 							{
 								deleteTrigger: '',
-								stackable: true
+								stackable: true,
 							},
-							G
-						)
+							G,
+						),
 					);
 				}
-			}
+			},
 		},
 
 		// 	Thirt Ability: Cracked Earth
@@ -179,7 +179,7 @@ export default G => {
 				[0, 0, 1, 1],
 				[1, 1, 1, 0], //origin line
 				[0, 0, 1, 1],
-				[0, 0, 1, 0]
+				[0, 0, 1, 0],
 			],
 
 			require: function() {
@@ -201,7 +201,7 @@ export default G => {
 					requireCreature: 0,
 					id: magmaSpawn.id,
 					flipped: magmaSpawn.flipped,
-					choices: [magmaSpawn.getHexMap(this.map), magmaSpawn.getHexMap(this.map, true)]
+					choices: [magmaSpawn.getHexMap(this.map), magmaSpawn.getHexMap(this.map, true)],
 				});
 			},
 
@@ -222,7 +222,7 @@ export default G => {
 					ability.creature, // Attacker
 					ability.damages1, // Damage Type
 					[], // Effects
-					targets
+					targets,
 				);
 
 				// If upgraded, leave Boiling Point traps on all hexes that don't contain
@@ -234,7 +234,7 @@ export default G => {
 						}
 					});
 				}
-			}
+			},
 		},
 
 		// 	Fourth Ability: Molten Hurl
@@ -263,7 +263,7 @@ export default G => {
 					!this.testDirection({
 						team: this._targetTeam,
 						x: x,
-						directions: this.directions
+						directions: this.directions,
 					})
 				) {
 					return false;
@@ -287,7 +287,7 @@ export default G => {
 					requireCreature: true,
 					x: x,
 					y: magmaSpawn.y,
-					directions: this.directions
+					directions: this.directions,
 				});
 			},
 
@@ -304,7 +304,7 @@ export default G => {
 					ability.damages, // Damage Type
 					1, // Area
 					[], // Effects
-					G
+					G,
 				);
 
 				// Destroy traps currently under self
@@ -366,11 +366,11 @@ export default G => {
 									}
 								}, 100);
 							}
-						}
+						},
 					});
 				};
 				hurl(path);
-			}
-		}
+			},
+		},
 	];
 };

--- a/src/abilities/Nightmare.js
+++ b/src/abilities/Nightmare.js
@@ -51,14 +51,14 @@ export default G => {
 							alterations: {
 								frost: 5,
 								defense: 5,
-								offense: this._getOffenseBuff()
+								offense: this._getOffenseBuff(),
 							},
-							stackable: true
+							stackable: true,
 						},
-						G
-					)
+						G,
+					),
 				);
-			}
+			},
 		},
 
 		// 	Second Ability: Icy Talons
@@ -76,7 +76,7 @@ export default G => {
 
 				if (
 					!this.atLeastOneTarget(this.creature.getHexMap(matrices.frontnback2hex), {
-						team: this._targetTeam
+						team: this._targetTeam,
 					})
 				) {
 					return false;
@@ -95,7 +95,7 @@ export default G => {
 					team: this._targetTeam,
 					id: this.creature.id,
 					flipped: this.creature.flipped,
-					hexes: this.creature.getHexMap(matrices.frontnback2hex)
+					hexes: this.creature.getHexMap(matrices.frontnback2hex),
 				});
 			},
 
@@ -125,18 +125,18 @@ export default G => {
 							'',
 							{
 								alterations: {
-									frost: -1
+									frost: -1,
 								},
-								stackable: true
+								stackable: true,
 							},
-							G
-						)
+							G,
+						),
 					], // Effects
-					G
+					G,
 				);
 
 				target.takeDamage(damage);
-			}
+			},
 		},
 
 		// 	Third Ability: Sudden Uppercut
@@ -154,7 +154,7 @@ export default G => {
 
 				if (
 					!this.atLeastOneTarget(this.creature.getHexMap(matrices.frontnback2hex), {
-						team: this._targetTeam
+						team: this._targetTeam,
 					})
 				) {
 					return false;
@@ -173,7 +173,7 @@ export default G => {
 					team: this._targetTeam,
 					id: this.creature.id,
 					flipped: this.creature.flipped,
-					hexes: this.creature.getHexMap(matrices.frontnback2hex)
+					hexes: this.creature.getHexMap(matrices.frontnback2hex),
 				});
 			},
 
@@ -193,14 +193,14 @@ export default G => {
 							'',
 							{
 								alterations: {
-									defense: -10
+									defense: -10,
 								},
 								stackable: true,
 								turnLifetime: 1,
-								deleteTrigger: 'onStartPhase'
+								deleteTrigger: 'onStartPhase',
 							},
-							G
-						)
+							G,
+						),
 					);
 				}
 				let damage = new Damage(
@@ -208,7 +208,7 @@ export default G => {
 					ability.damages, // Damage Type
 					1, // Area
 					effects,
-					G
+					G,
 				);
 
 				let result = target.takeDamage(damage);
@@ -218,7 +218,7 @@ export default G => {
 				}
 
 				target.delay();
-			}
+			},
 		},
 
 		// 	Fourth Ability: Icicle Spear
@@ -248,7 +248,7 @@ export default G => {
 						x: x,
 						directions: this.directions,
 						distance: this._getDistance(),
-						stopOnCreature: false
+						stopOnCreature: false,
 					})
 				) {
 					return false;
@@ -274,7 +274,7 @@ export default G => {
 					y: crea.y,
 					directions: this.directions,
 					distance: this._getDistance(),
-					stopOnCreature: false
+					stopOnCreature: false,
 				});
 			},
 
@@ -290,7 +290,7 @@ export default G => {
 
 						let d = {
 							pierce: ability.damages.pierce,
-							frost: 6 - i
+							frost: 6 - i,
 						};
 						if (d.frost < 0) {
 							d.frost = 0;
@@ -302,7 +302,7 @@ export default G => {
 							d, // Damage Type
 							1, // Area
 							[], // Effects
-							G
+							G,
 						);
 
 						let result = trg.takeDamage(damage);
@@ -316,7 +316,7 @@ export default G => {
 						}
 					}
 				}
-			}
-		}
+			},
+		},
 	];
 };

--- a/src/abilities/Nutcase.js
+++ b/src/abilities/Nutcase.js
@@ -39,13 +39,13 @@ export default G => {
 				// Target becomes unmoveable until end of their phase
 				let o = {
 					alterations: {
-						moveable: false
+						moveable: false,
 					},
 					deleteTrigger: 'onEndPhase',
 					// Delete this effect as soon as attacker's turn finishes
 					turnLifetime: 1,
 					creationTurn: G.turn - 1,
-					deleteOnOwnerDeath: true
+					deleteOnOwnerDeath: true,
 				};
 				// If upgraded, target abilities cost more energy
 				if (this.isUpgraded()) {
@@ -63,10 +63,10 @@ export default G => {
 							damage.attacker, // Target
 							'', // Trigger
 							o,
-							G
-						)
+							G,
+						),
 					],
-					G
+					G,
 				);
 				counterDamage.counter = true;
 				damage.attacker.takeDamage(counterDamage);
@@ -85,16 +85,16 @@ export default G => {
 							'',
 							{
 								alterations: {
-									moveable: false
+									moveable: false,
 								},
 								deleteTrigger: 'onStartPhase',
-								turnLifetime: 1
+								turnLifetime: 1,
 							},
-							G
-						)
+							G,
+						),
 					);
 				}
-			}
+			},
 		},
 
 		//	Second Ability: Hammer Time
@@ -112,7 +112,7 @@ export default G => {
 
 				if (
 					!this.atLeastOneTarget(this.creature.getHexMap(matrices.frontnback2hex), {
-						team: this._targetTeam
+						team: this._targetTeam,
 					})
 				) {
 					return false;
@@ -133,13 +133,13 @@ export default G => {
 						team: this._targetTeam,
 						id: this.creature.id,
 						flipped: this.creature.flipped,
-						hexes: this.creature.getHexMap(matrices.frontnback2hex)
+						hexes: this.creature.getHexMap(matrices.frontnback2hex),
 					});
 				} else {
 					// If upgraded, show choice of front and back hex groups
 					let choices = [
 						this.creature.getHexMap(matrices.front2hex),
-						this.creature.getHexMap(matrices.back2hex)
+						this.creature.getHexMap(matrices.back2hex),
 					];
 					G.grid.queryChoice({
 						fnOnSelect: function(choice, args) {
@@ -151,7 +151,7 @@ export default G => {
 						},
 						team: this._targetTeam,
 						id: this.creature.id,
-						choices: choices
+						choices: choices,
 					});
 				}
 			},
@@ -211,17 +211,17 @@ export default G => {
 								new Damage(
 									eff.owner,
 									{
-										pierce: ability.damages.pierce
+										pierce: ability.damages.pierce,
 									},
 									1,
 									[],
-									G
-								)
+									G,
+								),
 							);
 							eff.deleteEffect();
-						}
+						},
 					},
-					G
+					G,
 				);
 
 				let damage = new Damage(
@@ -229,11 +229,11 @@ export default G => {
 					this.damages, // Damage Type
 					1, // Area
 					[effect], // Effects
-					G
+					G,
 				);
 
 				target.takeDamage(damage);
-			}
+			},
 		},
 
 		// 	Third Ability: War Horn
@@ -251,7 +251,7 @@ export default G => {
 				if (
 					!this.testDirection({
 						team: this._targetTeam,
-						directions: this._directions
+						directions: this._directions,
 					})
 				) {
 					return false;
@@ -273,7 +273,7 @@ export default G => {
 					x: this.creature.x,
 					y: this.creature.y,
 					directions: this._directions,
-					dashedHexesAfterCreatureStop: false
+					dashedHexesAfterCreatureStop: false,
 				};
 				if (!this.isUpgraded()) {
 					G.grid.queryDirection(o);
@@ -388,7 +388,7 @@ export default G => {
 									}
 								}
 							}, 100);
-						}
+						},
 					});
 				} else {
 					target.takeDamage(damage);
@@ -447,7 +447,7 @@ export default G => {
 					overrideSpeed: 100,
 					ignorePath: true,
 					ignoreMovementPoint: true,
-					turnAroundOnComplete: false
+					turnAroundOnComplete: false,
 				};
 				// Note: order matters here; moving ourselves first results on overlapping
 				// hexes momentarily and messes up creature hex displays
@@ -455,13 +455,13 @@ export default G => {
 					targetHex,
 					$j.extend(
 						{
-							animation: 'push'
+							animation: 'push',
 						},
-						opts
-					)
+						opts,
+					),
 				);
 				this.creature.moveTo(hex, opts);
-			}
+			},
 		},
 
 		//	Third Ability: Fishing Hook
@@ -483,7 +483,7 @@ export default G => {
 						optTest: function(creature) {
 							// Size restriction of 2 if unupgraded
 							return ability.isUpgraded() ? true : creature.size <= 2;
-						}
+						},
 					})
 				) {
 					return false;
@@ -506,7 +506,7 @@ export default G => {
 					optTest: function(creature) {
 						// Size restriction of 2 if unupgraded
 						return ability.isUpgraded() ? true : creature.size <= 2;
-					}
+					},
 				});
 			},
 
@@ -521,7 +521,7 @@ export default G => {
 					ability.damages, // Damage Type
 					1, // Area
 					[], // Effects
-					G
+					G,
 				);
 
 				let inlinefront2hex = matrices.inlinefront2hex;
@@ -532,7 +532,7 @@ export default G => {
 						crea.y - inlinefront2hex.origin[1],
 						0,
 						false,
-						inlinefront2hex
+						inlinefront2hex,
 					)[0].creature == target;
 
 				let creaX = target.x + (trgIsInfront ? 0 : crea.size - target.size);
@@ -542,7 +542,7 @@ export default G => {
 					callback: function() {
 						crea.updateHex();
 						crea.queryMove();
-					}
+					},
 				});
 				let targetX = crea.x + (trgIsInfront ? target.size - crea.size : 0);
 				target.moveTo(G.grid.hexes[crea.y][targetX], {
@@ -551,9 +551,9 @@ export default G => {
 					callback: function() {
 						target.updateHex();
 						target.takeDamage(damage);
-					}
+					},
 				});
-			}
-		}
+			},
+		},
 	];
 };

--- a/src/abilities/Scavenger.js
+++ b/src/abilities/Scavenger.js
@@ -36,7 +36,7 @@ export default G => {
 			},
 
 			//	activate() :
-			activate: function() {}
+			activate: function() {},
 		},
 
 		// 	Second Ability: Slicing Pounce
@@ -54,7 +54,7 @@ export default G => {
 
 				if (
 					!this.atLeastOneTarget(this.creature.getHexMap(matrices.frontnback2hex), {
-						team: this._targetTeam
+						team: this._targetTeam,
 					})
 				) {
 					return false;
@@ -73,7 +73,7 @@ export default G => {
 					team: this._targetTeam,
 					id: this.creature.id,
 					flipped: this.creature.flipped,
-					hexes: this.creature.getHexMap(matrices.frontnback2hex)
+					hexes: this.creature.getHexMap(matrices.frontnback2hex),
 				});
 			},
 
@@ -91,10 +91,10 @@ export default G => {
 						'onDamage',
 						{
 							alterations: {
-								offense: -1
-							}
+								offense: -1,
+							},
 						},
-						G
+						G,
 					);
 					target.addEffect(effect);
 					G.log('%CreatureName' + target.id + "%'s offense is lowered by 1");
@@ -105,11 +105,11 @@ export default G => {
 					ability.damages, // Damage Type
 					1, // Area
 					[], // Effects
-					G
+					G,
 				);
 
 				target.takeDamage(damage);
-			}
+			},
 		},
 
 		// 	Third Ability: Escort Service
@@ -151,7 +151,7 @@ export default G => {
 
 				if (
 					!this.atLeastOneTarget(hexes, {
-						team: this._targetTeam
+						team: this._targetTeam,
 					})
 				) {
 					return false;
@@ -189,7 +189,7 @@ export default G => {
 						crea.y - matrices.inlinefront2hex.origin[1],
 						0,
 						false,
-						matrices.inlinefront2hex
+						matrices.inlinefront2hex,
 					)[0].creature == trg;
 
 				let select = hex => {
@@ -239,7 +239,7 @@ export default G => {
 						}),
 					args: {
 						trg: trg.id,
-						trgIsInfront: trgIsInfront
+						trgIsInfront: trgIsInfront,
 					},
 					callbackAfterQueryHexes: () => {
 						for (let i = 0; i < trg.hexagons.length; i++) {
@@ -247,7 +247,7 @@ export default G => {
 							trg.hexagons[i].displayVisualState('dashed');
 						}
 					},
-					fillHexOnHover: false
+					fillHexOnHover: false,
 				});
 			},
 
@@ -285,7 +285,7 @@ export default G => {
 					callback: function() {
 						trg.updateHex();
 					},
-					ignoreMovementPoint: true
+					ignoreMovementPoint: true,
 				});
 
 				trg.moveTo(trgDest, {
@@ -295,9 +295,9 @@ export default G => {
 						ability.creature.queryMove();
 					},
 					ignoreMovementPoint: true,
-					overrideSpeed: crea.animation.walk_speed
+					overrideSpeed: crea.animation.walk_speed,
 				});
-			}
+			},
 		},
 
 		// 	Fourth Ability: Deadly Toxin
@@ -315,7 +315,7 @@ export default G => {
 
 				if (
 					!this.atLeastOneTarget(this.creature.getHexMap(matrices.frontnback2hex), {
-						team: this._targetTeam
+						team: this._targetTeam,
 					})
 				) {
 					return false;
@@ -334,7 +334,7 @@ export default G => {
 					team: this._targetTeam,
 					id: this.creature.id,
 					flipped: this.creature.flipped,
-					hexes: this.creature.getHexMap(matrices.frontnback2hex)
+					hexes: this.creature.getHexMap(matrices.frontnback2hex),
 				});
 			},
 
@@ -354,7 +354,7 @@ export default G => {
 					damages, // Damage Type
 					1, // Area
 					[], // Effects
-					G
+					G,
 				);
 
 				let result = target.takeDamage(damage);
@@ -374,17 +374,17 @@ export default G => {
 									new Damage(
 										eff.owner,
 										{
-											poison: ability.damages.poison
+											poison: ability.damages.poison,
 										},
 										1,
 										[],
-										G
+										G,
 									),
-									{ isFromTrap: true }
+									{ isFromTrap: true },
 								);
-							}
+							},
 						},
-						G
+						G,
 					);
 
 					target.replaceEffect(effect);
@@ -393,7 +393,7 @@ export default G => {
 				}
 
 				G.UI.checkAbilities();
-			}
-		}
+			},
+		},
 	];
 };

--- a/src/abilities/Snow-Bunny.js
+++ b/src/abilities/Snow-Bunny.js
@@ -42,7 +42,7 @@ export default G => {
 						G.activeCreature.queryMove();
 					},
 					ignorePath: true,
-					ignoreMovementPoint: true
+					ignoreMovementPoint: true,
 				});
 			},
 
@@ -92,7 +92,7 @@ export default G => {
 					return undefined;
 				}
 				return hex;
-			}
+			},
 		},
 
 		// 	Second Ability: Big Pliers
@@ -110,7 +110,7 @@ export default G => {
 
 				if (
 					!this.atLeastOneTarget(this.creature.adjacentHexes(1), {
-						team: this._targetTeam
+						team: this._targetTeam,
 					})
 				) {
 					return false;
@@ -130,7 +130,7 @@ export default G => {
 					team: this._targetTeam,
 					id: snowBunny.id,
 					flipped: snowBunny.player.flipped,
-					hexes: snowBunny.adjacentHexes(1)
+					hexes: snowBunny.adjacentHexes(1),
 				});
 			},
 
@@ -143,7 +143,7 @@ export default G => {
 				// If upgraded, do pure damage against frozen targets
 				if (this.isUpgraded() && target.stats.frozen) {
 					damages = {
-						pure: 0
+						pure: 0,
 					};
 					for (let type in ability.damages) {
 						if ({}.hasOwnProperty.call(ability.damages, type)) {
@@ -157,10 +157,10 @@ export default G => {
 					damages, // Damage Type
 					1, // Area
 					[], // Effects
-					G
+					G,
 				);
 				target.takeDamage(damage);
-			}
+			},
 		},
 
 		// 	Third Ability: Blowing Wind
@@ -180,7 +180,7 @@ export default G => {
 				if (
 					!this.testDirection({
 						team: this._targetTeam,
-						directions: this.directions
+						directions: this.directions,
 					})
 				) {
 					return false;
@@ -203,7 +203,7 @@ export default G => {
 					requireCreature: true,
 					x: snowBunny.x,
 					y: snowBunny.y,
-					directions: this.directions
+					directions: this.directions,
 				});
 			},
 
@@ -251,7 +251,7 @@ export default G => {
 					callback: function() {
 						G.activeCreature.queryMove();
 					},
-					animation: 'push'
+					animation: 'push',
 				});
 
 				G.Phaser.camera.shake(0.01, 500, true, G.Phaser.camera.SHAKE_VERTICAL, true);
@@ -272,11 +272,11 @@ export default G => {
 					callback: function() {
 						G.activeCreature.queryMove();
 					},
-					animation: 'push'
+					animation: 'push',
 				});
 
 				G.Phaser.camera.shake(0.01, 500, true, G.Phaser.camera.SHAKE_VERTICAL, true);
-			}
+			},
 		},
 
 		// 	Fourth Ability: Freezing Spit
@@ -295,7 +295,7 @@ export default G => {
 				if (
 					!this.testDirection({
 						team: this._targetTeam,
-						directions: this.directions
+						directions: this.directions,
 					})
 				) {
 					return false;
@@ -318,7 +318,7 @@ export default G => {
 					requireCreature: true,
 					x: snowBunny.x,
 					y: snowBunny.y,
-					directions: [1, 1, 1, 1, 1, 1]
+					directions: [1, 1, 1, 1, 1, 1],
 				});
 			},
 
@@ -335,7 +335,7 @@ export default G => {
 					path,
 					args,
 					52,
-					-20
+					-20,
 				);
 				let tween = projectileInstance[0];
 				let sprite = projectileInstance[1];
@@ -354,7 +354,7 @@ export default G => {
 						dmg, // Damage Type
 						1, // Area
 						[],
-						G
+						G,
 					);
 					let damageResult = target.takeDamage(damage);
 
@@ -370,9 +370,9 @@ export default G => {
 				return {
 					duration: 500,
 					delay: 0,
-					activateAnimation: false
+					activateAnimation: false,
 				};
-			}
-		}
+			},
+		},
 	];
 };

--- a/src/abilities/Vehemoth.js
+++ b/src/abilities/Vehemoth.js
@@ -52,7 +52,7 @@ export default G => {
 										let iceDemonArray = G.findCreature({
 											type: 'S7', // Ice Demon
 											dead: false, // Still Alive
-											team: [1 - trg.team % 2, 1 - trg.team % 2 + 2] // Oposite team
+											team: [1 - (trg.team % 2), 1 - (trg.team % 2) + 2], // Oposite team
 										});
 
 										if (iceDemonArray.length == 0) {
@@ -60,15 +60,15 @@ export default G => {
 										}
 									},
 									alterations: ability.effects[0],
-									noLog: true
+									noLog: true,
 								}, // Optional arguments
-								G
+								G,
 							);
 							crea.addEffect(effect);
 						}
 					}
 				}
-			}
+			},
 		},
 
 		// 	Second Ability: Head Bash
@@ -88,7 +88,7 @@ export default G => {
 					!this.testDirection({
 						team: this._targetTeam,
 						distance: this.distance,
-						sourceCreature: this.creature
+						sourceCreature: this.creature,
 					})
 				) {
 					return false;
@@ -112,7 +112,7 @@ export default G => {
 					x: crea.x,
 					y: crea.y,
 					distance: this.distance,
-					sourceCreature: crea
+					sourceCreature: crea,
 				});
 			},
 
@@ -162,7 +162,7 @@ export default G => {
 							callback: function() {
 								G.activeCreature.queryMove();
 							},
-							animation: 'push'
+							animation: 'push',
 						});
 						pushed = true;
 					}
@@ -178,10 +178,10 @@ export default G => {
 					d, // Damage Type
 					1, // Area
 					[], // Effects
-					G
+					G,
 				);
 				target.takeDamage(damage);
-			}
+			},
 		},
 
 		// 	Thirt Ability: Snow Storm
@@ -207,7 +207,7 @@ export default G => {
 						true,
 						true,
 						crea.id,
-						crea.team
+						crea.team,
 					)
 					.concat(
 						arrayUtils.filterCreature(
@@ -215,28 +215,28 @@ export default G => {
 							true,
 							true,
 							crea.id,
-							crea.team
+							crea.team,
 						),
 						arrayUtils.filterCreature(
 							G.grid.getHexMap(crea.x, crea.y, 0, false, straitrow),
 							true,
 							true,
 							crea.id,
-							crea.team
+							crea.team,
 						),
 						arrayUtils.filterCreature(
 							G.grid.getHexMap(crea.x + 1, crea.y, 0, false, bellowrow),
 							true,
 							true,
 							crea.id,
-							crea.team
+							crea.team,
 						),
 						arrayUtils.filterCreature(
 							G.grid.getHexMap(crea.x + 2, crea.y + 2, 0, false, straitrow),
 							true,
 							true,
 							crea.id,
-							crea.team
+							crea.team,
 						),
 
 						arrayUtils.filterCreature(
@@ -244,41 +244,41 @@ export default G => {
 							true,
 							true,
 							crea.id,
-							crea.team
+							crea.team,
 						),
 						arrayUtils.filterCreature(
 							G.grid.getHexMap(crea.x - 1, crea.y - 2, 2, true, bellowrow),
 							true,
 							true,
 							crea.id,
-							crea.team
+							crea.team,
 						),
 						arrayUtils.filterCreature(
 							G.grid.getHexMap(crea.x, crea.y, 2, true, straitrow),
 							true,
 							true,
 							crea.id,
-							crea.team
+							crea.team,
 						),
 						arrayUtils.filterCreature(
 							G.grid.getHexMap(crea.x - 1, crea.y, 2, true, bellowrow),
 							true,
 							true,
 							crea.id,
-							crea.team
+							crea.team,
 						),
 						arrayUtils.filterCreature(
 							G.grid.getHexMap(crea.x - 2, crea.y + 2, 2, true, straitrow),
 							true,
 							true,
 							crea.id,
-							crea.team
-						)
+							crea.team,
+						),
 					);
 
 				if (
 					!this.atLeastOneTarget(hexes, {
-						team: this._targetTeam
+						team: this._targetTeam,
 					})
 				) {
 					return false;
@@ -300,7 +300,7 @@ export default G => {
 							true,
 							true,
 							crea.id,
-							crea.team
+							crea.team,
 						)
 						.concat(
 							arrayUtils.filterCreature(
@@ -308,29 +308,29 @@ export default G => {
 								true,
 								true,
 								crea.id,
-								crea.team
+								crea.team,
 							),
 							arrayUtils.filterCreature(
 								G.grid.getHexMap(crea.x, crea.y, 0, false, matrices.straitrow),
 								true,
 								true,
 								crea.id,
-								crea.team
+								crea.team,
 							),
 							arrayUtils.filterCreature(
 								G.grid.getHexMap(crea.x + 1, crea.y, 0, false, matrices.bellowrow),
 								true,
 								true,
 								crea.id,
-								crea.team
+								crea.team,
 							),
 							arrayUtils.filterCreature(
 								G.grid.getHexMap(crea.x + 2, crea.y + 2, 0, false, matrices.straitrow),
 								true,
 								true,
 								crea.id,
-								crea.team
-							)
+								crea.team,
+							),
 						),
 					//Behind
 					arrayUtils
@@ -339,7 +339,7 @@ export default G => {
 							true,
 							true,
 							crea.id,
-							crea.team
+							crea.team,
 						)
 						.concat(
 							arrayUtils.filterCreature(
@@ -347,30 +347,30 @@ export default G => {
 								true,
 								true,
 								crea.id,
-								crea.team
+								crea.team,
 							),
 							arrayUtils.filterCreature(
 								G.grid.getHexMap(crea.x, crea.y, 2, true, matrices.straitrow),
 								true,
 								true,
 								crea.id,
-								crea.team
+								crea.team,
 							),
 							arrayUtils.filterCreature(
 								G.grid.getHexMap(crea.x - 1, crea.y, 2, true, matrices.bellowrow),
 								true,
 								true,
 								crea.id,
-								crea.team
+								crea.team,
 							),
 							arrayUtils.filterCreature(
 								G.grid.getHexMap(crea.x - 2, crea.y + 2, 2, true, matrices.straitrow),
 								true,
 								true,
 								crea.id,
-								crea.team
-							)
-						)
+								crea.team,
+							),
+						),
 				];
 
 				G.grid.queryChoice({
@@ -381,7 +381,7 @@ export default G => {
 					requireCreature: 1,
 					id: crea.id,
 					flipped: crea.flipped,
-					choices: choices
+					choices: choices,
 				});
 			},
 
@@ -404,14 +404,14 @@ export default G => {
 								ability.damages1, // Damage Type
 								1, // Area
 								[], // Effects
-								G
-							)
+								G,
+							),
 						);
 
 						creaturesHit.push(choice[i].creature);
 					}
 				}
-			}
+			},
 		},
 
 		// 	Fourth Ability: Frozen Orb
@@ -431,7 +431,7 @@ export default G => {
 					!this.testDirection({
 						team: this._targetTeam,
 						directions: this.directions,
-						sourceCreature: this.creature
+						sourceCreature: this.creature,
 					})
 				) {
 					return false;
@@ -472,7 +472,7 @@ export default G => {
 					requireCreature: true,
 					x: crea.x,
 					y: crea.y,
-					sourceCreature: crea
+					sourceCreature: crea,
 				});
 			},
 
@@ -508,18 +508,18 @@ export default G => {
 						effectFn: function(eff) {
 							eff.target.stats.frozen = true;
 							this.deleteEffect();
-						}
+						},
 					},
-					G
+					G,
 				);
 
 				ability.areaDamage(
 					ability.creature,
 					ability.damages,
 					[effect], // Effects
-					trgs
+					trgs,
 				);
-			}
-		}
+			},
+		},
 	];
 };

--- a/src/animations.js
+++ b/src/animations.js
@@ -47,9 +47,9 @@ export class Animations {
 			// Ignore traps for hover creatures, unless this is the last hex
 			let enterHexOpts = $j.extend(
 				{
-					ignoreTraps: creature.movementType() !== 'normal' && hexId < path.length - 1
+					ignoreTraps: creature.movementType() !== 'normal' && hexId < path.length - 1,
 				},
-				opts
+				opts,
 			);
 
 			tween.onComplete.add(() => {
@@ -155,10 +155,10 @@ export class Animations {
 			.tween(creature.grp)
 			.to(
 				{
-					alpha: 0
+					alpha: 0,
 				},
 				500,
-				Phaser.Easing.Linear.None
+				Phaser.Easing.Linear.None,
 			)
 			.start();
 
@@ -175,10 +175,10 @@ export class Animations {
 				.tween(creature.grp)
 				.to(
 					{
-						alpha: 1
+						alpha: 1,
 					},
 					500,
-					Phaser.Easing.Linear.None
+					Phaser.Easing.Linear.None,
 				)
 				.start();
 
@@ -261,27 +261,27 @@ export class Animations {
 			dist = arrayUtils.filterCreature(path.slice(0), false, false).length,
 			emissionPoint = {
 				x: this2.creature.grp.x + startX,
-				y: this2.creature.grp.y + startY
+				y: this2.creature.grp.y + startY,
 			},
 			targetPoint = {
 				x: target.grp.x + 52,
-				y: target.grp.y - 20
+				y: target.grp.y - 20,
 			},
 			// Sprite id here
 			sprite = game.grid.creatureGroup.create(emissionPoint.x, emissionPoint.y, spriteId),
 			duration = dist * 75;
 
 		sprite.anchor.setTo(0.5);
-		sprite.rotation = -Math.PI / 3 + args.direction * Math.PI / 3;
+		sprite.rotation = -Math.PI / 3 + (args.direction * Math.PI) / 3;
 		let tween = game.Phaser.add
 			.tween(sprite)
 			.to(
 				{
 					x: targetPoint.x,
-					y: targetPoint.y
+					y: targetPoint.y,
 				},
 				duration,
-				Phaser.Easing.Linear.None
+				Phaser.Easing.Linear.None,
 			)
 			.start();
 

--- a/src/creature.js
+++ b/src/creature.js
@@ -56,7 +56,7 @@ export class Creature {
 		this.y = obj.y - 0;
 		this.pos = {
 			x: this.x,
-			y: this.y
+			y: this.y,
 		};
 		this.size = obj.size - 0;
 		this.type = obj.type;
@@ -110,7 +110,7 @@ export class Creature {
 			fatigueImmunity: false,
 			frozen: false,
 			// Extra energy required for abilities
-			reqEnergy: 0
+			reqEnergy: 0,
 		};
 
 		this.stats = $j.extend({}, this.baseStats); //Copy
@@ -124,7 +124,7 @@ export class Creature {
 			new Ability(this, 0, game),
 			new Ability(this, 1, game),
 			new Ability(this, 2, game),
-			new Ability(this, 3, game)
+			new Ability(this, 3, game),
 		];
 
 		this.updateHex();
@@ -178,7 +178,7 @@ export class Creature {
 		this.healthIndicatorSprite = this.healthIndicatorGroup.create(
 			this.player.flipped ? 19 : 19 + 90 * (this.size - 1),
 			49,
-			'p' + this.team + '_health'
+			'p' + this.team + '_health',
 		);
 		// Add text
 		this.healthIndicatorText = game.Phaser.add.text(
@@ -190,8 +190,8 @@ export class Creature {
 				fill: '#fff',
 				align: 'center',
 				stroke: '#000',
-				strokeThickness: 6
-			}
+				strokeThickness: 6,
+			},
 		);
 		this.healthIndicatorText.anchor.setTo(0.5, 0.5);
 		this.healthIndicatorGroup.add(this.healthIndicatorText);
@@ -229,10 +229,10 @@ export class Creature {
 				.tween(game.grid.materialize_overlay)
 				.to(
 					{
-						alpha: 0
+						alpha: 0,
 					},
 					500,
-					Phaser.Easing.Linear.None
+					Phaser.Easing.Linear.None,
 				)
 				.start();
 		}
@@ -241,10 +241,10 @@ export class Creature {
 			.tween(this.grp)
 			.to(
 				{
-					alpha: 1
+					alpha: 1,
 				},
 				500,
-				Phaser.Easing.Linear.None
+				Phaser.Easing.Linear.None,
 			)
 			.start();
 
@@ -327,7 +327,7 @@ export class Creature {
 				if (!game.turnThrottle) {
 					clearInterval(interval);
 					game.skipTurn({
-						tooltip: 'Frozen'
+						tooltip: 'Frozen',
 					});
 				}
 			}, 50);
@@ -461,8 +461,8 @@ export class Creature {
 						action: 'move',
 						target: {
 							x: hex.x,
-							y: hex.y
-						}
+							y: hex.y,
+						},
 					});
 					args.creature.delayable = false;
 					game.UI.btnDelay.changeState('disabled');
@@ -470,11 +470,11 @@ export class Creature {
 						animation: args.creature.movementType() === 'flying' ? 'fly' : 'walk',
 						callback: function() {
 							game.activeCreature.queryMove();
-						}
+						},
 					});
-				}
+				},
 			},
-			o
+			o,
 		);
 
 		if (!o.isAbility) {
@@ -503,7 +503,7 @@ export class Creature {
 			args.creature.tracePosition({
 				x: hex.x,
 				y: hex.y,
-				overlayClass: 'creature moveto selected player' + args.creature.team
+				overlayClass: 'creature moveto selected player' + args.creature.team,
 			});
 		};
 		let select = o.noPath || this.movementType() === 'flying' ? selectFlying : selectNormal;
@@ -514,7 +514,7 @@ export class Creature {
 					game.UI.btnSkipTurn.click();
 				},
 				fnOnCancel: function() {},
-				confirmText: 'Skip turn'
+				confirmText: 'Skip turn',
 			});
 		} else {
 			game.grid.queryHexes({
@@ -522,14 +522,14 @@ export class Creature {
 				fnOnConfirm: o.callback,
 				args: {
 					creature: this,
-					args: o.args
+					args: o.args,
 				}, // Optional args
 				size: this.size,
 				flipped: this.player.flipped,
 				id: this.id,
 				hexes: o.range,
 				ownCreatureHexShade: o.ownCreatureHexShade,
-				targeting: o.targeting
+				targeting: o.targeting,
 			});
 		}
 	}
@@ -552,7 +552,7 @@ export class Creature {
 		this.tracePosition({
 			x: hex.x,
 			y: hex.y,
-			overlayClass: 'hover h_player' + this.team
+			overlayClass: 'hover h_player' + this.team,
 		});
 	}
 
@@ -692,7 +692,7 @@ export class Creature {
 				ignorePath: false,
 				customMovementPoint: 0,
 				overrideSpeed: 0,
-				turnAroundOnComplete: true
+				turnAroundOnComplete: true,
 			},
 			path;
 
@@ -751,7 +751,7 @@ export class Creature {
 				x: item.x,
 				y: item.y,
 				displayClass: 'adj',
-				drawOverCreatureTiles: false
+				drawOverCreatureTiles: false,
 			});
 		}); // Trace path
 
@@ -762,7 +762,7 @@ export class Creature {
 			x: last.x,
 			y: last.y,
 			overlayClass: 'creature moveto selected player' + this.team,
-			drawOverCreatureTiles: false
+			drawOverCreatureTiles: false,
 		});
 	}
 
@@ -772,7 +772,7 @@ export class Creature {
 			y: this.y,
 			overlayClass: '',
 			displayClass: '',
-			drawOverCreatureTiles: true
+			drawOverCreatureTiles: true,
 		};
 
 		args = $j.extend(defaultArgs, args);
@@ -814,7 +814,7 @@ export class Creature {
 			game.grid.hexes[y][x],
 			this.size,
 			this.id,
-			this.game.grid
+			this.game.grid,
 		); // Calculate path
 	}
 
@@ -847,7 +847,7 @@ export class Creature {
 
 		return {
 			x: x,
-			y: y
+			y: y,
 		};
 	}
 
@@ -881,28 +881,28 @@ export class Creature {
 				c = [
 					{
 						y: this.y,
-						x: this.x + 1
+						x: this.x + 1,
 					},
 					{
 						y: this.y - 1,
-						x: this.x + o
+						x: this.x + o,
 					},
 					{
 						y: this.y - 1,
-						x: this.x - 1 + o
+						x: this.x - 1 + o,
 					},
 					{
 						y: this.y,
-						x: this.x - 1
+						x: this.x - 1,
 					},
 					{
 						y: this.y + 1,
-						x: this.x - 1 + o
+						x: this.x - 1 + o,
 					},
 					{
 						y: this.y + 1,
-						x: this.x + o
-					}
+						x: this.x + o,
+					},
 				];
 			}
 
@@ -910,36 +910,36 @@ export class Creature {
 				c = [
 					{
 						y: this.y,
-						x: this.x + 1
+						x: this.x + 1,
 					},
 					{
 						y: this.y - 1,
-						x: this.x + o
+						x: this.x + o,
 					},
 					{
 						y: this.y - 1,
-						x: this.x - 1 + o
+						x: this.x - 1 + o,
 					},
 					{
 						y: this.y - 1,
-						x: this.x - 2 + o
+						x: this.x - 2 + o,
 					},
 					{
 						y: this.y,
-						x: this.x - 2
+						x: this.x - 2,
 					},
 					{
 						y: this.y + 1,
-						x: this.x - 2 + o
+						x: this.x - 2 + o,
 					},
 					{
 						y: this.y + 1,
-						x: this.x - 1 + o
+						x: this.x - 1 + o,
 					},
 					{
 						y: this.y + 1,
-						x: this.x + o
-					}
+						x: this.x + o,
+					},
 				];
 			}
 
@@ -947,44 +947,44 @@ export class Creature {
 				c = [
 					{
 						y: this.y,
-						x: this.x + 1
+						x: this.x + 1,
 					},
 					{
 						y: this.y - 1,
-						x: this.x + o
+						x: this.x + o,
 					},
 					{
 						y: this.y - 1,
-						x: this.x - 1 + o
+						x: this.x - 1 + o,
 					},
 					{
 						y: this.y - 1,
-						x: this.x - 2 + o
+						x: this.x - 2 + o,
 					},
 					{
 						y: this.y - 1,
-						x: this.x - 3 + o
+						x: this.x - 3 + o,
 					},
 					{
 						y: this.y,
-						x: this.x - 3
+						x: this.x - 3,
 					},
 					{
 						y: this.y + 1,
-						x: this.x - 3 + o
+						x: this.x - 3 + o,
 					},
 					{
 						y: this.y + 1,
-						x: this.x - 2 + o
+						x: this.x - 2 + o,
 					},
 					{
 						y: this.y + 1,
-						x: this.x - 1 + o
+						x: this.x - 1 + o,
 					},
 					{
 						y: this.y + 1,
-						x: this.x + o
-					}
+						x: this.x + o,
+					},
 				];
 			}
 
@@ -1092,7 +1092,7 @@ export class Creature {
 
 		let defaultOpt = {
 			ignoreRetaliation: false,
-			isFromTrap: false
+			isFromTrap: false,
 		};
 
 		o = $j.extend(defaultOpt, o);
@@ -1124,7 +1124,7 @@ export class Creature {
 
 				return {
 					damages: 0,
-					kill: false
+					kill: false,
 				};
 			}
 
@@ -1148,7 +1148,7 @@ export class Creature {
 				return {
 					damages: dmg,
 					damageObj: damage,
-					kill: true
+					kill: true,
 				}; // Killed
 			}
 
@@ -1176,7 +1176,7 @@ export class Creature {
 			return {
 				damages: dmg,
 				damageObj: damage,
-				kill: false
+				kill: false,
 			}; // Not Killed
 		} else {
 			if (damage.status == 'Dodged') {
@@ -1207,7 +1207,7 @@ export class Creature {
 
 		return {
 			damageObj: damage,
-			kill: false
+			kill: false,
 		}; // Not killed
 	}
 
@@ -1334,22 +1334,22 @@ export class Creature {
 		let hintColor = {
 			confirm: {
 				fill: '#ffffff',
-				stroke: '#000000'
+				stroke: '#000000',
 			},
 			gamehintblack: {
 				fill: '#ffffff',
-				stroke: '#000000'
+				stroke: '#000000',
 			},
 			healing: {
-				fill: '#00ff00'
+				fill: '#00ff00',
 			},
 			msg_effects: {
-				fill: '#ffff00'
+				fill: '#ffff00',
 			},
 			creature_name: {
 				fill: '#ffffff',
-				stroke: '#AAAAAA'
-			}
+				stroke: '#AAAAAA',
+			},
 		};
 
 		let style = $j.extend(
@@ -1358,9 +1358,9 @@ export class Creature {
 				fill: '#ff0000',
 				align: 'center',
 				stroke: '#000000',
-				strokeThickness: 2
+				strokeThickness: 2,
 			},
-			hintColor[cssClass]
+			hintColor[cssClass],
 		);
 
 		// Remove constant element
@@ -1372,10 +1372,10 @@ export class Creature {
 						.tween(grpHintElem)
 						.to(
 							{
-								alpha: 0
+								alpha: 0,
 							},
 							tooltipSpeed,
-							tooltipTransition
+							tooltipTransition,
 						)
 						.start();
 					grpHintElem.tweenAlpha.onComplete.add(function() {
@@ -1384,7 +1384,7 @@ export class Creature {
 				}
 			},
 			this,
-			true
+			true,
 		);
 
 		let hint = game.Phaser.add.text(0, 50, text, style);
@@ -1398,10 +1398,10 @@ export class Creature {
 				.tween(hint)
 				.to(
 					{
-						alpha: 1
+						alpha: 1,
 					},
 					tooltipSpeed,
-					tooltipTransition
+					tooltipTransition,
 				)
 				.start();
 		} else {
@@ -1409,24 +1409,24 @@ export class Creature {
 				.tween(hint)
 				.to(
 					{
-						alpha: 1
+						alpha: 1,
 					},
 					tooltipSpeed,
-					tooltipTransition
+					tooltipTransition,
 				)
 				.to(
 					{
-						alpha: 1
+						alpha: 1,
 					},
 					tooltipDisplaySpeed,
-					tooltipTransition
+					tooltipTransition,
 				)
 				.to(
 					{
-						alpha: 0
+						alpha: 0,
 					},
 					tooltipSpeed,
-					tooltipTransition
+					tooltipTransition,
 				)
 				.start();
 			hint.tweenAlpha.onComplete.add(function() {
@@ -1450,15 +1450,15 @@ export class Creature {
 					.tween(grpHintElem)
 					.to(
 						{
-							y: offset
+							y: offset,
 						},
 						tooltipSpeed,
-						tooltipTransition
+						tooltipTransition,
 					)
 					.start();
 			},
 			this,
-			true
+			true,
 		);
 	}
 
@@ -1534,7 +1534,7 @@ export class Creature {
 		if (!game.firstKill && !isDeny) {
 			// First Kill
 			this.killer.score.push({
-				type: 'firstKill'
+				type: 'firstKill',
 			});
 			game.firstKill = true;
 		}
@@ -1545,13 +1545,13 @@ export class Creature {
 				// TEAM KILL (DENY)
 				this.killer.score.push({
 					type: 'deny',
-					creature: this
+					creature: this,
 				});
 			} else {
 				// Humiliation
 				this.killer.score.push({
 					type: 'humiliation',
-					player: this.team
+					player: this.team,
 				});
 			}
 		}
@@ -1562,13 +1562,13 @@ export class Creature {
 				// TEAM KILL (DENY)
 				this.killer.score.push({
 					type: 'deny',
-					creature: this
+					creature: this,
 				});
 			} else {
 				// KILL
 				this.killer.score.push({
 					type: 'kill',
-					creature: this
+					creature: this,
 				});
 			}
 		}
@@ -1589,7 +1589,7 @@ export class Creature {
 			// ANNIHILATION
 			this.killer.score.push({
 				type: 'annihilation',
-				player: this.team
+				player: this.team,
 			});
 		}
 
@@ -1602,20 +1602,20 @@ export class Creature {
 			.tween(this.sprite)
 			.to(
 				{
-					alpha: 0
+					alpha: 0,
 				},
 				500,
-				Phaser.Easing.Linear.None
+				Phaser.Easing.Linear.None,
 			)
 			.start();
 		let tweenHealth = game.Phaser.add
 			.tween(this.healthIndicatorGroup)
 			.to(
 				{
-					alpha: 0
+					alpha: 0,
 				},
 				500,
-				Phaser.Easing.Linear.None
+				Phaser.Easing.Linear.None,
 			)
 			.start();
 		tweenSprite.onComplete.add(() => {
@@ -1653,7 +1653,9 @@ export class Creature {
 	 * shortcut convenience function to grid.getHexMap
 	 */
 	getHexMap(map, invertFlipped) {
-		let x = (this.player.flipped ? !invertFlipped : invertFlipped)
+		let x = (this.player.flipped
+		? !invertFlipped
+		: invertFlipped)
 			? this.x + 1 - this.size
 			: this.x;
 		return this.game.grid.getHexMap(
@@ -1661,7 +1663,7 @@ export class Creature {
 			this.y - map.origin[1],
 			0 - map.origin[0],
 			this.player.flipped ? !invertFlipped : invertFlipped,
-			map
+			map,
 		);
 	}
 
@@ -1670,7 +1672,7 @@ export class Creature {
 			debuff = 0,
 			buffObjs = {
 				effects: [],
-				drops: []
+				drops: [],
 			};
 
 		let addToBuffObjs = function(obj) {
@@ -1731,7 +1733,7 @@ export class Creature {
 		return {
 			buff: 0,
 			debuff: debuff,
-			objs: buffObjs
+			objs: buffObjs,
 		};
 	}
 
@@ -1756,10 +1758,10 @@ export class Creature {
 				.tween(this.grp)
 				.to(
 					{
-						alpha: 0.5
+						alpha: 0.5,
 					},
 					250,
-					Phaser.Easing.Linear.None
+					Phaser.Easing.Linear.None,
 				)
 				.start();
 		} else {
@@ -1767,10 +1769,10 @@ export class Creature {
 				.tween(this.grp)
 				.to(
 					{
-						alpha: 1
+						alpha: 1,
 					},
 					250,
-					Phaser.Easing.Linear.None
+					Phaser.Easing.Linear.None,
 				)
 				.start();
 		}

--- a/src/damage.js
+++ b/src/damage.js
@@ -29,7 +29,7 @@ export class Damage {
 		let trg = this.target.stats,
 			atk = this.attacker.stats,
 			returnObj = {
-				total: 0
+				total: 0,
 			};
 
 		// Damage calculation
@@ -41,7 +41,7 @@ export class Damage {
 				points = value;
 			} else {
 				points = Math.round(
-					value * (1 + (atk.offense - trg.defense / this.area + atk[key] - trg[key]) / 100)
+					value * (1 + (atk.offense - trg.defense / this.area + atk[key] - trg[key]) / 100),
 				);
 				// For debugging purposes
 				if (this.game.debugMode) {
@@ -63,7 +63,7 @@ export class Damage {
 							trg[key] +
 							'trg' +
 							key +
-							' )/100)'
+							' )/100)',
 					);
 				}
 			}

--- a/src/drops.js
+++ b/src/drops.js
@@ -7,7 +7,7 @@ export class Drop {
 		this.y = y;
 		this.pos = {
 			x: x,
-			y: y
+			y: y,
 		};
 		this.health = health;
 		this.energy = energy;
@@ -18,7 +18,7 @@ export class Drop {
 		this.display = game.grid.dropGroup.create(
 			this.hex.displayPos.x + 54,
 			this.hex.displayPos.y + 15,
-			'drop_' + this.name
+			'drop_' + this.name,
 		);
 		this.display.alpha = 0;
 		this.display.anchor.setTo(0.5, 0.5);
@@ -27,10 +27,10 @@ export class Drop {
 			.tween(this.display)
 			.to(
 				{
-					alpha: 1
+					alpha: 1,
 				},
 				500,
-				Phaser.Easing.Linear.None
+				Phaser.Easing.Linear.None,
 			)
 			.start();
 	}
@@ -56,7 +56,7 @@ export class Drop {
 			game.log('%CreatureName' + creature.id + '% gains ' + this.energy + ' energy');
 		}
 		creature.player.score.push({
-			type: 'pickupDrop'
+			type: 'pickupDrop',
 		});
 
 		creature.updateAlteration(); // Will cap the stats
@@ -65,10 +65,10 @@ export class Drop {
 			.tween(this.display)
 			.to(
 				{
-					alpha: 0
+					alpha: 0,
 				},
 				500,
-				Phaser.Easing.Linear.None
+				Phaser.Easing.Linear.None,
 			)
 			.start();
 

--- a/src/effect.js
+++ b/src/effect.js
@@ -36,9 +36,9 @@ export class Effect {
 				stackable: true,
 				noLog: false,
 				specialHint: undefined, // Special hint for log
-				deleteOnOwnerDeath: false
+				deleteOnOwnerDeath: false,
 			},
-			optArgs
+			optArgs,
 		);
 
 		$j.extend(this, args);

--- a/src/game.js
+++ b/src/game.js
@@ -141,9 +141,11 @@ export default class Game {
 					selectUnit: 'Please select an available unit from the left grid',
 					lowPlasma: 'Low Plasma! Cannot materialize the selected unit',
 					// plasmaCost :    String :    plasma cost of the unit to materialize
-					materializeUnit: plasmaCost => { return 'Materialize unit at target location for ' + plasmaCost + ' plasma'; },
+					materializeUnit: plasmaCost => {
+						return 'Materialize unit at target location for ' + plasmaCost + ' plasma';
+					},
 					materializeUsed: 'Materialization has already been used this round',
-					heavyDev: 'This unit is currently under heavy development'
+					heavyDev: 'This unit is currently under heavy development',
 				},
 			},
 		};

--- a/src/sound/bufferloader.js
+++ b/src/sound/bufferloader.js
@@ -31,7 +31,7 @@ export class BufferLoader {
 				},
 				error => {
 					console.error('decodeAudioData error', error);
-				}
+				},
 			);
 		};
 

--- a/src/sound/soundsys.js
+++ b/src/sound/soundsys.js
@@ -10,9 +10,9 @@ export class SoundSys {
 				music_volume: 0.1,
 				effects_volume: 0.6,
 				heartbeats_volume: 0.3,
-				announcer_volume: 0.6
+				announcer_volume: 0.6,
 			},
-			o || {}
+			o || {},
 		);
 
 		$j.extend(this, o);

--- a/src/ui/button.js
+++ b/src/ui/button.js
@@ -28,8 +28,8 @@ export class Button {
 				glowing: {},
 				selected: {},
 				active: {},
-				normal: {}
-			}
+				normal: {},
+			},
 		};
 
 		opts = $j.extend(defaultOpts, opts);

--- a/src/ui/chat.js
+++ b/src/ui/chat.js
@@ -95,7 +95,7 @@ export class Chat {
 			lastMessage.amount++;
 			lastMessage.time = currentTime;
 			$j(lastMessage.DOMObject).html(
-				this.createHTMLTemplate(msg, lastMessage.amount, currentTime, false)
+				this.createHTMLTemplate(msg, lastMessage.amount, currentTime, false),
 			);
 		} else {
 			this.messages.push({
@@ -103,7 +103,7 @@ export class Chat {
 				amount: 1,
 				time: currentTime,
 				class: htmlClass,
-				DOMObject: $j.parseHTML(this.createHTMLTemplate(msg, 1, currentTime, true, htmlClass))
+				DOMObject: $j.parseHTML(this.createHTMLTemplate(msg, 1, currentTime, true, htmlClass)),
 			});
 
 			// Append the last message's DOM object

--- a/src/ui/progressbar.js
+++ b/src/ui/progressbar.js
@@ -6,7 +6,7 @@ export class ProgressBar {
 			height: 318,
 			width: 9,
 			color: 'red',
-			$bar: undefined
+			$bar: undefined,
 		};
 
 		this.game = game;
@@ -28,7 +28,7 @@ export class ProgressBar {
 		this.$bar.css({
 			width: this.width,
 			height: this.height * percentage,
-			'background-color': this.color
+			'background-color': this.color,
 		});
 	}
 
@@ -42,10 +42,10 @@ export class ProgressBar {
 			{
 				queue: false,
 				width: this.width,
-				height: this.height * percentage
+				height: this.height * percentage,
 			},
 			500,
-			'linear'
+			'linear',
 		);
 	}
 
@@ -58,10 +58,10 @@ export class ProgressBar {
 		this.$preview.css(
 			{
 				width: this.width - 2,
-				height: (this.height - 2) * percentage
+				height: (this.height - 2) * percentage,
 			},
 			500,
-			'linear'
+			'linear',
 		);
 	}
 }

--- a/src/utility/gamelog.js
+++ b/src/utility/gamelog.js
@@ -72,7 +72,7 @@ export class GameLog {
 					clearInterval(interval);
 					game.activeCreature.queryMove(); // Avoid bug
 					game.action(this.data[this.timeCursor], {
-						callback: fun
+						callback: fun,
 					});
 				}
 			}, 100);
@@ -105,7 +105,7 @@ export class GameLog {
 				game.action(this.data[this.timeCursor], {
 					callback: function() {
 						game.activeCreature.queryMove();
-					}
+					},
 				});
 			}
 		}, 100);
@@ -115,7 +115,7 @@ export class GameLog {
 		let config = isEmpty(this.gameConfig) ? getGameConfig() : this.gameConfig,
 			dict = {
 				config: config,
-				log: this.data
+				log: this.data,
 			},
 			json = JSON.stringify(dict),
 			hash = 'AB-' + this.game.version + ':' + btoa(JSON.stringify(dict)),

--- a/src/utility/hex.js
+++ b/src/utility/hex.js
@@ -47,7 +47,7 @@ export class Hex {
 		this.y = y;
 		this.pos = {
 			x: x,
-			y: y
+			y: y,
 		};
 		this.coord = String.fromCharCode(64 + this.y + 1) + (this.x + 1);
 		game = this.game;
@@ -68,10 +68,10 @@ export class Hex {
 
 		// Horizontal hex grid, width is distance between opposite sides
 		this.width = 90;
-		this.height = this.width / Math.sqrt(3) * 2 * 0.75;
+		this.height = (this.width / Math.sqrt(3)) * 2 * 0.75;
 		this.displayPos = {
 			x: (y % 2 === 0 ? x + 0.5 : x) * this.width,
-			y: y * this.height
+			y: y * this.height,
 		};
 
 		this.originalDisplayPos = $j.extend({}, this.displayPos);
@@ -419,8 +419,8 @@ export class Hex {
 					{
 						font: '30pt Play',
 						fill: '#000000',
-						align: 'center'
-					}
+						align: 'center',
+					},
 				);
 				this.coordText.anchor.setTo(0.5, 0.5);
 				this.grid.overhexesGroup.add(this.coordText);
@@ -520,7 +520,7 @@ export class Hex {
 	toJSON() {
 		return {
 			x: this.x,
-			y: this.y
+			y: this.y,
 		};
 	}
 } // End of Hex Class

--- a/src/utility/matrices.js
+++ b/src/utility/matrices.js
@@ -7,7 +7,7 @@ export const diagonalup = [
 	[0, 0, 1, 0, 0],
 	[0, 1, 0, 0, 0],
 	[0, 1, 0, 0, 0],
-	[1, 0, 0, 0, 0]
+	[1, 0, 0, 0, 0],
 ];
 
 diagonalup.origin = [4, 0];
@@ -21,7 +21,7 @@ export const diagonaldown = [
 	[0, 0, 0, 1, 0],
 	[0, 0, 0, 1, 0],
 	[0, 0, 0, 0, 1],
-	[0, 0, 0, 0, 1]
+	[0, 0, 0, 0, 1],
 ];
 
 diagonaldown.origin = [0, 0];
@@ -31,7 +31,7 @@ straitrow.origin = [0, 0];
 
 export const bellowrow = [
 	[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], // Origin line
-	[0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+	[0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
 ];
 
 bellowrow.origin = [0, 0];
@@ -40,7 +40,7 @@ export const frontnback2hex = [
 	[0, 0, 0, 0],
 	[0, 1, 0, 1],
 	[1, 0, 0, 1], // Origin line
-	[0, 1, 0, 1]
+	[0, 1, 0, 1],
 ];
 
 frontnback2hex.origin = [2, 2];
@@ -49,7 +49,7 @@ export const frontnback3hex = [
 	[0, 0, 0, 0, 0],
 	[0, 1, 0, 0, 1],
 	[1, 0, 0, 0, 1], // Origin line
-	[0, 1, 0, 0, 1]
+	[0, 1, 0, 0, 1],
 ];
 
 frontnback3hex.origin = [3, 2];
@@ -58,7 +58,7 @@ export const front2hex = [
 	[0, 0, 0, 0],
 	[0, 0, 0, 1],
 	[0, 0, 0, 1], // Origin line
-	[0, 0, 0, 1]
+	[0, 0, 0, 1],
 ];
 
 front2hex.origin = [2, 2];
@@ -67,7 +67,7 @@ export const back2hex = [
 	[0, 0, 0, 0],
 	[0, 1, 0, 0],
 	[1, 0, 0, 0], // Origin line
-	[0, 1, 0, 0]
+	[0, 1, 0, 0],
 ];
 
 back2hex.origin = [2, 2];
@@ -76,7 +76,7 @@ export const inlinefront2hex = [
 	[0, 0, 0, 0],
 	[0, 0, 0, 0],
 	[0, 0, 0, 1], // Origin line
-	[0, 0, 0, 0]
+	[0, 0, 0, 0],
 ];
 
 inlinefront2hex.origin = [2, 2];
@@ -85,7 +85,7 @@ export const inlineback2hex = [
 	[0, 0, 0, 0],
 	[0, 0, 0, 0],
 	[1, 0, 0, 0], // Origin line
-	[0, 0, 0, 0]
+	[0, 0, 0, 0],
 ];
 
 inlineback2hex.origin = [2, 2];
@@ -94,7 +94,7 @@ export const inlinefrontnback2hex = [
 	[0, 0, 0, 0],
 	[0, 0, 0, 0],
 	[1, 0, 0, 1], // Origin line
-	[0, 0, 0, 0]
+	[0, 0, 0, 0],
 ];
 
 inlinefrontnback2hex.origin = [2, 2];
@@ -103,7 +103,7 @@ export const front1hex = [
 	[0, 0, 0],
 	[0, 0, 1],
 	[0, 0, 1], // Origin line
-	[0, 0, 1]
+	[0, 0, 1],
 ];
 
 front1hex.origin = [1, 2];
@@ -112,7 +112,7 @@ export const backtop1hex = [
 	[0, 0, 0],
 	[0, 1, 0],
 	[0, 0, 0], // Origin line
-	[0, 0, 0]
+	[0, 0, 0],
 ];
 
 backtop1hex.origin = [1, 2];
@@ -121,7 +121,7 @@ export const inlineback1hex = [
 	[0, 0, 0],
 	[0, 0, 0],
 	[1, 0, 0], // Origin line
-	[0, 0, 0]
+	[0, 0, 0],
 ];
 
 inlineback1hex.origin = [1, 2];
@@ -130,7 +130,7 @@ export const backbottom1hex = [
 	[0, 0, 0],
 	[0, 0, 0],
 	[0, 0, 0], // Origin line
-	[0, 1, 0]
+	[0, 1, 0],
 ];
 
 backbottom1hex.origin = [1, 2];
@@ -139,7 +139,7 @@ export const fronttop1hex = [
 	[0, 0, 0],
 	[0, 0, 1],
 	[0, 0, 0], // Origin line
-	[0, 0, 0]
+	[0, 0, 0],
 ];
 
 fronttop1hex.origin = [1, 2];
@@ -148,7 +148,7 @@ export const inlinefront1hex = [
 	[0, 0, 0],
 	[0, 0, 0],
 	[0, 0, 1], // Origin line
-	[0, 0, 0]
+	[0, 0, 0],
 ];
 
 inlinefront1hex.origin = [1, 2];
@@ -157,7 +157,7 @@ export const frontbottom1hex = [
 	[0, 0, 0],
 	[0, 0, 0],
 	[0, 0, 0], // Origin line
-	[0, 0, 1]
+	[0, 0, 1],
 ];
 
 frontbottom1hex.origin = [1, 2];
@@ -166,7 +166,7 @@ export const headlessBoomerang = [
 	[0, 0, 0, 0, 0],
 	[0, 1, 1, 1, 1],
 	[0, 1, 1, 1, 1], //origin line
-	[0, 1, 1, 1, 1]
+	[0, 1, 1, 1, 1],
 ];
 
 headlessBoomerang.origin = [0, 2];
@@ -175,7 +175,7 @@ export const headlessBoomerangUpgraded = [
 	[0, 0, 0, 0, 0, 0],
 	[0, 1, 1, 1, 1, 1],
 	[0, 1, 1, 1, 1, 1], //origin line
-	[0, 1, 1, 1, 1, 1]
+	[0, 1, 1, 1, 1, 1],
 ];
 
 headlessBoomerangUpgraded.origin = [0, 2];

--- a/src/utility/team.js
+++ b/src/utility/team.js
@@ -2,7 +2,7 @@ export const Team = Object.freeze({
 	enemy: 1,
 	ally: 2,
 	same: 3,
-	both: 4
+	both: 4,
 });
 
 /** isTeam

--- a/src/utility/trap.js
+++ b/src/utility/trap.js
@@ -27,7 +27,7 @@ export class Trap {
 			ownerCreature: undefined, // Needed for fullTurnLifetime
 			destroyOnActivate: false,
 			typeOver: undefined,
-			destroyAnimation: undefined
+			destroyAnimation: undefined,
 		};
 
 		$j.extend(this, o, opt);
@@ -51,7 +51,7 @@ export class Trap {
 			this.displayOver = game.grid.trapOverGroup.create(
 				pos.x + this.hex.width / 2,
 				pos.y + 60,
-				spriteName
+				spriteName,
 			);
 			this.displayOver.anchor.setTo(0.5);
 			this.displayOver.scale.x *= -1;
@@ -70,10 +70,10 @@ export class Trap {
 						.tween(sprite.scale)
 						.to(
 							{
-								y: 0
+								y: 0,
 							},
 							tweenDuration,
-							Phaser.Easing.Linear.None
+							Phaser.Easing.Linear.None,
 						)
 						.start();
 					tween.onComplete.add(() => {
@@ -99,10 +99,10 @@ export class Trap {
 		duration = duration - 0; // Avoid undefined
 		this.game.Phaser.add.tween(this.display).to(
 			{
-				alpha: 0
+				alpha: 0,
 			},
 			duration,
-			Phaser.Easing.Linear.None
+			Phaser.Easing.Linear.None,
 		);
 	}
 
@@ -110,10 +110,10 @@ export class Trap {
 		duration = duration - 0; // Avoid undefined
 		this.game.Phaser.add.tween(this.display).to(
 			{
-				alpha: 1
+				alpha: 1,
 			},
 			duration,
-			Phaser.Easing.Linear.None
+			Phaser.Easing.Linear.None,
 		);
 	}
 }


### PR DESCRIPTION
Resolves #1605 

I removed eslint-prettier-cli since it's not needed: `eslint-plugin-prettier` handles eslint for us.
Also removed the consitent newline rules since those get handles by prettier. 


<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1625"><img src="https://gitpod.io/api/apps/github/pbs/github.com/RobinVdBroeck/AncientBeast.git/71f57ee6619715037915f4ea100ddc4c37a723cd.svg" /></a>

