### PR TITLE
issue #1691

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3317,9 +3317,9 @@
 			"dev": true
 		},
 		"elliptic": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-			"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+			"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
 			"dev": true,
 			"requires": {
 				"bn.js": "^4.4.0",

--- a/src/game.js
+++ b/src/game.js
@@ -912,7 +912,15 @@ export default class Game {
 			i;
 
 		for (i = totalCreatures - 1; i >= 0; i--) {
-			if (this.creatureData[i].type == type) {
+			//if the object in current iteration does not have type property, checks instead for realm + level concat;
+			if (
+				this.creatureData[i].type == type ||
+				this.creatureData[i].realm + this.creatureData[i].level == type
+			) {
+				if (!this.creatureData[i].type) {
+					//if type == realm + level, assign type property with value as realm + level then return creature obj;
+					this.creatureData[i].type = this.creatureData[i].realm + this.creatureData[i].level;
+				}
 				return this.creatureData[i];
 			}
 		}


### PR DESCRIPTION
#1691 

retrieveCreatureStats in game.js and showCreature in interface.js both were looking for the 'type' property in creatureData, which was only valid on some creatures (presumably unlocked ones).

I hope this work around is viable and if not please let me know and I can modify.

<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1708"><img src="https://gitpod.io/api/apps/github/pbs/github.com/dylanelliott27/AncientBeast.git/19b60655a2fc52e1f56a9801e590b6f7e9f7d762.svg" /></a>


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

</details>
<!-- /Issuehunt content-->