### PR TITLE
#1752: Change opacity specificity to disabled buttons only

### DIFF
--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -351,9 +351,12 @@
 	background-image: url('~assets/interface/frame_upgrade.png');
 }
 
+.button.disabled {
+	opacity: 0.5;
+}
+
 .disabled {
 	cursor: default !important;
-	opacity: 0.5;
 
 	&.ability {
 		cursor: help !important;


### PR DESCRIPTION
This is a bugfix for [issue 1752](https://github.com/FreezingMoon/AncientBeast/issues/1752).