### PR TITLE
hover on locked unit gives makes cursor not-allowed

### DIFF
--- a/src/style/grid.less
+++ b/src/style/grid.less
@@ -55,6 +55,12 @@
 	background-color: rgba(0, 0, 0, 0.55);
 }
 
+//hover on locked unit gives not-allowed cursor
+
+#creaturegrid .vignette.locked:hover {
+	cursor: not-allowed;
+}
+
 #creaturegrid .vignette.queued div.overlay {
 	background-image: url('~assets/icons/queue.svg');
 	animation: pulse0106 750ms infinite alternate;

--- a/src/style/grid.less
+++ b/src/style/grid.less
@@ -55,7 +55,7 @@
 	background-color: rgba(0, 0, 0, 0.55);
 }
 
-//hover on locked unit gives not-allowed cursor
+// Hovering on locked unit gives not-allowed cursor
 
 #creaturegrid .vignette.locked:hover {
 	cursor: not-allowed;


### PR DESCRIPTION
Hovering over the button under the cards for a locked unit change the cursor to not-allowed.

<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1697"><img src="https://gitpod.io/api/apps/github/pbs/github.com/Max0nyshchenko/AncientBeast.git/9e8d78f95171e8de831fc667963f3e90153130a7.svg" /></a>

