### PR TITLE
#1825: stop end game audio when exiting

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -1367,7 +1367,7 @@ export default class Game {
 	 */
 	endGame() {
 		this.soundsys.stopMusic();
-		this.soundsys.playSound(this.soundLoaded[5], this.soundsys.effectsGainNode);
+		this.endGameSound = this.soundsys.playSound(this.soundLoaded[5], this.soundsys.effectsGainNode);
 
 		this.stopTimer();
 		this.gameState = 'ended';
@@ -1483,6 +1483,7 @@ export default class Game {
 	}
 
 	resetGame() {
+		this.endGameSound.stop();
 		this.UI.showGameSetup();
 		this.stopTimer(this.timeInterval);
 		this.players = [];


### PR DESCRIPTION
Resolves #1825

I felt kinda responsible for this bug, so I wanted to fix it
I would suggest to extend the SoundSys class in the future for it to contain all the playing sounds, so it would be easy to manage and debugg in case of "sound bugs". It's rather an architectural change thought

<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1827"><img src="https://gitpod.io/api/apps/github/pbs/github.com/ItsMeaga1n/AncientBeast.git/e194084b348a2db68617f8666ebf6cbe6ee6ed48.svg" /></a>

