### PR TITLE
slide out already used abilities #1562

### DIFF
--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -404,8 +404,8 @@
 
 #leftpanel .button{
 	background-color: rgba(0, 0, 0, 0.55);
-	&.disabled{
 	transition: transform .5s;
+	&.disabled{	
 	transform: translateX(-50%);
 		&:hover{
 			transform: translateX(0%);
@@ -414,8 +414,8 @@
 }
 #rightpanel .button{
 	background-color: rgba(0, 0, 0, 0.55);
-	&.disabled{
 	transition: transform .5s;
+	&.disabled{	
 	transform: translateX(50%);
 		&:hover{
 			transform:translateX(0);

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -348,7 +348,6 @@
 
 	&.ability {
 		cursor: help !important;
-		
 	}
 }
 

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -299,7 +299,6 @@
 }
 
 #rightpanel {
-	background: rgba(0, 0, 0, 0.55);
 	position: absolute;
 	right: 20px;
 	top: 100px;
@@ -349,6 +348,7 @@
 
 	&.ability {
 		cursor: help !important;
+		
 	}
 }
 
@@ -403,6 +403,26 @@
 	color: red;
 }
 
+#leftpanel .button{
+	background-color: rgba(0, 0, 0, 0.55);
+	&.disabled{
+	transition: transform .5s;
+	transform: translateX(-50%);
+		&:hover{
+			transform: translateX(0%);
+		}
+	}
+}
+#rightpanel .button{
+	background-color: rgba(0, 0, 0, 0.55);
+	&.disabled{
+	transition: transform .5s;
+	transform: translateX(50%);
+		&:hover{
+			transform:translateX(0);
+		}
+	}
+}
 // Card anchor refactor
 div.section.info {
 	position: relative;
@@ -933,9 +953,6 @@ div.section.info {
 	display: block;
 }
 
-#abilities {
-	background: rgba(0, 0, 0, 0.55);
-}
 
 .button + .desc {
 	position: absolute;
@@ -1289,6 +1306,7 @@ span.pure {
 #rightpanel .progressbar {
 	right: -20px;
 }
+
 
 .progressbar .bar {
 	display: block;


### PR DESCRIPTION
This pull request slides out disabled buttons and adds hover behavior. It also removes the background color from abilities and right panel and applies to buttons so the buttons  won't have black background.

<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1632"><img src="https://gitpod.io/api/apps/github/pbs/github.com/rianconley/AncientBeast.git/38d135676a731e0f19e2410de41589d508aa5373.svg" /></a>


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1562: slide out already used abilities](https://issuehunt.io/repos/2089437/issues/1562)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->