### PR TITLE
1106 - Bunny Hop triggers however an enemy comes into proximity with the Bunny

### DIFF
--- a/src/abilities/Headless.js
+++ b/src/abilities/Headless.js
@@ -299,13 +299,15 @@ export default (G) => {
 				}); //remove creatures
 				ability.end();
 
-				//Movement
+				// Movement
 				arrayUtils.filterCreature(path, false, false);
 				let destination = null;
 				let destinationTarget = null;
 				if (target.size === 1) {
-					// Small creature, pull target towards self
-					destinationTarget = path.first();
+					/* Small creature, pull target towards self landing it in the hex directly
+					in front of the Headless. */
+					const hexInFrontOfHeadless = path[0];
+					destinationTarget = hexInFrontOfHeadless;
 				} else if (target.size === 2) {
 					// Medium creature, pull self and target towards each other half way,
 					// rounding upwards for self (self move one extra hex if required)
@@ -321,6 +323,8 @@ export default (G) => {
 
 				let x;
 				let hex;
+
+				// Check if Headless will be moved.
 				if (destination !== null) {
 					x = args.direction === 4 ? destination.x + crea.size - 1 : destination.x;
 					hex = G.grid.hexes[destination.y][x];
@@ -337,6 +341,8 @@ export default (G) => {
 						},
 					});
 				}
+
+				// Check if target creature will be moved.
 				if (destinationTarget !== null) {
 					x = args.direction === 1 ? destinationTarget.x + target.size - 1 : destinationTarget.x;
 					hex = G.grid.hexes[destinationTarget.y][x];

--- a/src/abilities/Snow-Bunny.js
+++ b/src/abilities/Snow-Bunny.js
@@ -142,18 +142,19 @@ export default (G) => {
 			},
 
 			/**
-			 * Determine if a hex containing an enemy is in front of the bunny.
+			 * Determine if a hex containing an enemy is in front of the bunny. Useful
+			 * for checking if a newly moved enemy has entered the Bunny's Hop zone.
 			 *
-			 * @param {Hex} hexWithEnemy
-			 * @returns Hex
+			 * @param {Hex} hexWithEnemy Hex known to contain an enemy.
+			 * @returns {Hex | undefined} hexWithEnemy if it did move in front of the bunny, otherwise undefined.
 			 */
 			_findEnemyHexInFront: function (hexWithEnemy) {
 				const frontHexesWithEnemy = this._detectFrontHexesWithEnemy();
-				const foundEnemyHex = frontHexesWithEnemy.find(
+				const foundEnemyHex = frontHexesWithEnemy.some(
 					({ hex }) => hexWithEnemy.creature === hex.creature,
 				);
 
-				return foundEnemyHex;
+				return foundEnemyHex ? hexWithEnemy : undefined;
 			},
 
 			/**

--- a/src/abilities/Snow-Bunny.js
+++ b/src/abilities/Snow-Bunny.js
@@ -168,7 +168,7 @@ export default (G) => {
 
 					if (hexHasEnemy) {
 						acc.push({
-							// 0 = front above, 1 = front, 2 = front below
+							// Maps to HopTriggerDirections.
 							direction: idx,
 							hex: curr,
 						});

--- a/src/abilities/Snow-Bunny.js
+++ b/src/abilities/Snow-Bunny.js
@@ -25,15 +25,17 @@ export default (G) => {
 				/* If enough uses, jump away when an enemy has entered our trigger area, 
 				and we have a space to jump back to. */
 				const abilityCanTrigger =
+					this.timesUsedThisTurn < this._getUsesPerTurn() &&
+					// Bunny cannot use this ability if affected by these states.
+					!(this.creature.materializationSickness || this.creature.stats.frozen) &&
 					// This ability only triggers on other creature's turns, it's purely defensive.
 					this.creature !== this.game.activeCreature &&
-					this.timesUsedThisTurn < this._getUsesPerTurn() &&
-					!this.creature.stats.frozen &&
 					enemyInFront &&
-					/* Only the active creature should trigger the Hop, not other creatures
-					that happen to be nearby. */
+					/* Only the active enemy creature should trigger the Hop, not other enemy 
+					creatures that happen to be nearby. */
 					enemyInFront === this.game.activeCreature &&
-					this._getHopHex(enemyInFront.hexagons[0]) !== undefined;
+					// Bunny needs a valid hex to retreat into.
+					this._getHopHex(enemyInFront.hexagons[0]);
 
 				return abilityCanTrigger;
 			},

--- a/src/abilities/Snow-Bunny.js
+++ b/src/abilities/Snow-Bunny.js
@@ -131,7 +131,9 @@ export default (G) => {
 			 */
 			_findEnemyHexInFront: function (hexWithEnemy) {
 				const frontHexesWithEnemy = this._detectFrontHexesWithEnemy();
-				const foundEnemy = frontHexesWithEnemy.find(({ hex }) => hexWithEnemy.coord === hex.coord);
+				const foundEnemy = frontHexesWithEnemy.find(
+					({ hex }) => hexWithEnemy.creature === hex.creature,
+				);
 				console.log({ hexWithEnemy, frontHexesWithEnemy, foundEnemy });
 
 				return foundEnemy;

--- a/src/abilities/Snow-Bunny.js
+++ b/src/abilities/Snow-Bunny.js
@@ -21,16 +21,19 @@ export default (G) => {
 		 * After any movement, if an enemy is newly detected in the 3 hexes in front
 		 * of the bunny (facing right for player 1, left for player 2), the creature
 		 * will move backwards one space in an opposite direction.
-		 *
-		 * The ability is only usable if the creature is not affected by ability-restricting
-		 * effects such as Materialization Sickness or Frozen.
 		 */
 		{
 			//	Type : Can be "onQuery", "onStartPhase", "onDamage"
 			trigger: 'onCreatureMove onOtherCreatureMove',
 
 			/**
-			 * Determine if the ability should trigger.
+			 * Bunny Hop triggers on any movement during other creature's turns (not the
+			 * Bunny's self-movement) that causes an enemy to appear in front of the Bunny.
+			 * This could be the enemy moving, or an enemy or ally displacing the Bunny
+			 * or another creature.
+			 *
+			 * Bunny Hop is only usable if the creature is not affected by ability-restricting
+			 * effects such as Materialization Sickness or Frozen.
 			 *
 			 * @param {Hex} hex Destination hex where a creature (bunny or other) has moved.
 			 * @returns {boolean} If the ability should trigger.

--- a/src/abilities/Snow-Bunny.js
+++ b/src/abilities/Snow-Bunny.js
@@ -24,11 +24,6 @@ export default (G) => {
 		 *
 		 * The ability is only usable if the creature is not affected by ability-restricting
 		 * effects such as Materialization Sickness or Frozen.
-		 *
-		 * Movement rules:
-		 * - If movement in the opposite direction is impossible, it will move backwards.
-		 * - If the top and bottom front hexes are both occupied, it will move backwards.
-		 * - If moving backwards and is unable to do so. movement is cancelled.
 		 */
 		{
 			//	Type : Can be "onQuery", "onStartPhase", "onDamage"
@@ -99,6 +94,11 @@ export default (G) => {
 			/**
 			 * Analyse frontal enemy positions and determine which (if any) Hexes are
 			 * available for the Bunny to hop backwards into.
+			 *
+			 * Movement rules:
+			 * - If movement in the opposite direction is impossible, it will move backwards.
+			 * - If the top and bottom front hexes are both occupied, it will move backwards.
+			 * - If moving backwards and is unable to do so. movement is cancelled.
 			 *
 			 * At this point we have determined the ability should be triggered, so we
 			 * are only concerned which enemies to hop away from, not which enemies originally

--- a/src/abilities/Snow-Bunny.js
+++ b/src/abilities/Snow-Bunny.js
@@ -24,18 +24,18 @@ export default (G) => {
 
 				/* If enough uses, jump away when an enemy has entered our trigger area, 
 				and we have a space to jump back to. */
-				return (
+				const abilityCanTrigger =
 					// This ability only triggers on other creature's turns, it's purely defensive.
-					this.game.activeCreature !== this.creature &&
+					this.creature !== this.game.activeCreature &&
 					this.timesUsedThisTurn < this._getUsesPerTurn() &&
+					!this.creature.stats.frozen &&
 					enemyInFront &&
 					/* Only the active creature should trigger the Hop, not other creatures
 					that happen to be nearby. */
 					enemyInFront === this.game.activeCreature &&
-					this._getTriggerHexId(enemyInFront.hexagons[0]) >= 0 &&
-					// TODO: check bunny isn't frozen
-					this._getHopHex(enemyInFront.hexagons[0]) !== undefined
-				);
+					this._getHopHex(enemyInFront.hexagons[0]) !== undefined;
+
+				return abilityCanTrigger;
 			},
 
 			//	activate() :

--- a/src/ability.js
+++ b/src/ability.js
@@ -293,12 +293,8 @@ export class Ability {
 				}
 			}
 		} else {
-			/* If creature is affected by materialization sickness or is frozen, cancel
-			all movement or abilities. */
-			if (
-				(this.creature.materializationSickness && this.affectedByMatSickness) ||
-				this.creature.stats.frozen
-			) {
+			// Test for materialization sickness
+			if (this.creature.materializationSickness && this.affectedByMatSickness) {
 				return false;
 			}
 		}

--- a/src/ability.js
+++ b/src/ability.js
@@ -293,8 +293,12 @@ export class Ability {
 				}
 			}
 		} else {
-			// Test for materialization sickness
-			if (this.creature.materializationSickness && this.affectedByMatSickness) {
+			/* If creature is affected by materialization sickness or is frozen, cancel
+			all movement or abilities. */
+			if (
+				(this.creature.materializationSickness && this.affectedByMatSickness) ||
+				this.creature.stats.frozen
+			) {
 				return false;
 			}
 		}


### PR DESCRIPTION
This MR allows the Bunny Hop ability to trigger when:

* an enemy enters the 3 hexes in front of the Bunny (already worked)
* the Bunny is displaced and now has an enemy within the 3 hexes in front of the Bunny (new)

![CleanShot 2021-12-07 at 21 47 42](https://user-images.githubusercontent.com/199204/145024677-eff110c4-d575-4ee7-a261-83e187872539.gif)

![CleanShot 2021-12-07 at 21 48 26](https://user-images.githubusercontent.com/199204/145024943-2d5f0f42-d950-4f68-bf7f-8552c04d4e8e.gif)

When Bunny is frozen:

![CleanShot 2021-12-07 at 21 46 01](https://user-images.githubusercontent.com/199204/145026428-9b18406b-6a48-49b3-9960-78f8093b2e1d.png)

![CleanShot 2021-12-07 at 21 46 15](https://user-images.githubusercontent.com/199204/145026465-88fe03ca-6069-492a-ac9b-890ef74c0bc1.png)


<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1939"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

