### PR TITLE
Make Nutcase immobile when not active + clean up log

### DIFF
--- a/src/abilities/Nutcase.js
+++ b/src/abilities/Nutcase.js
@@ -81,8 +81,6 @@ export default (G) => {
 					return false;
 				}
 
-				// this.end();
-
 				// Target becomes unmovable until end of their phase
 				let o = {
 					alterations: {
@@ -102,7 +100,7 @@ export default (G) => {
 				}
 
 				const attackerEffect = new Effect(
-					this.name,
+					this.title,
 					this.creature, // Caster
 					damage.attacker, // Target
 					'', // Trigger

--- a/src/abilities/Nutcase.js
+++ b/src/abilities/Nutcase.js
@@ -15,12 +15,16 @@ export default (G) => {
 		/**
 		 * First Ability: Tentacle Bush
 		 * When ending the Nutcase's turn, it gains the "Tentacle Bush" effect which:
-		 * - makes the Nutcase immovable
-		 * - adds a damage shield which applies an effect against melee attackers which:
-		 *  - makes the attacker immovable (roots them in place)
-		 *  - if upgraded, makes the attacker's abilities cost 5 energy more
-		 *  - lasts until the attacker's next turn
-		 *  - does not stack effects (i.e. not 10 energy for two attacks if upgraded)
+		 * - makes the Nutcase immovable until its next turn
+		 * - applies an effect against melee attackers
+		 * - lasts until its next turn
+		 * - is never active during the Nutcase's own turn making this a defensive ability.
+		 *
+		 * The effect applied to attackers:
+		 * - makes the attacker immovable (roots them in place)
+		 * - if upgraded, makes the attacker's abilities cost +5 energy
+		 * - lasts until the end of the attacker's current turn
+		 * - does not stack (i.e. not +10 energy for two attacks)
 		 */
 		{
 			trigger: 'onEndPhase',


### PR DESCRIPTION
This MR tweaks Nutcase's Tentacle Bush ability:

1. Nutcase is always immovable when it is not active. Previously this effect would only occur when it was hit.
2. The Nutcase damage shield (attacker immovable and +5 energy cost when upgraded) does not stack.
3. Tweaked log messages.

Nutcase being immobile even though it hasn't been attack this round:

![CleanShot 2021-12-13 at 09 25 37](https://user-images.githubusercontent.com/199204/145735357-68586c1c-6d26-4a7f-9cb9-63214d2a0247.gif)

After Scavenger attacking upgraded Nutcase twice, his ability cost has only increased +5 (15 -> 20).

![CleanShot 2021-12-13 at 09 28 47](https://user-images.githubusercontent.com/199204/145735209-44d4814d-ccde-4db8-af30-94372d9603cd.png)

Showing the Scavenger only has one effect (not stacked):

![CleanShot 2021-12-13 at 10 07 15](https://user-images.githubusercontent.com/199204/145735425-15e7953d-dc05-4dfa-9671-ce89d6dd391e.png)

Upgraded log with hints:

![CleanShot 2021-12-13 at 09 58 09](https://user-images.githubusercontent.com/199204/145735390-dbb820e7-8ee0-412b-abd6-1f9770468b5b.gif)

![CleanShot 2021-12-13 at 10 01 57](https://user-images.githubusercontent.com/199204/145735405-a9b84c60-7411-4ec5-9320-ee44331a6d34.png)





<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1950"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

