### PR TITLE
Replaced flee for fullscreen button in match UI

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -945,11 +945,6 @@
 						<p><span class="activePlayer turntime">&#8734;</span> / <span class="timepool">&#8734;</span></p>
 					</div>
 				</div>
-				<div style="position:relative">
-					<div id="fullscreen" class="button" style="right:100px">
-						<div></div>
-					</div>
-				</div>
 				<div id="rightpanel">
 					<div style="position:relative">
 						<div id="audio" class="button"></div>
@@ -979,14 +974,20 @@
 						</div>
 					</div>
 					<div style="position:relative">
-						<div id="flee" class="button"></div>
+						<div id="fullscreen" class="button" >
+							<div></div>
+						</div>
+						
+						<!-- Will be moved to another part of the ui -->
+						<!-- <div id="flee" class="button"></div>
 						<div class="desc">
 							<div class="arrow"></div>
 							<div class="shortcut">hotkey F</div>
 							<span>Flee Match</span>
 							<p>Give up but only after first 12 rounds.</p>
-						</div>
+						</div> -->
 					</div>
+					
 					<div class="progressbar">
 						<div class="bar poolbar"></div>
 						<div class="bar timebar"></div>

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -973,10 +973,16 @@
 							<p>Delayed creatures will act at the end of the round, if alive and still able to.</p>
 						</div>
 					</div>
-					<div style="position:relative">
-						<div id="fullscreen" class="button" >
+					<div style="position:relative" >
+						<div id="fullscreen" class="button slideIn" >
 							<div></div>
 						</div>
+						<div class="desc">
+							<div class="arrow"></div>
+							<div class="shortcut">hotkey Shift + F</div>
+							<span>Fullscreen</span>
+							<p>Toggle fullscreen mode</p>
+						</div> 
 						
 						<!-- Will be moved to another part of the ui -->
 						<!-- <div id="flee" class="button"></div>

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -981,7 +981,7 @@
 							<div class="arrow"></div>
 							<div class="shortcut">hotkey Shift + F</div>
 							<span>Fullscreen</span>
-							<p>Toggle fullscreen mode</p>
+							<p>Toggle fullscreen mode as you please.</p>
 						</div> 
 						
 						<!-- Will be moved to another part of the ui -->

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -981,7 +981,7 @@
 							<div class="arrow"></div>
 							<div class="shortcut">hotkey Shift + F</div>
 							<span>Fullscreen</span>
-							<p>Toggle fullscreen mode as you please.</p>
+							<p>Toggle fullscreen mode as you wish.</p>
 						</div> 
 						
 						<!-- Will be moved to another part of the ui -->

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -390,10 +390,13 @@
 }
 
 .button#fullscreen {
-	position: relative;
+	position: inherit;
 	width: 80px;
 	height: 80px;
+	opacity: 0.8;
+	background-color: inherit;
 	z-index: inherit;
+
 	div {
 		width: 100%;
 		height: 100%;

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -389,8 +389,15 @@
 	}
 }
 
-.button#fullscreen:before {
-	background-image: none;
+.button#fullscreen {
+	position: relative;
+	width: 80px;
+	height: 80px;
+	z-index: inherit;
+	div {
+		width: 100%;
+		height: 100%;
+	}
 }
 
 .button#audio {
@@ -461,7 +468,7 @@
 	transition: transform 0.5s;
 	transform: translateX(50%);
 	&:hover {
-		transform: translateX(0);
+		transform: translateX(0%);
 	}
 	&.slideIn {
 		transform: translateX(0);

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -1791,6 +1791,7 @@ export class UI {
 
 					this.btnAudio.changeState('normal');
 					this.btnSkipTurn.changeState('normal');
+					this.btnFullscreen.changeState('normal');
 					// Change ability buttons
 					this.changeAbilityButtons();
 					// Update upgrade info
@@ -1805,6 +1806,7 @@ export class UI {
 						() => {
 							this.btnAudio.changeState('slideIn');
 							this.btnSkipTurn.changeState('slideIn');
+							this.btnFullscreen.changeState('slideIn');
 							if (!creature.hasWait && creature.delayable && !game.queue.isCurrentEmpty()) {
 								this.btnDelay.changeState('slideIn');
 							}


### PR DESCRIPTION
Fixed placement of fullscreen button in UI match and removed flee button as requested in #1730.  Also, adjusted `.button#fullscreen `selector in `styles.less` to match the size of the other ui buttons. 





<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1820"><img src="https://gitpod.io/api/apps/github/pbs/github.com/jamesleeat/AncientBeast.git/d8c132cb2e05a5888e1d6208946def750d132bdc.svg" /></a>

