### PR TITLE
Lock cursor for locked cards

### DIFF
--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -356,7 +356,7 @@
 }
 
 .disabled {
-	cursor: default !important;
+	cursor: not-allowed !important;
 
 	&.ability {
 		cursor: help !important;
@@ -465,6 +465,10 @@
 	&.slideIn {
 		transform: translateX(0);
 	}
+}
+
+.card.disabled a.name {
+	cursor: not-allowed;
 }
 // Card anchor refactor
 div.section.info {

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -203,7 +203,9 @@ export class UI {
 			{
 				$button: $j('#materialize_button'),
 				css: {
-					disabled: {},
+					disabled: {
+						cursor: 'not-allowed',
+					},
 					glowing: {
 						cursor: 'pointer',
 					},
@@ -1124,9 +1126,10 @@ export class UI {
 			});
 
 			// Materialize button
-			$j('#materialize_button').removeClass('glowing').unbind('click');
-			$j('#card .sideA').addClass('disabled').unbind('click');
+			this.materializeButton.changeState('disabled');
 			$j('#materialize_button p').text(game.msg.ui.dash.heavyDev);
+
+			$j('#card .sideA').addClass('disabled').unbind('click');
 		}
 	}
 


### PR DESCRIPTION
Fix #1711 
- Add cursor styles for disabled card state
- Add styles for disable state of materialize button
- Add state changing for locked materialize button

<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1761"><img src="https://gitpod.io/api/apps/github/pbs/github.com/TheSeally/AncientBeast.git/454e866079d65b11eb1d0a9f8875fe01dd1dd695.svg" /></a>



<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1761"><img src="https://gitpod.io/api/apps/github/pbs/github.com/TheSeally/AncientBeast.git/454e866079d65b11eb1d0a9f8875fe01dd1dd695.svg" /></a>

