### PR TITLE
Updated some ability info to be more clear and grammatically correct

### DIFF
--- a/assets/units/data.json
+++ b/assets/units/data.json
@@ -38,7 +38,7 @@
 		"ability_info": [
 			{
 				"title": "Plasma Field",
-				"desc": "Protects from most harmful abilities when unit is not currently active.",
+				"desc": "Protects from most harmful abilities when the unit is not currently active.",
 				"info": "-1 plasma for each countered attack.",
 				"upgrade": "9 pure damage counter hit.",
 				"costs": {
@@ -1319,7 +1319,7 @@
 		"ability_info": [
 			{
 				"title": "Explosive End",
-				"desc": "Instantly detonates upon death, dealing damage to all adjacent units.",
+				"desc": "Instantly self detonates upon death, dealing damage to all adjacent units.",
 				"info": "10 burn + 10 crush + 10 sonic damage.",
 				"upgrade": "Detonates only nearby foes."
 			},

--- a/assets/units/data.json
+++ b/assets/units/data.json
@@ -38,7 +38,7 @@
 		"ability_info": [
 			{
 				"title": "Plasma Field",
-				"desc": "Protects from most harmful abilities when unit not being currently active.",
+				"desc": "Protects from most harmful abilities when unit is not currently active.",
 				"info": "-1 plasma for each countered attack.",
 				"upgrade": "9 pure damage counter hit.",
 				"costs": {
@@ -870,7 +870,7 @@
 			},
 			{
 				"title": "Sudden Uppercut",
-				"desc": "Sucker punches a near enemy using limb, making him delay the next turn.",
+				"desc": "Sucker punches a nearby enemy using limb, making him delay the next turn.",
 				"info": "10 crush + 10 frost damage and delay.",
 				"upgrade": "-10 defense until it will act.",
 				"damages": {
@@ -1319,7 +1319,7 @@
 		"ability_info": [
 			{
 				"title": "Explosive End",
-				"desc": "Instantly detonates when being killed, dealing damage to all adjacent units.",
+				"desc": "Instantly detonates upon death, dealing damage to all adjacent units.",
 				"info": "10 burn + 10 crush + 10 sonic damage.",
 				"upgrade": "Detonates only nearby foes."
 			},
@@ -1386,7 +1386,7 @@
 		"ability_info": [
 			{
 				"title": "Ragnarok Day",
-				"desc": "Before dying, bombarding the whole battlefield after one complete round.",
+				"desc": "Before dying, bombards the whole battlefield after one complete round.",
 				"info": "5 crush + 15 burn damage to all units.",
 				"upgrade": "Does double damage now."
 			},


### PR DESCRIPTION
This PR references https://github.com/FreezingMoon/AncientBeast/issues/1856

I changed a few other abilities to sound better or fix grammatical mistakes. 
For Nightmare
Ability: Sudden Uppercut
Original: "Sucker punches a near enemy using limb, making him delay the next turn."
New: "Sucker punches a nearby enemy using limb, making him delay the next turn."

For Cycloper:
Ability: Explosive End
Original "Instantly detonates when being killed, dealing damage to all adjacent units"
New: "Instantly detonates upon death, dealing damage to all adjacent units."

Dark Priest:
Ability: Plasma Field
Original: "Protects from most harmful abilities when unit not being currently active."
New: "Protects from most harmful abilities when unit is not currently active."

Vulcan:
Ability: Ragnarok Day
Original: "Before dying, bombarding the whole battlefield after one complete round."
New: "Before dying, bombards the whole battlefield after one complete round."



