### PR TITLE
Added timestamp in saved game logs (fixes #1934)

### DIFF
--- a/src/utility/gamelog.js
+++ b/src/utility/gamelog.js
@@ -44,9 +44,9 @@ export class GameLog {
 			this.data = data;
 			return this.config(config);
 		} else if (typeof log == 'string') {
-			let results = log.match(/^AB-(dev|[0-9.]+):(.+)$/);
+			let results = log.match(/^AB-(dev|[0-9.]+)(\@[0-9\-]+)?:(.+)$/);
 			if (results) {
-				log = JSON.parse(atob(results[2]));
+				log = JSON.parse(atob(results[3]));
 				return this.play(log);
 			}
 		}
@@ -112,17 +112,17 @@ export class GameLog {
 	}
 
 	get(state) {
+		let today = new Date().toISOString().slice(0, 10);
 		let config = isEmpty(this.gameConfig) ? getGameConfig() : this.gameConfig,
 			dict = {
 				config: config,
 				log: this.data,
 			},
 			json = JSON.stringify(dict),
-			hash = 'AB-' + this.game.version + ':' + btoa(JSON.stringify(dict)),
+			hash = 'AB-' + this.game.version + '@' + today + ':' + btoa(JSON.stringify(dict)),
 			output,
 			strOutput;
 
-		let today = new Date().toISOString().slice(0, 10);
 		dict.config['date'] = today;
 		let fileName = `AB-${this.game.version}:${today}`;
 

--- a/src/utility/gamelog.js
+++ b/src/utility/gamelog.js
@@ -123,6 +123,7 @@ export class GameLog {
 			strOutput;
 
 		let today = new Date().toISOString().slice(0, 10);
+		dict.config['date'] = today;
 		let fileName = `AB-${this.game.version}:${today}`;
 
 		switch (state) {

--- a/src/utility/gamelog.js
+++ b/src/utility/gamelog.js
@@ -123,7 +123,6 @@ export class GameLog {
 			output,
 			strOutput;
 
-		dict.config['date'] = today;
 		let fileName = `AB-${this.game.version}:${today}`;
 
 		switch (state) {


### PR DESCRIPTION
The config entry in the JSON saved log has the date of the save file,
same as the filename. See the issue for discussion.

If your pull request tries to address a specific issue from the repository, please reference to it.
Don't forget to include a description of the changes proposes. https://discord.me/AncientBeast


<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1938"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

