### PR TITLE
1649 - Fix unit Drop location after being affected by certain traps

### DIFF
--- a/src/abilities/Impaler.js
+++ b/src/abilities/Impaler.js
@@ -208,9 +208,9 @@ export default (G) => {
 					'onStepOut',
 					{
 						effectFn: (eff) => {
-							const handleCreatureEvent = (message, payload) => {
+							const waitForMovementComplete = (message, payload) => {
 								if (message === 'movementComplete' && payload.creature.id === eff.target.id) {
-									this.game.signals.creature.remove(handleCreatureEvent);
+									this.game.signals.creature.remove(waitForMovementComplete);
 
 									G.log('%CreatureName' + eff.target.id + '% is hit by ' + eff.name);
 									eff.target.takeDamage(new Damage(eff.owner, damages, 1, [], G), {
@@ -226,7 +226,7 @@ export default (G) => {
 							};
 
 							// Wait until movement is completely finished before processing effects.
-							this.game.signals.creature.add(handleCreatureEvent);
+							this.game.signals.creature.add(waitForMovementComplete);
 						},
 					},
 					G,

--- a/src/abilities/Impaler.js
+++ b/src/abilities/Impaler.js
@@ -209,8 +209,7 @@ export default (G) => {
 					{
 						effectFn: (eff) => {
 							const handleCreatureEvent = (message, payload) => {
-								console.log({ message, payload }, eff.target);
-								if (message === 'movementComplete' && payload.id === eff.target.id) {
+								if (message === 'movementComplete' && payload.creature.id === eff.target.id) {
 									this.game.signals.creature.remove(handleCreatureEvent);
 
 									G.log('%CreatureName' + eff.target.id + '% is hit by ' + eff.name);

--- a/src/abilities/Impaler.js
+++ b/src/abilities/Impaler.js
@@ -137,7 +137,7 @@ export default (G) => {
 			},
 		},
 
-		// 	Thirt Ability: Poisonous Vine
+		// 	Third Ability: Poisonous Vine
 		{
 			//	Type : Can be "onQuery", "onStartPhase", "onDamage"
 			trigger: 'onQuery',
@@ -207,17 +207,27 @@ export default (G) => {
 					this,
 					'onStepOut',
 					{
-						effectFn: function (eff) {
-							G.log('%CreatureName' + eff.target.id + '% is hit by ' + eff.name);
-							eff.target.takeDamage(new Damage(eff.owner, damages, 1, [], G), {
-								isFromTrap: true,
-							});
-							// Hack: manually destroy traps so we don't activate multiple traps
-							// and see multiple logs etc.
-							target.hexagons.forEach(function (hex) {
-								hex.destroyTrap();
-							});
-							eff.deleteEffect();
+						effectFn: (eff) => {
+							const handleCreatureEvent = (message, payload) => {
+								console.log({ message, payload }, eff.target);
+								if (message === 'movementComplete' && payload.id === eff.target.id) {
+									this.game.signals.creature.remove(handleCreatureEvent);
+
+									G.log('%CreatureName' + eff.target.id + '% is hit by ' + eff.name);
+									eff.target.takeDamage(new Damage(eff.owner, damages, 1, [], G), {
+										isFromTrap: true,
+									});
+									// Hack: manually destroy traps so we don't activate multiple traps
+									// and see multiple logs etc.
+									target.hexagons.forEach(function (hex) {
+										hex.destroyTrap();
+									});
+									eff.deleteEffect();
+								}
+							};
+
+							// Wait until movement is completely finished before processing effects.
+							this.game.signals.creature.add(handleCreatureEvent);
 						},
 					},
 					G,

--- a/src/abilities/Nutcase.js
+++ b/src/abilities/Nutcase.js
@@ -204,7 +204,7 @@ export default (G) => {
 					'Hammered', // Name
 					this.creature, // Caster
 					target, // Target
-					'onStepOut', // Trigger
+					'onStepIn', // Trigger
 					{
 						effectFn: function (eff) {
 							eff.target.takeDamage(
@@ -470,7 +470,7 @@ export default (G) => {
 			},
 		},
 
-		//	Third Ability: Fishing Hook
+		//	Fourth Ability: Fishing Hook
 		{
 			//	Type : Can be "onQuery", "onStartPhase", "onDamage"
 			trigger: 'onQuery',

--- a/src/abilities/Nutcase.js
+++ b/src/abilities/Nutcase.js
@@ -204,21 +204,30 @@ export default (G) => {
 					'Hammered', // Name
 					this.creature, // Caster
 					target, // Target
-					'onStepIn', // Trigger
+					'onStepOut', // Trigger
 					{
 						effectFn: function (eff) {
-							eff.target.takeDamage(
-								new Damage(
-									eff.owner,
-									{
-										pierce: ability.damages.pierce,
-									},
-									1,
-									[],
-									G,
-								),
-							);
-							eff.deleteEffect();
+							const waitForMovementComplete = (message, payload) => {
+								if (message === 'movementComplete' && payload.creature.id === eff.target.id) {
+									this.game.signals.creature.remove(waitForMovementComplete);
+
+									eff.target.takeDamage(
+										new Damage(
+											eff.owner,
+											{
+												pierce: ability.damages.pierce,
+											},
+											1,
+											[],
+											G,
+										),
+									);
+									eff.deleteEffect();
+								}
+							};
+
+							// Wait until movement is completely finished before processing effects.
+							this.game.signals.creature.add(waitForMovementComplete);
 						},
 					},
 					G,

--- a/src/animations.js
+++ b/src/animations.js
@@ -239,8 +239,6 @@ export class Animations {
 		// TODO: Reveal health indicator
 		creature.healthShow();
 
-		game.onCreatureMove(creature, hex); // Trigger
-
 		creature.hexagons.forEach((h) => {
 			h.pickupDrop(creature);
 		});

--- a/src/creature.js
+++ b/src/creature.js
@@ -788,10 +788,10 @@ export class Creature {
 		}
 
 		let interval = setInterval(() => {
+			// Check if creature's movement animation is completely finished.
 			if (!game.freezedInput) {
 				clearInterval(interval);
 				opts.callback();
-				// Creature's movement is completely finished.
 				game.signals.creature.dispatch('movementComplete', { creature: this, hex });
 				game.onCreatureMove(this, hex); // Trigger
 			}

--- a/src/creature.js
+++ b/src/creature.js
@@ -791,6 +791,9 @@ export class Creature {
 			if (!game.freezedInput) {
 				clearInterval(interval);
 				opts.callback();
+				// Creature's movement is completely finished.
+				game.signals.creature.dispatch('movementComplete', this);
+				game.onCreatureMove(this, hex); // Trigger
 			}
 		}, 100);
 	}
@@ -799,7 +802,7 @@ export class Creature {
 	 *
 	 * hex :	Hex :	Destination Hex
 	 *
-	 * Trace the path from the current possition to the given coordinates
+	 * Trace the path from the current position to the given coordinates
 	 *
 	 */
 	tracePath(hex) {
@@ -1181,13 +1184,13 @@ export class Creature {
 	 *
 	 * damage :	Damage : 	Damage object
 	 *
-	 * return :	Object :	Contains damages dealed and if creature is killed or not
+	 * return :	Object :	Contains damages dealt and if creature is killed or not
 	 */
 	takeDamage(damage, o) {
 		let game = this.game;
 
 		if (this.dead) {
-			game.log('%CreatureName' + this.id + '% is already dead, aborting takeDamage call.');
+			console.info(`${this.name} (${this.id}) is already dead, aborting takeDamage call.`);
 			return;
 		}
 

--- a/src/creature.js
+++ b/src/creature.js
@@ -792,7 +792,7 @@ export class Creature {
 				clearInterval(interval);
 				opts.callback();
 				// Creature's movement is completely finished.
-				game.signals.creature.dispatch('movementComplete', this);
+				game.signals.creature.dispatch('movementComplete', { creature: this, hex });
 				game.onCreatureMove(this, hex); // Trigger
 			}
 		}, 100);

--- a/src/game.js
+++ b/src/game.js
@@ -181,7 +181,7 @@ export default class Game {
 			oncePerDamageChain: /\boncePerDamageChain\b/,
 		};
 
-		const signalChannels = ['ui', 'metaPowers'];
+		const signalChannels = ['ui', 'metaPowers', 'creature'];
 		this.signals = this.setupSignalChannels(signalChannels);
 	}
 

--- a/src/game.js
+++ b/src/game.js
@@ -1178,7 +1178,14 @@ export default class Game {
 		}
 	}
 
-	// Removed individual args from definition because we are using the arguments variable.
+	/**
+	 * Be careful when using this trigger to apply damage as it can kill a creature
+	 * before it has completed its movement, resulting in incorrect Drop placement
+	 * and other bugs. Refer to Impaler Poisonous Vine ability for an example on how
+	 * to delay damage until the end of movement.
+	 *
+	 * Removed individual args from definition because we are using the arguments variable.
+	 */
 	onStepOut(/* creature, hex, callback */) {
 		this.triggerAbility('onStepOut', arguments);
 		this.triggerEffect('onStepOut', arguments);


### PR DESCRIPTION
This MR fixes the Drop location when a creature dies after being affected by Nutcase "Hammer Time" effect. Previously the Drop would appear on the hex the creature was at before movement:

![CleanShot 2021-12-10 at 22 01 36](https://user-images.githubusercontent.com/199204/145571384-4e72edf0-8f88-4c9f-816d-73c00a81d537.gif)

This was also the case with Impaler's "Poisonous Vine" trap effect:

![CleanShot 2021-12-10 at 22 02 28](https://user-images.githubusercontent.com/199204/145571600-eada8a39-6d52-44e9-a8e3-e8826174da43.gif)

The underlying issues is with the `onStepOut` trigger, which applies its effect (damage in this case) as soon as the creature starts moving. The solution was to delay the damage effect of those two abilities until after movement was complete.

I also had to change when the `onCreatureMove` game trigger fires to when game logic movement is complete, rather than just the animation is complete. Hopefully this hasn't introduced any new bugs, automated tests would be a big help here.

![CleanShot 2021-12-10 at 22 13 04](https://user-images.githubusercontent.com/199204/145572512-2e1c1be6-f870-4d09-8a44-26a0d0dac137.gif)

![CleanShot 2021-12-10 at 22 15 34](https://user-images.githubusercontent.com/199204/145573425-222b685b-350c-479c-9fc2-ad25dac6e181.gif)

![CleanShot 2021-12-10 at 22 20 27](https://user-images.githubusercontent.com/199204/145573448-195373a9-7ce3-4330-bc0d-fefba661a42a.gif)

![CleanShot 2021-12-10 at 22 21 21](https://user-images.githubusercontent.com/199204/145573454-7a68b8df-bc24-4693-bf96-bea72f0414e5.gif)



<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1944"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

