### PR TITLE
Fix Chimera's ping-pong bug

### DIFF
--- a/src/abilities/Chimera.js
+++ b/src/abilities/Chimera.js
@@ -299,8 +299,10 @@ export default (G) => {
 						if (nextHex.creature === _target && args.direction === 4) {
 							let nextHexes = G.grid.getHexLine(_target.x, _target.y, args.direction, false);
 							nextHexes = nextHexes.splice(_target.size);
-							if (nextHexes.length > 0) {
+							if (nextHexes.length > 0 && nextHexes[0].creature !== _target) {
 								nextHex = nextHexes[0];
+							} else {
+								nextHex = null;
 							}
 						}
 						if (nextHex !== null && nextHex !== hex && nextHex.creature) {


### PR DESCRIPTION
Fixes the issue in #1577.

In handling the special case when hitting left, the hexes are checked for the next creature as the current creature is incorrectly marked as the next. Within the hexes are the creature itself, so in some instances, the current creature the only one in the hex list so it is still valid target even though it shouldn't be.

The fix address this problem by adding a check to ensure the current target creature is not the next target.

<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1694"><img src="https://gitpod.io/api/apps/github/pbs/github.com/MartinFlores751/AncientBeast.git/2d852c40e80315765da2d063a875b1ed58d2fefe.svg" /></a>


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1577: Battering Ram ping-pong effect](https://issuehunt.io/repos/2089437/issues/1577)
---
</details>
<!-- /Issuehunt content-->