### PR TITLE
Fixed Issue 633, Slight refactor in hexgrid to remove duplicate code

### DIFF
--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -2428,11 +2428,14 @@ export class UI {
 			.find('.vignette.roundmarker')
 			.unbind('mouseover')
 			.unbind('mouseleave')
-			.bind('mouseover', () => {
+			.bind('mouseover', (e) => {
 				game.grid.showGrid(true);
+				game.grid.showMovementRangeInOverlay(game.activeCreature);
 			})
 			.bind('mouseleave', () => {
 				game.grid.showGrid(false);
+				game.grid.cleanOverlay();
+				game.grid.showMovementRange(game.activeCreature.id);
 			});
 
 		// Add shift keydown effect like above, onkeydown => showGrid

--- a/src/utility/hexgrid.js
+++ b/src/utility/hexgrid.js
@@ -1056,26 +1056,8 @@ export class HexGrid {
 
 	// TODO: Rewrite methods used here to only require the creature as an argument.
 	showMovementRange(id) {
-		let creature = this.game.creatures[id],
-			hexes;
-
-		if (creature.movementType() === 'flying') {
-			hexes = this.getFlyingRange(
-				creature.x,
-				creature.y,
-				creature.stats.movement,
-				creature.size,
-				creature.id,
-			);
-		} else {
-			hexes = this.getMovementRange(
-				creature.x,
-				creature.y,
-				creature.stats.movement,
-				creature.size,
-				creature.id,
-			);
-		}
+		let creature = this.game.creatures[id];
+		let hexes = this.findCreatureMovementHexes(creature);
 
 		// Block all hexes
 		this.forEachHex((hex) => {
@@ -1086,6 +1068,35 @@ export class HexGrid {
 		hexes.forEach((hex) => {
 			hex.setReachable();
 		});
+	}
+
+	showMovementRangeInOverlay(creature) {
+		let hexes = this.findCreatureMovementHexes(creature);
+
+		// Set reachable the given hexes
+		hexes.forEach((hex) => {
+			hex.overlayVisualState('hover h_player' + creature.team);
+		});
+	}
+
+	findCreatureMovementHexes(creature) {
+		if (creature.movementType() === 'flying') {
+			return this.getFlyingRange(
+				creature.x,
+				creature.y,
+				creature.stats.movement,
+				creature.size,
+				creature.id,
+			);
+		} else {
+			return this.getMovementRange(
+				creature.x,
+				creature.y,
+				creature.stats.movement,
+				creature.size,
+				creature.id,
+			);
+		}
 	}
 
 	selectHexUp() {


### PR DESCRIPTION
https://github.com/FreezingMoon/AncientBeast/issues/633

When hovering over roundmarker the current units movement range changes to grey so it can be seen. 
I also refactored hexgrid.js to remove duplicate code between showMovementRange and my newly created showMovementRangeInOverlay. 

Possible issues - this doesn't grey out the hexes when pressing the shift button. Since that wasn't listed in the issue I wasn't sure if I should add it. 


<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1828"><img src="https://gitpod.io/api/apps/github/pbs/github.com/CKillen/AncientBeast.git/fa867b98d6f8548abe602f9e137e6ce1417aab99.svg" /></a>

