### PR TITLE
Center combat location

### DIFF
--- a/src/style/pre-match.less
+++ b/src/style/pre-match.less
@@ -79,7 +79,7 @@
 body {
 	background: black url('~assets/interface/skulls.jpg') repeat;
 	margin: 0;
-	/*overflow: hidden;*/
+	overflow: hidden;
 	padding: 0;
 	font-family: 'Play', sans-serif;
 }


### PR DESCRIPTION
Combat location was not centered due to UI change PR, #1717
This commit fixes the issue by re-enabling overflow:hidden on body tag

Fixes: #1770

If your pull request tries to address a specific issue from the repository, please reference to it.
Don't forget to include a description of the changes proposes. https://discord.me/AncientBeast


<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1774"><img src="https://gitpod.io/api/apps/github/pbs/github.com/ChengYuuu/AncientBeast.git/615ca5e633c5e3dc9b9f7377cd1bd563cdf71bc7.svg" /></a>

