### PR TITLE
Fiery claw projectile hit location consistency

### DIFF
--- a/src/abilities/Abolished.js
+++ b/src/abilities/Abolished.js
@@ -111,13 +111,14 @@ export default (G) => {
 				let ability = this;
 
 				let target = arrayUtils.last(path).creature;
+				let startX = ability.creature.sprite.scale.x > 0 ? 200 : 52;
 				let projectileInstance = G.animations.projectile(
 					this,
 					target,
 					'effects_fiery-touch',
 					path,
 					args,
-					200,
+					startX,
 					-20,
 				);
 				let tween = projectileInstance[0];

--- a/src/abilities/Abolished.js
+++ b/src/abilities/Abolished.js
@@ -111,7 +111,7 @@ export default (G) => {
 				let ability = this;
 
 				let target = arrayUtils.last(path).creature;
-				let startX = ability.creature.sprite.scale.x > 0 ? 200 : 52;
+				let startX = ability.creature.sprite.scale.x > 0 ? 232 : 52;
 				let projectileInstance = G.animations.projectile(
 					this,
 					target,

--- a/src/animations.js
+++ b/src/animations.js
@@ -257,7 +257,7 @@ export class Animations {
 	}
 
 	projectile(this2, target, spriteId, path, args, startX, startY) {
-		//Get the side of the target that is closest to emission
+		// Get the side of the target that is closest to emission
 		let emissionPointX = this2.creature.grp.x + startX;
 		let targetLeftX = target.grp.x + 52;
 		let targetRightX = target.grp.x + 52 + (target.size - 1) * 90;

--- a/src/animations.js
+++ b/src/animations.js
@@ -285,12 +285,7 @@ export class Animations {
 			duration = dist * 75;
 
 		sprite.anchor.setTo(0.5);
-		sprite.rotation = Math.atan(
-			(emissionPoint.y - targetPoint.y) / (emissionPoint.x - targetPoint.x),
-		);
-		if (emissionPoint.x - targetPoint.x > 0) {
-			sprite.rotation += Math.PI;
-		}
+		sprite.rotation = -Math.PI / 3 + (args.direction * Math.PI) / 3;
 		let tween = game.Phaser.add
 			.tween(sprite)
 			.to(

--- a/src/animations.js
+++ b/src/animations.js
@@ -260,7 +260,7 @@ export class Animations {
 		//Get the side of the target that is closest to emission
 		let emissionPointX = this2.creature.grp.x + startX;
 		let targetLeftX = target.grp.x + 52;
-		let targetRightX = target.grp.x + 52 + (target.size - 1) * 75;
+		let targetRightX = target.grp.x + 52 + (target.size - 1) * 90;
 		let targetX =
 			Math.abs(emissionPointX - targetLeftX) < Math.abs(emissionPointX - targetRightX)
 				? targetLeftX
@@ -279,10 +279,15 @@ export class Animations {
 			},
 			// Sprite id here
 			sprite = game.grid.creatureGroup.create(emissionPoint.x, emissionPoint.y, spriteId),
-			duration = dist * 75;
+			duration = dist * 750;
 
 		sprite.anchor.setTo(0.5);
-		sprite.rotation = -Math.PI / 3 + (args.direction * Math.PI) / 3;
+		sprite.rotation = Math.atan(
+			(emissionPoint.y - targetPoint.y) / (emissionPoint.x - targetPoint.x),
+		);
+		if (emissionPoint.x - targetPoint.x > 0) {
+			sprite.rotation += Math.PI;
+		}
 		let tween = game.Phaser.add
 			.tween(sprite)
 			.to(

--- a/src/animations.js
+++ b/src/animations.js
@@ -257,14 +257,23 @@ export class Animations {
 	}
 
 	projectile(this2, target, spriteId, path, args, startX, startY) {
+		//Get the side of the target that is closest to emission
+		let emissionPointX = this2.creature.grp.x + startX;
+		let targetLeftX = target.grp.x + 52;
+		let targetRightX = target.grp.x + 52 + (target.size - 1) * 74;
+		let targetX =
+			Math.abs(emissionPointX - targetLeftX) < Math.abs(emissionPointX - targetRightX)
+				? targetLeftX
+				: targetRightX;
+
 		let game = this.game,
 			dist = arrayUtils.filterCreature(path.slice(0), false, false).length,
 			emissionPoint = {
-				x: this2.creature.grp.x + startX,
+				x: emissionPointX,
 				y: this2.creature.grp.y + startY,
 			},
 			targetPoint = {
-				x: target.grp.x + 52,
+				x: targetX,
 				y: target.grp.y - 20,
 			},
 			// Sprite id here

--- a/src/animations.js
+++ b/src/animations.js
@@ -257,25 +257,28 @@ export class Animations {
 	}
 
 	projectile(this2, target, spriteId, path, args, startX, startY) {
-		// Get the side of the target that is closest to emission
+		// Get the target's position on the projectile's path that is closest
 		let emissionPointX = this2.creature.grp.x + startX;
-		let targetLeftX = target.grp.x + 52;
-		let targetRightX = target.grp.x + 52 + (target.size - 1) * 90;
-		let targetX =
-			Math.abs(emissionPointX - targetLeftX) < Math.abs(emissionPointX - targetRightX)
-				? targetLeftX
-				: targetRightX;
-
+		var distance = Number.MAX_SAFE_INTEGER;
+		var targetX = path[0].displayPos.x;
+		for (let hex of path) {
+			if (typeof hex.creature != 'undefined' && hex.creature.id == target.id) {
+				if (distance > Math.abs(emissionPointX - hex.displayPos.x)) {
+					distance = Math.abs(emissionPointX - hex.displayPos.x);
+					targetX = hex.displayPos.x;
+				}
+			}
+		}
 		let game = this.game,
 			baseDist = arrayUtils.filterCreature(path.slice(0), false, false).length,
 			dist = baseDist == 0 ? 1 : baseDist,
 			emissionPoint = {
-				x: emissionPointX,
+				x: this2.creature.grp.x + startX,
 				y: this2.creature.grp.y + startY,
 			},
 			targetPoint = {
-				x: targetX,
-				y: target.grp.y - 20,
+				x: targetX + 45,
+				y: path[baseDist].displayPos.y - 20,
 			},
 			// Sprite id here
 			sprite = game.grid.creatureGroup.create(emissionPoint.x, emissionPoint.y, spriteId),

--- a/src/animations.js
+++ b/src/animations.js
@@ -260,14 +260,15 @@ export class Animations {
 		//Get the side of the target that is closest to emission
 		let emissionPointX = this2.creature.grp.x + startX;
 		let targetLeftX = target.grp.x + 52;
-		let targetRightX = target.grp.x + 52 + (target.size - 1) * 74;
+		let targetRightX = target.grp.x + 52 + (target.size - 1) * 75;
 		let targetX =
 			Math.abs(emissionPointX - targetLeftX) < Math.abs(emissionPointX - targetRightX)
 				? targetLeftX
 				: targetRightX;
 
 		let game = this.game,
-			dist = arrayUtils.filterCreature(path.slice(0), false, false).length,
+			baseDist = arrayUtils.filterCreature(path.slice(0), false, false).length,
+			dist = baseDist == 0 ? 1 : baseDist,
 			emissionPoint = {
 				x: emissionPointX,
 				y: this2.creature.grp.y + startY,

--- a/src/animations.js
+++ b/src/animations.js
@@ -279,7 +279,7 @@ export class Animations {
 			},
 			// Sprite id here
 			sprite = game.grid.creatureGroup.create(emissionPoint.x, emissionPoint.y, spriteId),
-			duration = dist * 750;
+			duration = dist * 75;
 
 		sprite.anchor.setTo(0.5);
 		sprite.rotation = Math.atan(


### PR DESCRIPTION
Fixes issue #1745. Three major changes:
1. Fiery claw now should come out of abolished's front.
2. Fiery claw (and other projectiles) now should hit an enemy's side (front or back) that is closer.
3. Fiery claw (and other projectiles) now move faster when attacking an adjacent enemy.

<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1754"><img src="https://gitpod.io/api/apps/github/pbs/github.com/leopoldwe/AncientBeast.git/d68a7ea7efe98d7837b2ae7064d5488b4c83d272.svg" /></a>

