### PR TITLE
Fix bounce portraits in queue #1762

### DIFF
--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -2428,7 +2428,11 @@ export class UI {
 			$queueItem = this.$queue.find('.vignette[creatureid="' + creaID + '"]:first');
 		}
 
-		if ($queueItem.length > 0) {
+		const isPortraitLowerThanCombatCanvas =
+			parseInt($queueItem.css('top'), 10) >
+			parseInt($j('#combatwrapper canvas').css('marginTop'), 10);
+
+		if ($queueItem.length > 0 && !isPortraitLowerThanCombatCanvas) {
 			$queueItem.stop();
 			$queueItem.animate(
 				{


### PR DESCRIPTION
Fix #1762
Limited bounce height for portraits in queue during multiple clicks
Now a portraits cannot go below the game board

After this change highlighting a portrait still noticeable, but it prevent issue where the portrait can be flipped off-screen

<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1763"><img src="https://gitpod.io/api/apps/github/pbs/github.com/TheSeally/AncientBeast.git/fce05f1b5af2015245bc1f90e9370a3f110741c6.svg" /></a>

