### PR TITLE
display icon for cycle abilities

### DIFF
--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -329,6 +329,10 @@
 	transition: background-image 0.5s linear !important;
 }
 
+.button.nextIcon {
+	background-image: url('~assets/icons/next.svg') !important;
+}
+
 .button.upgraded.noclick:hover:before {
 	opacity: 1;
 }

--- a/src/ui/button.js
+++ b/src/ui/button.js
@@ -36,6 +36,12 @@ export class Button {
 		opts = $j.extend(defaultOpts, opts);
 		$j.extend(this, opts);
 		this.changeState(this.state);
+
+		// Used in applying and removing CSS transitions
+		this.cssTransitionMeta = {
+			transition: null,
+		};
+		this.resolveCssTransition = null;
 	}
 
 	changeState(state) {
@@ -123,6 +129,40 @@ export class Button {
 		if (state != 'normal') {
 			this.$button.addClass(state);
 			this.$button.css(this.css[state]);
+		}
+	}
+
+	/**
+	 * Apply a CSS class on a button for a duration
+	 * Useful for flashing a different icon etc for a certain period of time
+	 * @param {string} transitionClass A CSS class to apply for the transitition
+	 * @param {number} transitionMs Time spent in the transition
+	 */
+	cssTransition(transitionClass, transitionMs) {
+		const resolveCssTransitionTask = () => {
+			this.$button.removeClass(transitionClass);
+			this.resolveTransitionTask = null;
+		};
+
+		// Check if the metadata matches, if not then you start the transition immediately, otherwise
+		// preserve previous triggers but extend duration
+		if (this.cssTransitionMeta.transitionClass !== transitionClass) {
+			this.$button.removeClass(this.cssTransitionMeta.transitionClass);
+			this.$button.addClass(transitionClass);
+			this.stateTransitionMeta = {
+				transitionClass,
+			};
+		}
+
+		if (this.resolveCssTransitionTask) {
+			clearTimeout(this.resolveCssTransitionTask);
+			this.resolveCssTransitionTask = null;
+		}
+
+		// If transition state is not to be reached, do not call the transition function
+		// This eliminates async issues that might be encountered by careless use
+		if (transitionMs > 0) {
+			this.resolveCssTransitionTask = setTimeout(resolveCssTransitionTask, transitionMs);
 		}
 	}
 

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -1,11 +1,12 @@
 import * as $j from 'jquery';
+import * as time from '../utility/time';
+
 import { Button } from './button';
 import { Chat } from './chat';
-import { ProgressBar } from './progressbar';
-import * as time from '../utility/time';
 import { Creature } from '../creature';
-import { getUrl } from '../assetLoader';
 import { Fullscreen } from './fullscreen';
+import { ProgressBar } from './progressbar';
+import { getUrl } from '../assetLoader';
 
 /**
  * Class UI
@@ -235,7 +236,10 @@ export class UI {
 							let ability = game.activeCreature.abilities[i];
 							// Passive ability icon can cycle between usable abilities
 							if (i == 0) {
-								this.selectNextAbility();
+								const selectedAbility = this.selectNextAbility();
+								if (selectedAbility > 0) {
+									b.cssTransition('nextIcon', 1000);
+								}
 								return;
 							}
 							// Colored frame around selected ability
@@ -730,21 +734,23 @@ export class UI {
 		game.activeCreature.queryMove();
 	}
 
+	/**
+	 * Cycles to next available ability. Returns the ability number selected or -1 if deselected.
+	 */
 	selectNextAbility() {
 		let game = this.game,
 			b = this.selectedAbility == -1 ? 0 : this.selectedAbility;
 		if (this.selectedAbility == 3) {
 			game.activeCreature.queryMove();
 			this.selectAbility(-1);
-			return;
+			return -1;
 		}
 		for (let i = b + 1; i < 4; i++) {
 			let creature = game.activeCreature;
 
 			if (creature.abilities[i].require() && !creature.abilities[i].used) {
 				this.abilitiesButtons[i].triggerClick();
-				this.selectedAbility + 1;
-				return;
+				return i;
 			}
 		}
 	}


### PR DESCRIPTION
This pull addresses the following issue:

https://github.com/FreezingMoon/AncientBeast/issues/1176

Contents:

* New button css transition feature, apply css classes for a short amount of time as inspired by [ReactTransitionGroup](http://reactcommunity.org/react-transition-group/css-transition)
* Interface next ability toggle now has a return value indicating which ability number it has switched to
* Toggling to a next ability via clicking passive will now show the next icon if another ability is activated (not if it deselects one)


<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1731"><img src="https://gitpod.io/api/apps/github/pbs/github.com/TheGuardianWolf/AncientBeast.git/d3efbbf1649b018634643c77078de0492f912506.svg" /></a>

