### PR TITLE
1089 - Change Nutcase Tentacle Bush to "end of phase" effect

### DIFF
--- a/src/abilities/Nutcase.js
+++ b/src/abilities/Nutcase.js
@@ -22,7 +22,7 @@ export default (G) => {
 			},
 
 			activate: function () {
-				const test = new Effect(
+				const effect = new Effect(
 					this.title,
 					this.creature,
 					this.creature,
@@ -38,22 +38,18 @@ export default (G) => {
 					G,
 				);
 
-				this.creature.addEffect(test);
+				this.creature.addEffect(effect);
 
-				this.end(true);
+				this.end(
+					/* Suppress "uses ability" log message, just show the "affected by" Effect
+					log message. */
+					true,
+				);
 			},
 
 			_activateOnAttacker: function (effect, damage) {
 				// Must take melee damage from a non-trap source
-				if (damage === undefined) {
-					return false;
-				}
-
-				if (!damage.melee) {
-					return false;
-				}
-
-				if (damage.isFromTrap) {
+				if (damage === undefined || !damage.melee || damage.isFromTrap) {
 					return false;
 				}
 
@@ -103,90 +99,6 @@ export default (G) => {
 				}
 			},
 		},
-
-		// {
-		// 	trigger: 'onUnderAttack',
-
-		// 	require: function () {
-		// 		// Always true to highlight ability
-		// 		return true;
-		// 	},
-
-		// 	activate: function (damage) {
-		// 		// Must take melee damage from a non-trap source
-		// 		if (damage === undefined) {
-		// 			return false;
-		// 		}
-		// 		if (!damage.melee) {
-		// 			return false;
-		// 		}
-		// 		if (damage.isFromTrap) {
-		// 			return false;
-		// 		}
-
-		// 		let ability = this;
-		// 		ability.end();
-
-		// 		// Target becomes unmoveable until end of their phase
-		// 		let o = {
-		// 			alterations: {
-		// 				moveable: false,
-		// 			},
-		// 			deleteTrigger: 'onEndPhase',
-		// 			// Delete this effect as soon as attacker's turn finishes
-		// 			turnLifetime: 1,
-		// 			creationTurn: G.turn - 1,
-		// 			deleteOnOwnerDeath: true,
-		// 		};
-		// 		// If upgraded, target abilities cost more energy
-		// 		if (this.isUpgraded()) {
-		// 			o.alterations.reqEnergy = 5;
-		// 		}
-		// 		// Create a zero damage with debuff
-		// 		let counterDamage = new Damage(
-		// 			this.creature,
-		// 			{},
-		// 			1,
-		// 			[
-		// 				new Effect(
-		// 					this.title,
-		// 					this.creature, // Caster
-		// 					damage.attacker, // Target
-		// 					'', // Trigger
-		// 					o,
-		// 					G,
-		// 				),
-		// 			],
-		// 			G,
-		// 		);
-		// 		counterDamage.counter = true;
-		// 		damage.attacker.takeDamage(counterDamage);
-		// 		// Making attacker unmoveable will change its move query, so update it
-		// 		if (damage.attacker === G.activeCreature) {
-		// 			damage.attacker.queryMove();
-		// 		}
-
-		// 		// If inactive, Nutcase becomes unmoveable until start of its phase
-		// 		if (G.activeCreature !== this.creature) {
-		// 			this.creature.addEffect(
-		// 				new Effect(
-		// 					this.title,
-		// 					this.creature,
-		// 					this.creature,
-		// 					'',
-		// 					{
-		// 						alterations: {
-		// 							moveable: false,
-		// 						},
-		// 						deleteTrigger: 'onStartPhase',
-		// 						turnLifetime: 1,
-		// 					},
-		// 					G,
-		// 				),
-		// 			);
-		// 		}
-		// 	},
-		// },
 
 		//	Second Ability: Hammer Time
 		{

--- a/src/abilities/Nutcase.js
+++ b/src/abilities/Nutcase.js
@@ -40,7 +40,7 @@ export default (G) => {
 
 				this.creature.addEffect(test);
 
-				this.end();
+				this.end(true);
 			},
 
 			_activateOnAttacker: function (effect, damage) {

--- a/src/abilities/Nutcase.js
+++ b/src/abilities/Nutcase.js
@@ -65,6 +65,7 @@ export default (G) => {
 					turnLifetime: 1,
 					creationTurn: G.turn - 1,
 					deleteOnOwnerDeath: true,
+					stackable: false,
 				};
 
 				// If upgraded, target abilities cost more energy

--- a/src/abilities/Nutcase.js
+++ b/src/abilities/Nutcase.js
@@ -53,8 +53,7 @@ export default (G) => {
 					return false;
 				}
 
-				let ability = this;
-				ability.end();
+				this.end();
 
 				// Target becomes unmovable until end of their phase
 				let o = {
@@ -73,25 +72,16 @@ export default (G) => {
 					o.alterations.reqEnergy = 5;
 				}
 
-				// Create a zero damage with debuff
-				let counterDamage = new Damage(
-					this.creature,
-					{},
-					1,
-					[
-						new Effect(
-							this.title,
-							this.creature, // Caster
-							damage.attacker, // Target
-							'', // Trigger
-							o,
-							G,
-						),
-					],
+				const attackerEffect = new Effect(
+					this.title,
+					this.creature, // Caster
+					damage.attacker, // Target
+					'', // Trigger
+					o,
 					G,
 				);
-				counterDamage.counter = true;
-				damage.attacker.takeDamage(counterDamage);
+
+				damage.attacker.addEffect(attackerEffect);
 
 				// Making attacker unmovable will change its move query, so update it
 				if (damage.attacker === G.activeCreature) {

--- a/src/abilities/Nutcase.js
+++ b/src/abilities/Nutcase.js
@@ -14,21 +14,45 @@ export default (G) => {
 	G.abilities[40] = [
 		//	First Ability: Tentacle Bush
 		{
-			trigger: 'onUnderAttack',
+			trigger: 'onEndPhase',
 
 			require: function () {
 				// Always true to highlight ability
 				return true;
 			},
 
-			activate: function (damage) {
+			activate: function () {
+				const test = new Effect(
+					this.title,
+					this.creature,
+					this.creature,
+					'onUnderAttack',
+					{
+						alterations: {
+							moveable: false,
+						},
+						effectFn: (...args) => this._activateOnAttacker(...args),
+						deleteTrigger: 'onStartPhase',
+						turnLifetime: 1,
+					},
+					G,
+				);
+
+				this.creature.addEffect(test);
+
+				this.end();
+			},
+
+			_activateOnAttacker: function (effect, damage) {
 				// Must take melee damage from a non-trap source
 				if (damage === undefined) {
 					return false;
 				}
+
 				if (!damage.melee) {
 					return false;
 				}
+
 				if (damage.isFromTrap) {
 					return false;
 				}
@@ -36,7 +60,7 @@ export default (G) => {
 				let ability = this;
 				ability.end();
 
-				// Target becomes unmoveable until end of their phase
+				// Target becomes unmovable until end of their phase
 				let o = {
 					alterations: {
 						moveable: false,
@@ -47,10 +71,12 @@ export default (G) => {
 					creationTurn: G.turn - 1,
 					deleteOnOwnerDeath: true,
 				};
+
 				// If upgraded, target abilities cost more energy
 				if (this.isUpgraded()) {
 					o.alterations.reqEnergy = 5;
 				}
+
 				// Create a zero damage with debuff
 				let counterDamage = new Damage(
 					this.creature,
@@ -70,32 +96,97 @@ export default (G) => {
 				);
 				counterDamage.counter = true;
 				damage.attacker.takeDamage(counterDamage);
-				// Making attacker unmoveable will change its move query, so update it
+
+				// Making attacker unmovable will change its move query, so update it
 				if (damage.attacker === G.activeCreature) {
 					damage.attacker.queryMove();
 				}
-
-				// If inactive, Nutcase becomes unmoveable until start of its phase
-				if (G.activeCreature !== this.creature) {
-					this.creature.addEffect(
-						new Effect(
-							this.title,
-							this.creature,
-							this.creature,
-							'',
-							{
-								alterations: {
-									moveable: false,
-								},
-								deleteTrigger: 'onStartPhase',
-								turnLifetime: 1,
-							},
-							G,
-						),
-					);
-				}
 			},
 		},
+
+		// {
+		// 	trigger: 'onUnderAttack',
+
+		// 	require: function () {
+		// 		// Always true to highlight ability
+		// 		return true;
+		// 	},
+
+		// 	activate: function (damage) {
+		// 		// Must take melee damage from a non-trap source
+		// 		if (damage === undefined) {
+		// 			return false;
+		// 		}
+		// 		if (!damage.melee) {
+		// 			return false;
+		// 		}
+		// 		if (damage.isFromTrap) {
+		// 			return false;
+		// 		}
+
+		// 		let ability = this;
+		// 		ability.end();
+
+		// 		// Target becomes unmoveable until end of their phase
+		// 		let o = {
+		// 			alterations: {
+		// 				moveable: false,
+		// 			},
+		// 			deleteTrigger: 'onEndPhase',
+		// 			// Delete this effect as soon as attacker's turn finishes
+		// 			turnLifetime: 1,
+		// 			creationTurn: G.turn - 1,
+		// 			deleteOnOwnerDeath: true,
+		// 		};
+		// 		// If upgraded, target abilities cost more energy
+		// 		if (this.isUpgraded()) {
+		// 			o.alterations.reqEnergy = 5;
+		// 		}
+		// 		// Create a zero damage with debuff
+		// 		let counterDamage = new Damage(
+		// 			this.creature,
+		// 			{},
+		// 			1,
+		// 			[
+		// 				new Effect(
+		// 					this.title,
+		// 					this.creature, // Caster
+		// 					damage.attacker, // Target
+		// 					'', // Trigger
+		// 					o,
+		// 					G,
+		// 				),
+		// 			],
+		// 			G,
+		// 		);
+		// 		counterDamage.counter = true;
+		// 		damage.attacker.takeDamage(counterDamage);
+		// 		// Making attacker unmoveable will change its move query, so update it
+		// 		if (damage.attacker === G.activeCreature) {
+		// 			damage.attacker.queryMove();
+		// 		}
+
+		// 		// If inactive, Nutcase becomes unmoveable until start of its phase
+		// 		if (G.activeCreature !== this.creature) {
+		// 			this.creature.addEffect(
+		// 				new Effect(
+		// 					this.title,
+		// 					this.creature,
+		// 					this.creature,
+		// 					'',
+		// 					{
+		// 						alterations: {
+		// 							moveable: false,
+		// 						},
+		// 						deleteTrigger: 'onStartPhase',
+		// 						turnLifetime: 1,
+		// 					},
+		// 					G,
+		// 				),
+		// 			);
+		// 		}
+		// 	},
+		// },
 
 		//	Second Ability: Hammer Time
 		{

--- a/src/ability.js
+++ b/src/ability.js
@@ -521,7 +521,7 @@ export class Ability {
 
 			let dmg = new Damage(attacker, damages, targets[i].hexesHit, effects, this.game);
 			let damageResult = targets[i].target.takeDamage(dmg, {
-				ignoreRetaliation: ignoreRetaliation,
+				ignoreRetaliation,
 			});
 			multiKill += damageResult.kill + 0;
 		}


### PR DESCRIPTION
This MR fixes https://github.com/FreezingMoon/AncientBeast/issues/1089 by changing the Nutcase "Tentacle Bush" ability to apply an effect at the end of its turn.

When the effect is applied any enemy attacks will:

1. Make the Nutcase immovable.
2. Deal 1 damage to the attacker.
3. Make the attacker unable to move (also immovable) until its next turn.
4. If upgraded, the attacker's abilities cost 5 more until its next turn.

This also fixes a bug where if a Nutcase attacks another Nutcase, they would enter an infinite loop Tentacle Bushing each other.

---

Effect being applied at end of turn:

![CleanShot 2021-12-11 at 21 20 12](https://user-images.githubusercontent.com/199204/145674592-d47a5a82-41af-4489-887e-b10bc304759d.gif)

Creature attacking, taking damage, and being unable to move:

![CleanShot 2021-12-11 at 21 20 49](https://user-images.githubusercontent.com/199204/145674618-bef46312-0762-401a-94e5-ab9dfa5d4e94.gif)

Nut Case is immovable:

![CleanShot 2021-12-11 at 21 23 55](https://user-images.githubusercontent.com/199204/145674694-b44a441a-0b76-43d8-96b4-a116c2e24c3b.gif)

Scavenger attacking upgraded Nutcase twice and having energy cost increased twice:

<img width="585" alt="CleanShot 2021-12-11 at 21 27 51@2x" src="https://user-images.githubusercontent.com/199204/145674849-168e3a43-97d2-4888-8568-19d56dc04730.png">

<img width="442" alt="CleanShot 2021-12-11 at 21 28 53@2x" src="https://user-images.githubusercontent.com/199204/145674857-11babbd7-8e5a-47e9-958e-6c646e95c200.png">

---

Note - if the Nut Case delays its turn, the effect is not applied. It does not apply until the Nut Case ends (skips) its turn.

<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1945"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

