### PR TITLE
Enable energy cost update on cards for locked unit

### DIFF
--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -1123,6 +1123,19 @@ export class UI {
 				} else {
 					$ability.children('.wrapper').children('.info').children('#upgrade').text(' ');
 				}
+				if (key !== 0) {
+					$ability
+						.children('.wrapper')
+						.children('.info')
+						.children('#cost')
+						.text(' - costs ' + stats.ability_info[key].costs.energy + ' energy pts.');
+				} else {
+					$ability
+						.children('.wrapper')
+						.children('.info')
+						.children('#cost')
+						.text(' - this ability is passive.');
+				}
 			});
 
 			// Materialize button


### PR DESCRIPTION
Previously, clicking on locked unit does not update energy cost for
abilities. It only shows the energy cost from the last clicked playable
unit.
This commit enables energy costs to be updated even when unit is locked.

Fixes: #1723

If your pull request tries to address a specific issue from the repository, please reference to it.
Don't forget to include a description of the changes proposes. https://discord.me/AncientBeast


<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1766"><img src="https://gitpod.io/api/apps/github/pbs/github.com/ChengYuuu/AncientBeast.git/1bc145ab825fc4f40254d607eb0fd46f4b88350a.svg" /></a>

