### PR TITLE
Prematch UI overhaul for smartphones

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -303,7 +303,7 @@ export default class Game {
 
 	startLoading() {
 		$j('#gameSetupContainer').hide();
-		$j('#loader').show();
+		$j('#loader').removeClass('hide');
 		$j('body').css('cursor', 'wait');
 	}
 
@@ -316,6 +316,7 @@ export default class Game {
 		if (progress == 100) {
 			setTimeout(() => {
 				this.gameState = 'loaded';
+				$j('#combatwrapper').show();
 
 				$j('body').css('cursor', 'default');
 
@@ -364,7 +365,7 @@ export default class Game {
 			return;
 		}
 
-		$j('#loader').hide();
+		$j('#loader').addClass('hide');
 		$j('body').css('cursor', 'default');
 		this.setup(this.playerMode);
 	}
@@ -503,14 +504,18 @@ export default class Game {
 		this.resizeCombatFrame(); // Resize while the game is starting
 		this.UI.resizeDash();
 
-		// Handle resize events
-		$j(window).resize(() => {
-			// Throttle down to 1 event every 100ms of inactivity
+		var resizeGame = function () {
 			clearTimeout(this.windowResizeTimeout);
 			this.windowResizeTimeout = setTimeout(() => {
 				this.resizeCombatFrame();
 				this.UI.resizeDash();
 			}, 100);
+		}.bind(this);
+
+		// Handle resize events
+		$j(window).resize(() => {
+			// Throttle down to 1 event every 100ms of inactivity
+			resizeGame();
 		});
 
 		this.soundsys.playMusic();

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -34,10 +34,15 @@
 <body oncontextmenu="return false;" id="AncientBeast">
 	<div class="scrim loading"></div>
 	<div id="matchMaking">
-		<div id="loader"><img src="<%= require('assets/interface/AB.gif') %>" width="32" height="32" loading="lazy">Loading
-			<div id="barLoader">
-				<span class="progress"></span>
-			</div>
+		<div id="loader" class="hide">
+            <div>
+                <div>
+                    <img src="<%= require('assets/interface/AB.gif') %>" width="32" height="32" loading="lazy">Loading
+                </div>
+    			<div id="barLoader">
+    				<span class="progress"></span>
+    			</div>
+            </div>
 		</div>
 		<div id="gameSetupContainer">
 			<div id="gameTitle">
@@ -201,7 +206,6 @@
 					<input class="startButton" id="startButton" type="submit" value="START">
 					<span class="blink"> BUTTON</span>
 				</div>
-
 				<div id="start"><button type="submit"></button><span>Start</span></div>
 			</form>
 

--- a/src/style/pre-match.less
+++ b/src/style/pre-match.less
@@ -1,13 +1,16 @@
 #gameTitle {
 	display: block;
 	margin: auto;
-	width: 555px;
+	width: 100%;
 
 	div {
 		height: 125px;
 		background-image: url('~assets/interface/AncientBeast.png');
 		background-repeat: no-repeat;
 		margin-top: 20px;
+		margin-left: auto;
+		margin-right: auto;
+		max-width: 555px;
 	}
 
 	&:hover {
@@ -35,22 +38,28 @@
 	background: black url('~assets/interface/Reaper.jpg') no-repeat center top;
 	background-size: cover;
 	color: white;
+	overflow: auto;
+
+	#loader.hide {
+		display: none;
+	}
 
 	#loader {
-		width: 200px;
-		height: 50px;
-		position: absolute;
-		top: 50%;
-		left: 50%;
-		margin-left: -100px;
+		height: 100%;
 		margin-top: -2px;
 		line-height: 50px;
 		font-size: 40px;
 		display: none;
 
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex-direction: column;
+
 		#barLoader {
 			position: relative;
-			margin-left: -60px;
+			/*margin-left: -60px;*/
+			margin: auto;
 			background-image: url('~assets/interface/loadingEmpty.png');
 			background-repeat: no-repeat;
 			height: 54px;
@@ -58,7 +67,7 @@
 
 			.progress {
 				display: block;
-				height: 100vh;
+				height: 100%;
 				width: 0;
 				background-image: url('~assets/interface/loadingFull.png');
 				background-repeat: no-repeat;
@@ -70,7 +79,7 @@
 body {
 	background: black url('~assets/interface/skulls.jpg') repeat;
 	margin: 0;
-	overflow: hidden;
+	/*overflow: hidden;*/
 	padding: 0;
 	font-family: 'Play', sans-serif;
 }
@@ -96,7 +105,7 @@ body {
 #gameSetupContainer {
 	display: flex;
 	flex-direction: column;
-	flex-wrap: wrap;
+	/* flex-wrap: wrap; */
 	height: 100vh;
 
 	#gameSetup {
@@ -117,7 +126,7 @@ body {
 			display: flex;
 			flex-direction: row;
 			flex-wrap: wrap;
-			width: 495px;
+			max-width: 495px;
 
 			.gameOption {
 				background: #191919cc;
@@ -136,7 +145,7 @@ body {
 				}
 
 				.typeRadio {
-					white-space: nowrap;
+					/*white-space: nowrap;*/
 					display: flex;
 					flex-grow: 1;
 
@@ -282,6 +291,19 @@ a {
 	text-shadow: 2px 2px black;
 	text-decoration: none;
 	cursor: pointer;
+}
+
+@media (max-width: 370px) {
+	#startButtonWrapper {
+		display: flex;
+		flex-direction: column;
+	}
+}
+
+@media (max-width: 555px) {
+	#gameSetup {
+		padding-bottom: 120px;
+	}
 }
 
 @media (max-height: 555px) {

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -4,6 +4,7 @@
 	overflow: hidden;
 	position: relative;
 	text-align: center;
+	display: none;
 }
 
 #combatframe * {


### PR DESCRIPTION
While I was trying to figure out a solution for the canvas scaling issue I couldn't actually test the game on my phone. The prematch UI was unusable.

I took these screenshots on Firefox with dev tools but they are practically identical to what I saw on my phone.

![Screenshot from 2020-08-04 22-36-52](https://user-images.githubusercontent.com/13166716/89343198-36c3be80-d6a4-11ea-971c-35a0b3375eaa.png)

![Screenshot from 2020-08-04 22-36-48](https://user-images.githubusercontent.com/13166716/89343216-3e836300-d6a4-11ea-8b41-e947a5bee126.png)

The loading screen also looked a bit off but I didn't make a screenshot for it.

The newer UI looks like this:

![image](https://user-images.githubusercontent.com/13166716/89343484-a2a62700-d6a4-11ea-8ede-c42021687a9c.png)

I changed some fixed widths to "max-width" or completely replaced them with 100% width. This allows them to scale on small screens but stay as is on bigger screens.

I redid the loader with flexbox and made it hidden by default and dynamically enabled and disabled it with JS. Hide is a css class now because .hide() would remove the display: flex property and ruin the layout.

I had to remove overflow on the body tag and added text wrapping to the options.

![image](https://user-images.githubusercontent.com/13166716/89343958-67582800-d6a5-11ea-80b7-6f3e1748e384.png)

It's not 100% pretty but still better than nothing.

If the Viewport width is smaller than the main dialogue it starts to stretch vertically. I've added some extra space at the bottom so that the discord and AB button do not obscure the start button.

![image](https://user-images.githubusercontent.com/13166716/89345215-5c05fc00-d6a7-11ea-8bee-71db7bff0948.png)


Finally I've made the "PRESS START BUTTON" text vertical at really small widths. I feel like this is not really necessary because it will only make a difference on oddball devices with really bad aspect ratios.

![image](https://user-images.githubusercontent.com/13166716/89344417-23195780-d6a6-11ea-8359-44be03c9bcb5.png)

I added the "resizeGame" game function while I was hunting for the canvas bug which was mostly a Phaser problem where it forced 1080p but only in fullscreen. It doesn't cause any issues so I didn't bother removing it. These changes should have no effect on tablet or PC. The UI should be the same as before on those platforms but if you find any bugs please tell me about them.

<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1717"><img src="https://gitpod.io/api/apps/github/pbs/github.com/Vorlent/AncientBeast.git/7bbf11763aefe92f1aeeae2f11cca99e23b1abf1.svg" /></a>

