### PR TITLE
Vehemoth passive ability

### DIFF
--- a/src/abilities/Dark-Priest.js
+++ b/src/abilities/Dark-Priest.js
@@ -265,7 +265,7 @@ export default (G) => {
 				G.queue.removeTempCreature();
 
 				// Create full temporary Creature with placeholder position to show in queue
-				crea = $j.extend(crea, { x: 3, y: 3 }, { team: this.creature.player.id });
+				crea = $j.extend(crea, { x: 3, y: 3 }, { team: this.creature.player.id }, { temp: true });
 				let fullCrea = new Creature(crea, G);
 				// Don't allow temporary Creature to take up space
 				fullCrea.cleanHex();
@@ -333,9 +333,13 @@ export default (G) => {
 
 				//TODO: Make the UI show the updated number instantly
 
-				ability.end();
+				ability.end(false, true);
 
 				ability.creature.player.summon(creature, pos);
+				let crea = G.creatures.pop();
+				crea.id--;
+				G.creatures[crea.id] = crea;
+				G.creatureIdCounter--;
 				ability.creature.queryMove();
 			},
 		},

--- a/src/abilities/Vehemoth.js
+++ b/src/abilities/Vehemoth.js
@@ -31,16 +31,16 @@ export default (G) => {
 				let ability = this;
 				var buff = 0;
 
-				G.creatures.forEach(crea => {
+				G.creatures.forEach((crea) => {
 					if (!(crea instanceof Creature)) {
 						return;
 					}
-					if (crea.realm != "S" || crea.dead || crea.sprite.temp) {
+					if (crea.realm != 'S' || crea.dead || crea.sprite.temp) {
 						return;
 					}
 					buff += 2;
 				});
-				
+
 				var regrowBuff = 0;
 				if (this.isUpgraded()) {
 					regrowBuff = buff;
@@ -49,10 +49,10 @@ export default (G) => {
 				this.creature.replaceEffect(
 					// Add and replace the effect each time
 					new Effect(
-						"Lamellar Body", // name
+						'Lamellar Body', // name
 						this.creature, // caster
 						this.creature, // target
-						"", // trigger
+						'', // trigger
 						{
 							alterations: {
 								defense: buff,
@@ -61,9 +61,9 @@ export default (G) => {
 							},
 							stackable: false,
 						},
-						G
-					)
-				)
+						G,
+					),
+				);
 			},
 		},
 

--- a/src/abilities/Vehemoth.js
+++ b/src/abilities/Vehemoth.js
@@ -12,14 +12,15 @@ import { Effect } from '../effect';
  */
 export default (G) => {
 	G.abilities[6] = [
-		// 	First Ability: Frost Bite
+		// 	First Ability: Lamellar Body
 		{
 			//	Type : Can be "onQuery", "onStartPhase", "onDamage"
-			trigger: 'onEndPhase',
+			trigger: 'onCreatureSummon onOtherCreatureSummon onOtherCreatureDeath',
 
 			// 	require() :
 			require: function () {
-				if (!this.testRequirements()) {
+				// Stop temporary and dead creatures from activating
+				if (this.creature.dead || this.creature.temp) {
 					return false;
 				}
 				return true;
@@ -28,46 +29,41 @@ export default (G) => {
 			//	activate() :
 			activate: function () {
 				let ability = this;
-				this.end();
+				var buff = 0;
 
-				//Check all creatures
-				for (let i = 1; i < G.creatures.length; i++) {
-					if (G.creatures[i] instanceof Creature) {
-						let crea = G.creatures[i];
-
-						if (
-							isTeam(crea, ability.creature, Team.enemy) &&
-							!crea.dead &&
-							crea.findEffect('Snow Storm').length === 0
-						) {
-							let effect = new Effect(
-								'Snow Storm', // Name
-								ability.creature, // Caster
-								crea, // Target
-								'onOtherCreatureDeath', // Trigger
-								{
-									effectFn: function (eff) {
-										let trg = eff.target;
-
-										let iceDemonArray = G.findCreature({
-											type: 'S7', // Ice Demon
-											dead: false, // Still Alive
-											team: [1 - (trg.team % 2), 1 - (trg.team % 2) + 2], // Oposite team
-										});
-
-										if (iceDemonArray.length == 0) {
-											this.deleteEffect();
-										}
-									},
-									alterations: ability.effects[0],
-									noLog: true,
-								}, // Optional arguments
-								G,
-							);
-							crea.addEffect(effect);
-						}
+				G.creatures.forEach(crea => {
+					if (!(crea instanceof Creature)) {
+						return;
 					}
+					if (crea.realm != "S" || crea.dead || crea.sprite.temp) {
+						return;
+					}
+					buff += 2;
+				});
+				
+				var regrowBuff = 0;
+				if (this.isUpgraded()) {
+					regrowBuff = buff;
 				}
+
+				this.creature.replaceEffect(
+					// Add and replace the effect each time
+					new Effect(
+						"Lamellar Body", // name
+						this.creature, // caster
+						this.creature, // target
+						"", // trigger
+						{
+							alterations: {
+								defense: buff,
+								frost: buff,
+								regrowth: regrowBuff,
+							},
+							stackable: false,
+						},
+						G
+					)
+				)
 			},
 		},
 

--- a/src/abilities/Vehemoth.js
+++ b/src/abilities/Vehemoth.js
@@ -14,62 +14,62 @@ export default (G) => {
 	G.abilities[6] = [
 		// 	First Ability: Lamellar Body
 		{
-            //  Type : Can be "onQuery", "onStartPhase", "onDamage"
-            trigger: 'onCreatureSummon onOtherCreatureSummon onOtherCreatureDeath',
+			//  Type : Can be "onQuery", "onStartPhase", "onDamage"
+			trigger: 'onCreatureSummon onOtherCreatureSummon onOtherCreatureDeath',
 
-            _buff: 0,
+			_buff: 0,
 
-            //  require() :
-            require: function () {
-                // Stop temporary and dead creatures from activating
-                if (this.creature.dead || this.creature.temp) {
-                    return false;
-                }
-                // Stop activation if the other creature is not a sloth type
-                var buff = 0;
-                G.creatures.forEach((crea) => {
-                    if (crea.realm == 'S' && !crea.dead && !crea.temp) {
-                        buff += 2;
-                    }
-                });
-                if (buff == this._buff) {
-                    return false;
-                }
-                this._buff = buff;
-                return true;
-            },
+			//  require() :
+			require: function () {
+				// Stop temporary and dead creatures from activating
+				if (this.creature.dead || this.creature.temp) {
+					return false;
+				}
+				// Stop activation if the other creature is not a sloth type
+				var buff = 0;
+				G.creatures.forEach((crea) => {
+					if (crea.realm == 'S' && !crea.dead && !crea.temp) {
+						buff += 2;
+					}
+				});
+				if (buff == this._buff) {
+					return false;
+				}
+				this._buff = buff;
+				return true;
+			},
+	
+			//  activate() :
+			activate: function () {
+				let ability = this;
+				// Force Vehemoth to stay facing the right way
+				this.creature.facePlayerDefault();
 
-            //  activate() :
-            activate: function () {
-                let ability = this;
-                // Force Vehemoth to stay facing the right way
-                this.creature.facePlayerDefault();
+				var regrowBuff = 0;
+				if (this.isUpgraded()) {
+					regrowBuff = this._buff;
+				}
 
-                var regrowBuff = 0;
-                if (this.isUpgraded()) {
-                    regrowBuff = this._buff;
-                }
-
-                this.creature.replaceEffect(
-                    // Add and replace the effect each time
-                    new Effect(
-                        'Lamellar Body', // name
-                        this.creature, // caster
-                        this.creature, // target
-                        '', // trigger
-                        {
-                            alterations: {
-                                defense: this._buff,
-                                frost: this._buff,
-                                regrowth: regrowBuff,
-                            },
-                            stackable: false,
-                        },
-                        G,
-                    ),
-                );
-            },
-        },
+				this.creature.replaceEffect(
+					// Add and replace the effect each time
+					new Effect(
+						'Lamellar Body', // name
+						this.creature, // caster
+						this.creature, // target
+						'', // trigger
+						{
+							alterations: {
+								defense: this._buff,
+								frost: this._buff,
+								regrowth: regrowBuff,
+							},
+							stackable: false,
+						},
+						G,
+					),
+				);
+			},
+		},
 
 		// 	Second Ability: Flat Frons
 		{

--- a/src/abilities/Vehemoth.js
+++ b/src/abilities/Vehemoth.js
@@ -30,6 +30,8 @@ export default (G) => {
 			activate: function () {
 				let ability = this;
 				var buff = 0;
+				// Force Vehemoth to stay facing the right way
+				this.creature.facePlayerDefault();
 
 				G.creatures.forEach((crea) => {
 					if (!(crea instanceof Creature)) {

--- a/src/abilities/Vehemoth.js
+++ b/src/abilities/Vehemoth.js
@@ -14,60 +14,62 @@ export default (G) => {
 	G.abilities[6] = [
 		// 	First Ability: Lamellar Body
 		{
-			//	Type : Can be "onQuery", "onStartPhase", "onDamage"
-			trigger: 'onCreatureSummon onOtherCreatureSummon onOtherCreatureDeath',
+            //  Type : Can be "onQuery", "onStartPhase", "onDamage"
+            trigger: 'onCreatureSummon onOtherCreatureSummon onOtherCreatureDeath',
 
-			// 	require() :
-			require: function () {
-				// Stop temporary and dead creatures from activating
-				if (this.creature.dead || this.creature.temp) {
-					return false;
-				}
-				return true;
-			},
+            _buff: 0,
 
-			//	activate() :
-			activate: function () {
-				let ability = this;
-				var buff = 0;
-				// Force Vehemoth to stay facing the right way
-				this.creature.facePlayerDefault();
+            //  require() :
+            require: function () {
+                // Stop temporary and dead creatures from activating
+                if (this.creature.dead || this.creature.temp) {
+                    return false;
+                }
+                // Stop activation if the other creature is not a sloth type
+                var buff = 0;
+                G.creatures.forEach((crea) => {
+                    if (crea.realm == 'S' && !crea.dead && !crea.temp) {
+                        buff += 2;
+                    }
+                });
+                if (buff == this._buff) {
+                    return false;
+                }
+                this._buff = buff;
+                return true;
+            },
 
-				G.creatures.forEach((crea) => {
-					if (!(crea instanceof Creature)) {
-						return;
-					}
-					if (crea.realm != 'S' || crea.dead || crea.sprite.temp) {
-						return;
-					}
-					buff += 2;
-				});
+            //  activate() :
+            activate: function () {
+                let ability = this;
+                // Force Vehemoth to stay facing the right way
+                this.creature.facePlayerDefault();
 
-				var regrowBuff = 0;
-				if (this.isUpgraded()) {
-					regrowBuff = buff;
-				}
+                var regrowBuff = 0;
+                if (this.isUpgraded()) {
+                    regrowBuff = this._buff;
+                }
 
-				this.creature.replaceEffect(
-					// Add and replace the effect each time
-					new Effect(
-						'Lamellar Body', // name
-						this.creature, // caster
-						this.creature, // target
-						'', // trigger
-						{
-							alterations: {
-								defense: buff,
-								frost: buff,
-								regrowth: regrowBuff,
-							},
-							stackable: false,
-						},
-						G,
-					),
-				);
-			},
-		},
+                this.creature.replaceEffect(
+                    // Add and replace the effect each time
+                    new Effect(
+                        'Lamellar Body', // name
+                        this.creature, // caster
+                        this.creature, // target
+                        '', // trigger
+                        {
+                            alterations: {
+                                defense: this._buff,
+                                frost: this._buff,
+                                regrowth: regrowBuff,
+                            },
+                            stackable: false,
+                        },
+                        G,
+                    ),
+                );
+            },
+        },
 
 		// 	Second Ability: Flat Frons
 		{

--- a/src/abilities/Vehemoth.js
+++ b/src/abilities/Vehemoth.js
@@ -38,7 +38,7 @@ export default (G) => {
 				this._buff = buff;
 				return true;
 			},
-	
+
 			//  activate() :
 			activate: function () {
 				let ability = this;

--- a/src/creature.js
+++ b/src/creature.js
@@ -39,6 +39,7 @@ export class Creature {
 	 * statsAlt :		Object :	Object containing the alteration value for each stat //todo
 	 * abilities :		Array :		Array containing the 4 abilities
 	 * remainingMove : Integer :	Remaining moves allowed untill the end of turn
+	 * temp :           Boolean :   True if the creature is only temporary for preview, false otherwise
 	 *
 	 */
 
@@ -66,6 +67,7 @@ export class Creature {
 		this.display = obj.display;
 		this.drop = obj.drop;
 		this._movementType = 'normal';
+		this.temp = obj.temp;
 
 		if (obj.movementType) {
 			this._movementType = obj.movementType;
@@ -442,6 +444,12 @@ export class Creature {
 				});
 			}
 		});
+		
+		// Clean up temporary creature if a summon was cancelled.
+		if (game.creatures[game.creatures.length - 1].temp) {
+			game.creatures.pop();
+			game.creatureIdCounter--;
+		}
 
 		let remainingMove = this.remainingMove;
 		// No movement range if unmoveable
@@ -614,7 +622,7 @@ export class Creature {
 	 */
 	faceHex(faceto, facefrom, ignoreCreaHex, attackFix) {
 		if (!facefrom) {
-			facefrom = this.player.flipped ? this.hexagons[this.size - 1] : this.hexagons[0];
+			facefrom = this.player.flipped ? this.hexagons[0] : this.hexagons[this.size - 1];
 		}
 
 		if (

--- a/src/creature.js
+++ b/src/creature.js
@@ -444,7 +444,7 @@ export class Creature {
 				});
 			}
 		});
-		
+
 		// Clean up temporary creature if a summon was cancelled.
 		if (game.creatures[game.creatures.length - 1].temp) {
 			game.creatures.pop();

--- a/src/creature.js
+++ b/src/creature.js
@@ -622,7 +622,7 @@ export class Creature {
 	 */
 	faceHex(faceto, facefrom, ignoreCreaHex, attackFix) {
 		if (!facefrom) {
-			facefrom = this.player.flipped ? this.hexagons[0] : this.hexagons[this.size - 1];
+			facefrom = this.player.flipped ? this.hexagons[this.size - 1] : this.hexagons[0];
 		}
 
 		if (
@@ -635,6 +635,10 @@ export class Creature {
 		}
 
 		if (faceto instanceof Creature) {
+			if (faceto === this) {
+				this.facePlayerDefault();
+				return;
+			}
 			faceto = faceto.size < 2 ? faceto.hexagons[0] : faceto.hexagons[1];
 		}
 

--- a/src/player.js
+++ b/src/player.js
@@ -83,6 +83,7 @@ export class Player {
 
 		data = $j.extend(data, pos, {
 			team: this.id,
+			temp: false,
 		}); // Create the full data for creature creation
 
 		for (let i = game.creatureData.length - 1; i >= 0; i--) {


### PR DESCRIPTION
Addresses  #1740 and #1806.
Added a new field to Creature objects, temp, that tracks if the creature is temporary or not. During queryMove, any temporary creatures at the end of the creature array are removed. It was done this way because removing the temporary creature before the summon is complete causes problems, but cancelling by pressing escape does not call the fnOnCancel function.

Also implements Vehemoth's passive ability.


<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1813"><img src="https://gitpod.io/api/apps/github/pbs/github.com/leopoldwe/AncientBeast.git/b051f20e21b0c3cb86740fe82f548e555c169fe8.svg" /></a>

