### PR TITLE
Fix "Disable Materialization Sickness" power

### DIFF
--- a/src/abilities/Dark-Priest.js
+++ b/src/abilities/Dark-Priest.js
@@ -285,7 +285,7 @@ export default (G) => {
 				G.queue.tempCreature = fullCrea;
 
 				// Show temporary Creature in queue
-				G.queue.addByInitiative(fullCrea, creatureHasMaterializationSickness);
+				G.queue.addByInitiative(fullCrea, !creatureHasMaterializationSickness);
 				G.updateQueueDisplay();
 
 				// Reduce temporary Creature vignette transparency

--- a/src/creature.js
+++ b/src/creature.js
@@ -262,9 +262,9 @@ export class Creature {
 
 		/* Without Sickness the creature should act in the current turn, except the dark
 		priest who must always be in the next queue to properly start the game. */
-		const addToCurrentQueue = disableMaterializationSickness && !this.isDarkPriest();
+		const alsoAddToCurrentQueue = disableMaterializationSickness && !this.isDarkPriest();
 
-		game.queue.addByInitiative(this, !addToCurrentQueue);
+		game.queue.addByInitiative(this, alsoAddToCurrentQueue);
 
 		if (disableMaterializationSickness) {
 			this.materializationSickness = false;

--- a/src/creature_queue.js
+++ b/src/creature_queue.js
@@ -10,11 +10,11 @@ export class CreatureQueue {
 
 	/**
 	 * Add a creature to the next turn's queue by initiative, and optionally the current
-	 * queue. Adding a creature to the current queue avoids Materialization Sickness.
+	 * turn's queue.
 	 *
 	 * @param {Creature} creature The creature to add.
-	 * @param {boolean} alsoAddToCurrentQueue Also add the creature to the current queue.
-	 * @returns
+	 * @param {boolean} alsoAddToCurrentQueue Also add the creature to the current
+	 * turn's queue. Doing so lets a creature act in the same turn it was summoned.
 	 */
 	addByInitiative(creature, alsoAddToCurrentQueue = true) {
 		const queues = [this.nextQueue];

--- a/src/creature_queue.js
+++ b/src/creature_queue.js
@@ -9,25 +9,32 @@ export class CreatureQueue {
 	}
 
 	/**
-	 * Add a creature to the next turn's queue by initiative
+	 * Add a creature to the next turn's queue by initiative, and optionally the current
+	 * queue. Adding a creature to the current queue avoids Materialization Sickness.
 	 *
 	 * @param {Creature} creature The creature to add.
-	 * @param {boolean} addToNextQueue Add creature to the next queue, or the current one.
+	 * @param {boolean} alsoAddToCurrentQueue Also add the creature to the current queue.
 	 * @returns
 	 */
-	addByInitiative(creature, addToNextQueue = true) {
-		const targetQueue = addToNextQueue ? this.nextQueue : this.queue;
+	addByInitiative(creature, alsoAddToCurrentQueue = true) {
+		const queues = [this.nextQueue];
 
-		for (let i = 0; i < targetQueue.length; i++) {
-			let queue = targetQueue[i];
-
-			if (queue.delayed || queue.getInitiative() < creature.getInitiative()) {
-				targetQueue.splice(i, 0, creature);
-				return;
-			}
+		if (alsoAddToCurrentQueue) {
+			queues.push(this.queue);
 		}
 
-		targetQueue.push(creature);
+		queues.forEach((queue) => {
+			for (let i = 0; i < queue.length; i++) {
+				let queueItem = queue[i];
+
+				if (queueItem.delayed || queueItem.getInitiative() < creature.getInitiative()) {
+					queue.splice(i, 0, creature);
+					return;
+				}
+			}
+
+			queue.push(creature);
+		});
 	}
 
 	dequeue() {


### PR DESCRIPTION
While debugging I noticed the "Disable Materialization Sickness" power doesn't work beyond the first turn.

The fix is to add a creature to the current turn, and next turn, queue if it should avoid Materialization Sickness. Adding it just to the current turn queue fails to carry it over to the next turn queue.

Before fix:

![CleanShot 2021-12-13 at 20 27 15](https://user-images.githubusercontent.com/199204/145795935-3f103316-6988-4a42-b324-c9022390d1df.png)

![CleanShot 2021-12-13 at 20 27 57](https://user-images.githubusercontent.com/199204/145795963-3c28bd0b-689f-41d8-8256-701d233b92bc.png)

After fix:

![CleanShot 2021-12-13 at 20 29 24](https://user-images.githubusercontent.com/199204/145796217-df1de090-a9fd-4aba-8c3c-d610763f6e66.png)

![CleanShot 2021-12-13 at 20 30 04](https://user-images.githubusercontent.com/199204/145796239-e14d57aa-2cb6-4297-8b8f-3362bc36dde6.png)

![CleanShot 2021-12-13 at 20 30 56](https://user-images.githubusercontent.com/199204/145796360-6efb06f0-fdbf-4cc6-93cb-e8b58184eb83.png)


<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1951"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

