### PR TITLE
Make abolished turn toward target during fiery claw animation

### DIFF
--- a/src/abilities/Abolished.js
+++ b/src/abilities/Abolished.js
@@ -109,7 +109,6 @@ export default (G) => {
 			},
 			activate(path, args) {
 				let ability = this;
-				ability.end();
 
 				let target = arrayUtils.last(path).creature;
 				let projectileInstance = G.animations.projectile(
@@ -134,8 +133,14 @@ export default (G) => {
 					);
 					target.takeDamage(damage);
 
+					ability.end();
 					this.destroy();
 				}, sprite); // End tween.onComplete
+			},
+			getAnimationData: function () {
+				return {
+					duration: 425,
+				};
 			},
 		},
 		// Wild Fire

--- a/src/ability.js
+++ b/src/ability.js
@@ -290,8 +290,16 @@ export class Ability {
 		this.creature.facePlayerDefault();
 
 		// Force creatures to face towards their target
-		if (args[0] instanceof Creature) {
-			this.creature.faceHex(args[0]);
+		if (args[0]) {
+			if (args[0] instanceof Creature) {
+				this.creature.faceHex(args[0]);
+			} else if (args[0] instanceof Array) {
+				for (var argument of args[0]) {
+					if (argument instanceof Creature || argument.creature) {
+						this.creature.faceHex(argument);
+					}
+				}
+			}
 		}
 		// Play animations and sounds only for active abilities
 		if (this.getTrigger() === 'onQuery') {


### PR DESCRIPTION
Fixes  #1231.
Forces abolished to turn toward target during fiery claw animation.


<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1744"><img src="https://gitpod.io/api/apps/github/pbs/github.com/leopoldwe/AncientBeast.git/1f807ad565240f23ce6dfe2e422e00fce03337e9.svg" /></a>

