### PR TITLE
Make snowbunny only jump away during an enemy's turn.

### DIFF
--- a/src/abilities/Snow-Bunny.js
+++ b/src/abilities/Snow-Bunny.js
@@ -27,6 +27,7 @@ export default (G) => {
 					fromHex &&
 					fromHex.creature &&
 					isTeam(fromHex.creature, this.creature, Team.enemy) &&
+					fromHex.creature.travelDistance != 0 &&
 					this._getTriggerHexId(fromHex) >= 0 &&
 					this._getHopHex(fromHex) !== undefined
 				);

--- a/src/abilities/Snow-Bunny.js
+++ b/src/abilities/Snow-Bunny.js
@@ -27,7 +27,7 @@ export default (G) => {
 					fromHex &&
 					fromHex.creature &&
 					isTeam(fromHex.creature, this.creature, Team.enemy) &&
-					fromHex.creature.travelDist != 0 &&
+					this.game.activeCreature != this.creature &&
 					this._getTriggerHexId(fromHex) >= 0 &&
 					this._getHopHex(fromHex) !== undefined
 				);

--- a/src/abilities/Snow-Bunny.js
+++ b/src/abilities/Snow-Bunny.js
@@ -27,7 +27,7 @@ export default (G) => {
 					fromHex &&
 					fromHex.creature &&
 					isTeam(fromHex.creature, this.creature, Team.enemy) &&
-					fromHex.creature.travelDistance != 0 &&
+					fromHex.creature.travelDist != 0 &&
 					this._getTriggerHexId(fromHex) >= 0 &&
 					this._getHopHex(fromHex) !== undefined
 				);


### PR DESCRIPTION
Fixes #1621 
Snowbunny will now only jump back if the triggering creature moved on its turn.


<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1758"><img src="https://gitpod.io/api/apps/github/pbs/github.com/leopoldwe/AncientBeast.git/65b6cf426246dd1fb5c5c48ad73c799e8ed8fb27.svg" /></a>

