### PR TITLE
Ability turn around

### DIFF
--- a/src/abilities/Abolished.js
+++ b/src/abilities/Abolished.js
@@ -251,7 +251,7 @@ export default (G) => {
 			},
 			query() {
 				let ability = this;
-				console.log('query' + this.creature.pos);
+				console.log('query' + this.creature.pos.y);
 
 				let crea = this.creature;
 
@@ -279,7 +279,7 @@ export default (G) => {
 			},
 			activate() {
 				let ability = this;
-				console.log('activate' + this.creature.pos);
+				console.log('activate' + this.creature.pos.x);
 
 				ability.end();
 

--- a/src/abilities/Abolished.js
+++ b/src/abilities/Abolished.js
@@ -279,6 +279,9 @@ export default (G) => {
 			},
 			activate() {
 				let ability = this;
+				this.creature.faceHex(this.creature.hexagons[1]);
+				this.creature.faceHex(this.creature.hexagons[1]);
+
 				this.creature.facePlayerDefault();
 				console.log('posX' + this.creature.pos.x);
 				console.log('posY' + this.creature.pos.y);

--- a/src/abilities/Abolished.js
+++ b/src/abilities/Abolished.js
@@ -278,7 +278,7 @@ export default (G) => {
 			},
 			activate() {
 				let ability = this;
-				console.log(ability.getTargets(crea.adjacentHexes(1)));
+				console.log(ability.getTargets(this.creature.adjacentHexes(1)));
 
 				ability.end();
 

--- a/src/abilities/Abolished.js
+++ b/src/abilities/Abolished.js
@@ -256,7 +256,6 @@ export default (G) => {
 				let crea = this.creature;
 
 				// var inRangeCreatures = crea.hexagons[1].adjacentHex(1);
-				//this.creature.faceHex(this.creature.hexagons[2]);
 
 				let range = crea.adjacentHexes(1);
 
@@ -279,16 +278,6 @@ export default (G) => {
 			},
 			activate() {
 				let ability = this;
-				this.creature.faceHex(this.creature.hexagons[1]);
-				this.creature.faceHex(this.creature.hexagons[1]);
-
-				this.creature.facePlayerDefault();
-				console.log('posX' + this.creature.pos.x);
-				console.log('posY' + this.creature.pos.y);
-				console.log('hex0X' + this.creature.hexagons[0].x);
-				console.log('hex0Y' + this.creature.hexagons[0].y);
-				console.log('hex1X' + this.creature.hexagons[1].x);
-				console.log('hex1Y' + this.creature.hexagons[1].y);
 
 				ability.end();
 

--- a/src/abilities/Abolished.js
+++ b/src/abilities/Abolished.js
@@ -279,6 +279,7 @@ export default (G) => {
 			},
 			activate() {
 				let ability = this;
+				this.creature.facePlayerDefault();
 				console.log('posX' + this.creature.pos.x);
 				console.log('posY' + this.creature.pos.y);
 				console.log('hex0X' + this.creature.hexagons[0].x);

--- a/src/abilities/Abolished.js
+++ b/src/abilities/Abolished.js
@@ -251,6 +251,7 @@ export default (G) => {
 			},
 			query() {
 				let ability = this;
+
 				let crea = this.creature;
 
 				// var inRangeCreatures = crea.hexagons[1].adjacentHex(1);
@@ -277,14 +278,13 @@ export default (G) => {
 			},
 			activate() {
 				let ability = this;
+				console.log(ability.getTargets(crea.adjacentHexes(1)));
 
 				ability.end();
 
 				let crea = this.creature;
 				let aoe = crea.adjacentHexes(1);
 				let targets = ability.getTargets(aoe);
-
-				console.log(targets);
 
 				if (this.isUpgraded()) {
 					this.damages.burn = 30;

--- a/src/abilities/Abolished.js
+++ b/src/abilities/Abolished.js
@@ -254,7 +254,7 @@ export default (G) => {
 				let crea = this.creature;
 
 				// var inRangeCreatures = crea.hexagons[1].adjacentHex(1);
-				this.creature.faceHex(this.creature.hexagons[0]);
+				this.creature.faceHex(this.creature.hexagons[2]);
 
 				let range = crea.adjacentHexes(1);
 

--- a/src/abilities/Abolished.js
+++ b/src/abilities/Abolished.js
@@ -251,6 +251,7 @@ export default (G) => {
 			},
 			query() {
 				let ability = this;
+				console.log('query' + this.creature.pos);
 
 				let crea = this.creature;
 
@@ -278,7 +279,7 @@ export default (G) => {
 			},
 			activate() {
 				let ability = this;
-				console.log(ability.getTargets(this.creature.adjacentHexes(1)));
+				console.log('activate' + this.creature.pos);
 
 				ability.end();
 

--- a/src/abilities/Abolished.js
+++ b/src/abilities/Abolished.js
@@ -257,7 +257,6 @@ export default (G) => {
 				//this.creature.faceHex(this.creature.hexagons[2]);
 
 				let range = crea.adjacentHexes(1);
-				console.log(ability.getTargets(range));
 
 				G.grid.queryHexes({
 					fnOnConfirm: function () {
@@ -284,6 +283,8 @@ export default (G) => {
 				let crea = this.creature;
 				let aoe = crea.adjacentHexes(1);
 				let targets = ability.getTargets(aoe);
+
+				console.log(targets);
 
 				if (this.isUpgraded()) {
 					this.damages.burn = 30;

--- a/src/abilities/Abolished.js
+++ b/src/abilities/Abolished.js
@@ -254,7 +254,7 @@ export default (G) => {
 				let crea = this.creature;
 
 				// var inRangeCreatures = crea.hexagons[1].adjacentHex(1);
-				this.creature.faceHex(this.creature.hexagons[2]);
+				//this.creature.faceHex(this.creature.hexagons[2]);
 
 				let range = crea.adjacentHexes(1);
 

--- a/src/abilities/Abolished.js
+++ b/src/abilities/Abolished.js
@@ -256,9 +256,8 @@ export default (G) => {
 				// var inRangeCreatures = crea.hexagons[1].adjacentHex(1);
 				//this.creature.faceHex(this.creature.hexagons[2]);
 
-				console.log(ability.getTargets);
-
 				let range = crea.adjacentHexes(1);
+				console.log(ability.getTargets(range));
 
 				G.grid.queryHexes({
 					fnOnConfirm: function () {

--- a/src/abilities/Abolished.js
+++ b/src/abilities/Abolished.js
@@ -252,7 +252,6 @@ export default (G) => {
 			query() {
 				let ability = this;
 				let crea = this.creature;
-				this.creature.faceHex(this.creature.hexagons[1]);
 
 				// var inRangeCreatures = crea.hexagons[1].adjacentHex(1);
 
@@ -277,6 +276,8 @@ export default (G) => {
 			},
 			activate() {
 				let ability = this;
+				this.creature.faceHex(this.creature.hexagons[0]);
+
 				ability.end();
 
 				let crea = this.creature;

--- a/src/abilities/Abolished.js
+++ b/src/abilities/Abolished.js
@@ -256,6 +256,8 @@ export default (G) => {
 				// var inRangeCreatures = crea.hexagons[1].adjacentHex(1);
 				//this.creature.faceHex(this.creature.hexagons[2]);
 
+				console.log(ability.getTargets);
+
 				let range = crea.adjacentHexes(1);
 
 				G.grid.queryHexes({

--- a/src/abilities/Abolished.js
+++ b/src/abilities/Abolished.js
@@ -254,6 +254,7 @@ export default (G) => {
 				let crea = this.creature;
 
 				// var inRangeCreatures = crea.hexagons[1].adjacentHex(1);
+				this.creature.faceHex(this.creature.hexagons[0]);
 
 				let range = crea.adjacentHexes(1);
 
@@ -276,7 +277,6 @@ export default (G) => {
 			},
 			activate() {
 				let ability = this;
-				this.creature.faceHex(this.creature.hexagons[0]);
 
 				ability.end();
 

--- a/src/abilities/Abolished.js
+++ b/src/abilities/Abolished.js
@@ -279,7 +279,12 @@ export default (G) => {
 			},
 			activate() {
 				let ability = this;
-				console.log('activate' + this.creature.pos.x);
+				console.log('posX' + this.creature.pos.x);
+				console.log('posY' + this.creature.pos.y);
+				console.log('hex0X' + this.creature.hexagons[0].x);
+				console.log('hex0Y' + this.creature.hexagons[0].y);
+				console.log('hex1X' + this.creature.hexagons[1].x);
+				console.log('hex1Y' + this.creature.hexagons[1].y);
 
 				ability.end();
 

--- a/src/abilities/Abolished.js
+++ b/src/abilities/Abolished.js
@@ -252,6 +252,7 @@ export default (G) => {
 			query() {
 				let ability = this;
 				let crea = this.creature;
+				this.creature.faceHex(this.creature.hexagons[1]);
 
 				// var inRangeCreatures = crea.hexagons[1].adjacentHex(1);
 

--- a/src/ability.js
+++ b/src/ability.js
@@ -283,7 +283,7 @@ export class Ability {
 		console.log('here');
 		console.log(args[0]);
 
-		this.creature.faceHex(args[0]);
+		//this.creature.faceHex(args[0]);
 
 		// Force creatures to face towards their target
 		if (args[0] instanceof Creature) {

--- a/src/ability.js
+++ b/src/ability.js
@@ -283,6 +283,7 @@ export class Ability {
 
 		// Force creatures to face towards their target
 		if (args[0] instanceof Creature) {
+			console.log(args[0]);
 			this.creature.faceHex(args[0]);
 		}
 		// Play animations and sounds only for active abilities

--- a/src/ability.js
+++ b/src/ability.js
@@ -278,13 +278,13 @@ export class Ability {
 		let p1 = p0;
 		let p2 = p0;
 
-		/*p1 += this.creature.player.flipped ? 5 : -5;
-		p2 += this.creature.player.flipped ? -5 : 5;*/
+		p1 += this.creature.player.flipped ? 5 : -5;
+		p2 += this.creature.player.flipped ? -5 : 5;
 
 		// Force creatures to face towards their target
-		/*	if (args[0] instanceof Creature) {
+		if (args[0] instanceof Creature) {
 			this.creature.faceHex(args[0]);
-		}*/
+		}
 		// Play animations and sounds only for active abilities
 		if (this.getTrigger() === 'onQuery') {
 			let animId = Math.random();

--- a/src/ability.js
+++ b/src/ability.js
@@ -278,8 +278,8 @@ export class Ability {
 		let p1 = p0;
 		let p2 = p0;
 
-		p1 += this.creature.player.flipped ? 5 : -5;
-		p2 += this.creature.player.flipped ? -5 : 5;
+		/*p1 += this.creature.player.flipped ? 5 : -5;
+		p2 += this.creature.player.flipped ? -5 : 5;*/
 
 		// Force creatures to face towards their target
 		/*	if (args[0] instanceof Creature) {

--- a/src/ability.js
+++ b/src/ability.js
@@ -264,13 +264,13 @@ export class Ability {
 	 * @return {void}
 	 */
 	animation2(o) {
-		let game = this.game,
-			opt = $j.extend({ callback: function () {}, arg: {} }, o),
-			args = opt.arg,
-			activateAbility = () => {
+		//let game = this.game,
+		(opt = $j.extend({ callback: function () {}, arg: {} }, o)),
+			(args = opt.arg),
+			(activateAbility = () => {
 				this.activate(args[0], args[1]);
 				this.postActivate();
-			};
+			});
 
 		game.freezedInput = true;
 
@@ -279,8 +279,8 @@ export class Ability {
 		let p1 = p0;
 		let p2 = p0;
 
-		//	p1 += this.creature.player.flipped ? 5 : -5;
-		//p2 += this.creature.player.flipped ? -5 : 5;
+		p1 += this.creature.player.flipped ? 5 : -5;
+		p2 += this.creature.player.flipped ? -5 : 5;
 
 		// Force creatures to face towards their target
 		if (args[0] instanceof Creature) {

--- a/src/ability.js
+++ b/src/ability.js
@@ -264,9 +264,8 @@ export class Ability {
 	 * @return {void}
 	 */
 	animation2(o) {
-		//let game = this.game,
-		(opt = $j.extend({ callback: function () {}, arg: {} }, o)),
-			(args = opt.arg),
+		let game = this.game,
+			(opt = $j.extend({ callback: function () {}, arg: {} }, o)), (args = opt.arg),
 			(activateAbility = () => {
 				this.activate(args[0], args[1]);
 				this.postActivate();
@@ -283,9 +282,9 @@ export class Ability {
 		p2 += this.creature.player.flipped ? -5 : 5;
 
 		// Force creatures to face towards their target
-		if (args[0] instanceof Creature) {
+	/*	if (args[0] instanceof Creature) {
 			this.creature.faceHex(args[0]);
-		}
+		}*/
 		// Play animations and sounds only for active abilities
 		if (this.getTrigger() === 'onQuery') {
 			let animId = Math.random();

--- a/src/ability.js
+++ b/src/ability.js
@@ -281,13 +281,13 @@ export class Ability {
 		p1 += this.creature.player.flipped ? 5 : -5;
 		p2 += this.creature.player.flipped ? -5 : 5;
 		console.log('here');
+		console.log(args[0]);
 
 		this.creature.faceHex(args[0]);
 
 		// Force creatures to face towards their target
 		if (args[0] instanceof Creature) {
 			console.log('in condition');
-			console.log(args[0]);
 			this.creature.faceHex(args[0]);
 		}
 		// Play animations and sounds only for active abilities

--- a/src/ability.js
+++ b/src/ability.js
@@ -280,10 +280,8 @@ export class Ability {
 
 		p1 += this.creature.player.flipped ? 5 : -5;
 		p2 += this.creature.player.flipped ? -5 : 5;
-		console.log('here');
-		console.log(args[0]);
 
-		//this.creature.faceHex(args[0]);
+		this.creature.facePlayerDefault();
 
 		// Force creatures to face towards their target
 		if (args[0] instanceof Creature) {

--- a/src/ability.js
+++ b/src/ability.js
@@ -265,12 +265,12 @@ export class Ability {
 	 */
 	animation2(o) {
 		let game = this.game,
-			(opt = $j.extend({ callback: function () {}, arg: {} }, o)), (args = opt.arg),
-			(activateAbility = () => {
+			opt = $j.extend({ callback: function () {}, arg: {} }, o),
+			args = opt.arg,
+			activateAbility = () => {
 				this.activate(args[0], args[1]);
 				this.postActivate();
-			});
-
+			};
 		game.freezedInput = true;
 
 		// Animate
@@ -282,7 +282,7 @@ export class Ability {
 		p2 += this.creature.player.flipped ? -5 : 5;
 
 		// Force creatures to face towards their target
-	/*	if (args[0] instanceof Creature) {
+		/*	if (args[0] instanceof Creature) {
 			this.creature.faceHex(args[0]);
 		}*/
 		// Play animations and sounds only for active abilities

--- a/src/ability.js
+++ b/src/ability.js
@@ -1,9 +1,9 @@
-/*import * as $j from 'jquery';
+import * as $j from 'jquery';
 import { Damage } from './damage';
 import { Hex } from './utility/hex';
 import { Creature } from './creature';
 import { isTeam, Team } from './utility/team';
-import * as arrayUtils from './utility/arrayUtils';*/
+import * as arrayUtils from './utility/arrayUtils';
 
 /**
  * Ability Class
@@ -279,13 +279,13 @@ export class Ability {
 		let p1 = p0;
 		let p2 = p0;
 
-		p1 += this.creature.player.flipped ? 5 : -5;
-		p2 += this.creature.player.flipped ? -5 : 5;
+		//	p1 += this.creature.player.flipped ? 5 : -5;
+		//p2 += this.creature.player.flipped ? -5 : 5;
 
 		// Force creatures to face towards their target
-		/*if (args[0] instanceof Creature) {
+		if (args[0] instanceof Creature) {
 			this.creature.faceHex(args[0]);
-		}*/
+		}
 		// Play animations and sounds only for active abilities
 		if (this.getTrigger() === 'onQuery') {
 			let animId = Math.random();

--- a/src/ability.js
+++ b/src/ability.js
@@ -1,9 +1,9 @@
-import * as $j from 'jquery';
+/*import * as $j from 'jquery';
 import { Damage } from './damage';
 import { Hex } from './utility/hex';
 import { Creature } from './creature';
 import { isTeam, Team } from './utility/team';
-import * as arrayUtils from './utility/arrayUtils';
+import * as arrayUtils from './utility/arrayUtils';*/
 
 /**
  * Ability Class
@@ -279,13 +279,13 @@ export class Ability {
 		let p1 = p0;
 		let p2 = p0;
 
-		//	p1 += this.creature.player.flipped ? 5 : -5;
+		p1 += this.creature.player.flipped ? 5 : -5;
 		p2 += this.creature.player.flipped ? -5 : 5;
 
 		// Force creatures to face towards their target
-		if (args[0] instanceof Creature) {
+		/*if (args[0] instanceof Creature) {
 			this.creature.faceHex(args[0]);
-		}
+		}*/
 		// Play animations and sounds only for active abilities
 		if (this.getTrigger() === 'onQuery') {
 			let animId = Math.random();

--- a/src/ability.js
+++ b/src/ability.js
@@ -280,9 +280,11 @@ export class Ability {
 
 		p1 += this.creature.player.flipped ? 5 : -5;
 		p2 += this.creature.player.flipped ? -5 : 5;
+		console.log('here');
 
 		// Force creatures to face towards their target
 		if (args[0] instanceof Creature) {
+			console.log('in condition');
 			console.log(args[0]);
 			this.creature.faceHex(args[0]);
 		}

--- a/src/ability.js
+++ b/src/ability.js
@@ -279,7 +279,7 @@ export class Ability {
 		let p1 = p0;
 		let p2 = p0;
 
-		p1 += this.creature.player.flipped ? 5 : -5;
+		//	p1 += this.creature.player.flipped ? 5 : -5;
 		p2 += this.creature.player.flipped ? -5 : 5;
 
 		// Force creatures to face towards their target

--- a/src/ability.js
+++ b/src/ability.js
@@ -282,6 +282,8 @@ export class Ability {
 		p2 += this.creature.player.flipped ? -5 : 5;
 		console.log('here');
 
+		this.creature.faceHex(args[0]);
+
 		// Force creatures to face towards their target
 		if (args[0] instanceof Creature) {
 			console.log('in condition');


### PR DESCRIPTION
Hello! I made a change in src/ability.js that fixes the pointless turn around that happens when Abolished uses the Greater Pyre ability behind. https://github.com/FreezingMoon/AncientBeast/issues/1648 
Let me know if it needs work! :) 

discord: noodlezxx#4192

Thanks


<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1681"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nourazekry/AncientBeast.git/23435886ef423639872a330ad8525965f9997bef.svg" /></a>

