### PR TITLE
Fix/1802 add load game

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -70,6 +70,19 @@ $j(() => {
 				}
 			},
 		},
+		KeyL: {
+			onkeydown(event) {
+				if (event.metaKey || event.ctrlKey) {
+					readLogFromFile()
+						.then((logstr) => JSON.parse(logstr))
+						.then((log) => G.gamelog.play(log))
+						.catch((err) => {
+							alert('An error occurred while loading the log file');
+							console.log(err);
+						});
+				}
+			},
+		},
 	};
 
 	// Binding Hotkeys
@@ -241,6 +254,35 @@ function getReg() {
 	};
 
 	return reg;
+}
+
+/**
+ * read log from file
+ * @returns {Promise<string>}
+ */
+function readLogFromFile() {
+	return new Promise((resolve, reject) => {
+		let fileInput = document.createElement('input');
+		fileInput.accept = '.AB';
+		fileInput.type = 'file';
+
+		fileInput.onchange = (event) => {
+			let file = event.target.files[0];
+			let reader = new FileReader();
+
+			reader.readAsText(file);
+
+			reader.onload = () => {
+				resolve(reader.result);
+			};
+
+			reader.onerror = () => {
+				reject(reader.error);
+			};
+		};
+
+		fileInput.click();
+	});
 }
 
 /**

--- a/src/script.js
+++ b/src/script.js
@@ -41,7 +41,7 @@ dataJson.forEach(async (creature) => {
 	);
 });
 
-$j(document).ready(() => {
+$j(() => {
 	let scrim = $j('.scrim');
 	scrim.on('transitionend', function () {
 		scrim.remove();
@@ -63,7 +63,7 @@ $j(document).ready(() => {
 	$j('#fullscreen').on('click', () => fullscreen.toggle());
 
 	// Binding Hotkeys
-	$j(document).keydown((event) => {
+	$j(document).on('keydown', (event) => {
 		const fullscreenHotkey = 70;
 		const pressedKey = event.keyCode || event.which;
 		if (event.shiftKey && fullscreenHotkey == pressedKey) {
@@ -91,9 +91,9 @@ $j(document).ready(() => {
 	});
 
 	// Focus the form to enable "press enter to start the game" functionality
-	$j('#startButton').focus();
+	$j('#startButton').trigger('focus');
 
-	$j('form#gameSetup').submit((e) => {
+	$j('form#gameSetup').on('submit', (e) => {
 		e.preventDefault(); // Prevent submit
 		let gameconfig = getGameConfig();
 		G.loadGame(gameconfig);
@@ -154,7 +154,7 @@ $j(document).ready(() => {
 		console.log('new user created.' + session);
 		return false; // Prevent submit
 	}
-	$j('form#register').submit(register);
+	$j('form#register').on('submit', register);
 
 	async function login(e) {
 		e.preventDefault(); // Prevent submit
@@ -197,7 +197,7 @@ $j(document).ready(() => {
 		return false; // Prevent submit
 	}
 	// Login form
-	$j('form#login').submit(login);
+	$j('form#login').on('submit', login);
 	$j('#startMatchButton').on('click', () => {
 		let gameConfig = getGameConfig();
 		G.loadGame(gameConfig, true);

--- a/src/script.js
+++ b/src/script.js
@@ -62,12 +62,24 @@ $j(() => {
 	let fullscreen = new Fullscreen($j('#fullscreen'));
 	$j('#fullscreen').on('click', () => fullscreen.toggle());
 
+	let startScreenHotkeys = {
+		KeyF: {
+			onkeydown(event) {
+				if (event.shiftKey) {
+					fullscreen.toggle();
+				}
+			},
+		},
+	};
+
 	// Binding Hotkeys
 	$j(document).on('keydown', (event) => {
-		const fullscreenHotkey = 70;
-		const pressedKey = event.keyCode || event.which;
-		if (event.shiftKey && fullscreenHotkey == pressedKey) {
-			fullscreen.toggle();
+		let keydownAction = startScreenHotkeys[event.code] && startScreenHotkeys[event.code].onkeydown;
+
+		if (keydownAction !== undefined) {
+			keydownAction.call(this, event);
+
+			event.preventDefault();
 		}
 	});
 

--- a/src/script.js
+++ b/src/script.js
@@ -283,7 +283,7 @@ function getReg() {
 function readLogFromFile() {
 	return new Promise((resolve, reject) => {
 		let fileInput = document.createElement('input');
-		fileInput.accept = '.ab';
+		fileInput.accept = '.AB';
 		fileInput.type = 'file';
 
 		fileInput.onchange = (event) => {

--- a/src/script.js
+++ b/src/script.js
@@ -263,7 +263,7 @@ function getReg() {
 function readLogFromFile() {
 	return new Promise((resolve, reject) => {
 		let fileInput = document.createElement('input');
-		fileInput.accept = '.AB';
+		fileInput.accept = '.ab';
 		fileInput.type = 'file';
 
 		fileInput.onchange = (event) => {

--- a/src/utility/gamelog.js
+++ b/src/utility/gamelog.js
@@ -143,7 +143,7 @@ export class GameLog {
 					return;
 				}
 
-				this.saveFile(JSON.stringify(dict.log), `${fileName}.AB`);
+				this.saveFile(JSON.stringify(dict), `${fileName}.ab`);
 				break;
 			case 'hash':
 				output = hash;


### PR DESCRIPTION
Fix #1802 

Implement loading log from file.

Unfortunately in firefox you need to interact with screen before hotkey become available due to browser restrictions. Without interaction after pressing hotkey I saw in browser console warning message about this restriction

<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1911"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

