### PR TITLE
Fix/hotkeys leak

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -242,6 +242,10 @@ export default class Game {
 	 */
 
 	loadGame(setupOpt, matchInitialized, matchid) {
+		// Need to remove keydown listener before new game start
+		// to prevent memory leak and mixing hotkeys between start screen and game
+		$j(document).off('keydown');
+
 		if (this.multiplayer && !matchid) {
 			this.matchInitialized = matchInitialized;
 		}

--- a/src/utility/gamelog.js
+++ b/src/utility/gamelog.js
@@ -30,13 +30,6 @@ export class GameLog {
 		} else {
 			game.loadGame(config);
 			this.gameConfig = config;
-
-			// TODO: We should be able to initiate this w/o manipulating the DOM -- However,
-			// currently "random" BG is processed on Submit. -- ktiedt
-			let btn = $j('#startButton');
-			if (btn.length === 1) {
-				btn.click();
-			}
 		}
 	}
 


### PR DESCRIPTION
I found that for now key bindings from start screen is available in game screen too. It causes memory leaks and can lead to strange behaviour (for example there are 2 active key handlers for fullscreen mode one from game hotkeys and one from  start screen). So, I decide to it is much better to clear key bindings from start screen before game until we haven't more understandable hotkey binding system. Also remove unnecessary code, game can start without DOM interaction


P.s. @DreadKnight, do your browser correct work with uppercase extension while loading log (https://github.com/FreezingMoon/AncientBeast/blob/6ebb20cca21b1e88cb565c7c0fd602cbed6d3e04/src/script.js#L286)? 
In my chromium browser it open a window that search only for lowercase file extensions, so it will not find anything because gamelog saves as .AB file

<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1913"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

