### PR TITLE
Set fullScreenScaleMode

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -384,6 +384,7 @@ export default class Game {
 		this.Phaser.scale.pageAlignHorizontally = true;
 		this.Phaser.scale.pageAlignVertically = true;
 		this.Phaser.scale.scaleMode = Phaser.ScaleManager.SHOW_ALL;
+		this.Phaser.scale.fullScreenScaleMode = Phaser.ScaleManager.SHOW_ALL;
 		this.Phaser.scale.refresh();
 		this.Phaser.stage.disableVisibilityChange = true;
 


### PR DESCRIPTION
Fix https://github.com/FreezingMoon/AncientBeast/issues/673

Fullscreen uses a different scaling mode by default (ScaleManager.NONE). 
scaleMode and fullScreenScaleMode are now identical and the same scaling is now being used in both outside and inside fullscreen mode.

I have also added some minor UI cleanup that makes the launch UI slightly more usable on smartphones.
If you want I can upload those changes in a different PR.

<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1709"><img src="https://gitpod.io/api/apps/github/pbs/github.com/Vorlent/AncientBeast.git/486722508eca6975bf6b77a5b00a98a5d4104165.svg" /></a>

