### PR TITLE
change log file extension to lower-case

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -283,7 +283,7 @@ function getReg() {
 function readLogFromFile() {
 	return new Promise((resolve, reject) => {
 		let fileInput = document.createElement('input');
-		fileInput.accept = '.AB';
+		fileInput.accept = '.ab';
 		fileInput.type = 'file';
 
 		fileInput.onchange = (event) => {

--- a/src/utility/gamelog.js
+++ b/src/utility/gamelog.js
@@ -135,7 +135,7 @@ export class GameLog {
 				if (this._debounce) {
 					return;
 				}
-				this.saveFile(JSON.stringify(dict), `${fileName}.AB`);
+				this.saveFile(JSON.stringify(dict), `${fileName}.ab`);
 				break;
 			case 'hash':
 				output = hash;


### PR DESCRIPTION
In chromium, input property "accept" can only work with lower case extensions


<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1915"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

