### PR TITLE
Black dashed hex under creature while targeting ranged

### DIFF
--- a/src/utility/hexgrid.js
+++ b/src/utility/hexgrid.js
@@ -346,7 +346,7 @@ export class HexGrid {
 			}
 		}
 
-		o.hexesDashed = o.hexesDashed.filter((hexDash) => !hexDash.creature);
+		//o.hexesDashed = o.hexesDashed.filter((hexDash) => !hexDash.creature);
 
 		this.queryHexes({
 			fnOnConfirm: (hex, args) => {


### PR DESCRIPTION
Just put black dashed hex for the first part of #1004. There doesn't seem any conflict with lock file, for now.

<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1958"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

