### PR TITLE
Fix global hotkeys preventing typing some characters

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -74,7 +74,7 @@ $j(() => {
 		},
 		KeyL: {
 			keyDownTest(event) {
-				return event.metaKey || event.ctrlKey;
+				return event.metaKey && event.ctrlKey;
 			},
 			keyDownAction(event) {
 				readLogFromFile()

--- a/src/script.js
+++ b/src/script.js
@@ -65,35 +65,42 @@ $j(() => {
 
 	let startScreenHotkeys = {
 		KeyF: {
-			onkeydown(event) {
-				if (event.shiftKey) {
-					fullscreen.toggle();
-				}
+			keyDownTest(event) {
+				return event.shiftKey;
+			},
+			keyDownAction() {
+				fullscreen.toggle();
 			},
 		},
 		KeyL: {
-			onkeydown(event) {
-				if (event.metaKey || event.ctrlKey) {
-					readLogFromFile()
-						.then((logstr) => JSON.parse(logstr))
-						.then((log) => G.gamelog.play(log))
-						.catch((err) => {
-							alert('An error occurred while loading the log file');
-							console.log(err);
-						});
-				}
+			keyDownTest(event) {
+				return event.metaKey || event.ctrlKey;
+			},
+			keyDownAction(event) {
+				readLogFromFile()
+					.then((logstr) => JSON.parse(logstr))
+					.then((log) => G.gamelog.play(log))
+					.catch((err) => {
+						alert('An error occurred while loading the log file');
+						console.log(err);
+					});
 			},
 		},
 	};
 
 	// Binding Hotkeys
 	$j(document).on('keydown', (event) => {
-		let keydownAction = startScreenHotkeys[event.code] && startScreenHotkeys[event.code].onkeydown;
+		const hotkey = startScreenHotkeys[event.code];
 
-		if (keydownAction !== undefined) {
-			keydownAction.call(this, event);
+		if (hotkey === undefined) {
+			return;
+		}
 
+		const { keyDownTest, keyDownAction } = hotkey;
+
+		if (keyDownTest.call(this, event)) {
 			event.preventDefault();
+			keyDownAction.call(this, event);
 		}
 	});
 


### PR DESCRIPTION
This MR fixes https://github.com/FreezingMoon/AncientBeast/issues/1930.

Can type "f"/"l" characters:

![CleanShot 2021-12-02 at 15 16 43](https://user-images.githubusercontent.com/199204/144362932-91e06ea0-44ef-4f32-be6b-d92bb33735a0.gif)

Can still use global hotkeys:

* SHIFT + F opens full screen.
* CTRL + META + L loads log file.

![CleanShot 2021-12-02 at 15 17 32](https://user-images.githubusercontent.com/199204/144362996-ff67ca1b-e7a6-411f-998b-2f9bb1bb9e48.gif)

<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1931"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

