### PR TITLE
Fix Vine trap vanishing prematurely

### DIFF
--- a/src/abilities/Impaler.js
+++ b/src/abilities/Impaler.js
@@ -175,8 +175,8 @@ export default (G) => {
 			activate: function (target) {
 				this.end();
 				let damages = this.damages;
-				// Last 1 turn, or indefinitely if upgraded
-				let lifetime = this.isUpgraded() ? 0 : 1;
+				// Last 1 turn excluding current turn, or indefinitely if upgraded
+				let lifetime = this.isUpgraded() ? 0 : 2;
 				let ability = this;
 
 				// Destroy trap if it wasn't triggered and target is dead


### PR DESCRIPTION
Change trap's lifetime to 2. It will mean that the trap will last for 1
additional round excluding current round.

Fixes: #1430

If your pull request tries to address a specific issue from the repository, please reference to it.
Don't forget to include a description of the changes proposes. https://discord.me/AncientBeast


<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1775"><img src="https://gitpod.io/api/apps/github/pbs/github.com/ChengYuuu/AncientBeast.git/655496d71e2bc593e30508271b7a9a76652ee54d.svg" /></a>

