### PR TITLE
Fixed positioning of loading text

### DIFF
--- a/src/style/pre-match.less
+++ b/src/style/pre-match.less
@@ -74,7 +74,6 @@
 		#barLoader {
 			position: relative;
 			/*margin-left: -60px;*/
-			margin: auto;
 			background-image: url('~assets/interface/loadingEmpty.png');
 			background-repeat: no-repeat;
 			height: 54px;


### PR DESCRIPTION
Fixed positioning of loading text and spinner as requested on issue #1796 
Removed `margin: auto` rule from `#barLoader` in `pre-match.less`.


<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1819"><img src="https://gitpod.io/api/apps/github/pbs/github.com/jamesleeat/AncientBeast.git/2bcbd51abdd50e901652fc321b126dbad0b005f1.svg" /></a>

