### PR TITLE
1810 - Golden Wyrm's ultimate ability

### DIFF
--- a/assets/units/data.json
+++ b/assets/units/data.json
@@ -2598,7 +2598,7 @@
 	{
 		"id": 33,
 		"name": "Golden Wyrm",
-		"playable": false,
+		"playable": true,
 		"level": 7,
 		"realm": "A",
 		"size": 3,
@@ -2669,9 +2669,7 @@
 				"desc": "Rapidly transfers up to 50 health points to a nearby allied unit, this is non lethal.",
 				"info": "Usage requires being at least 51 health.",
 				"upgrade": "+10 regrowth bonus each use.",
-				"costs": {
-					"energy": 50
-				}
+				"costs": {}
 			}
 		]
 	},

--- a/assets/units/data.json
+++ b/assets/units/data.json
@@ -2669,7 +2669,9 @@
 				"desc": "Rapidly transfers up to 50 health points to a nearby allied unit, this is non lethal.",
 				"info": "Usage requires being at least 51 health.",
 				"upgrade": "+10 regrowth bonus each use.",
-				"costs": {}
+				"costs": {
+					"energy": 25
+				}
 			}
 		]
 	},

--- a/src/abilities/Golden-Wyrm.js
+++ b/src/abilities/Golden-Wyrm.js
@@ -307,7 +307,6 @@ export default (G) => {
 
 				// TODO: Should we show messages/hints for this transfer beyond health lost/gained?
 
-				// If upgraded, buff +10 regrowth.
 				if (this.isUpgraded()) {
 					const regrowthBuffEffect = new Effect(
 						// No name to avoid logging.

--- a/src/abilities/Golden-Wyrm.js
+++ b/src/abilities/Golden-Wyrm.js
@@ -315,12 +315,10 @@ export default (G) => {
 
 				if (this.isUpgraded()) {
 					const regrowthBuffEffect = new Effect(
-						// No name to avoid logging.
-						// TODO: Should we show a hint above the Wyrm?
+						this.title,
+						this.creature,
+						this.creature,
 						'',
-						this.creature, // Caster
-						this.creature, // Target
-						'', // Trigger
 						{
 							alterations: {
 								regrowth: 10,
@@ -333,6 +331,10 @@ export default (G) => {
 						regrowthBuffEffect,
 						// TODO: What should this say?
 						`%CreatureName${this.creature.id}% is brimming with health`,
+						// TODO: Should we show a hint?
+						'',
+						false,
+						true,
 					);
 				}
 			},

--- a/src/abilities/Golden-Wyrm.js
+++ b/src/abilities/Golden-Wyrm.js
@@ -297,21 +297,23 @@ export default (G) => {
 			activate: function (target) {
 				this.end();
 
-				/* The amount of health transferred is the creature's missing life, capped 
-				to 50. */
+				// The health transferred is the creature's missing life, capped to 50.
 				const transferAmount = Math.min(
 					target.stats.health - target.health,
 					this._maxTransferAmount,
 				);
 
-				target.heal(transferAmount);
+				target.heal(transferAmount, false, false);
 
 				/* Damage Golden Wyrm using `.heal()` instead of `.takeDamage()` to apply 
 				raw damage that bypasses dodge, shielded, etc and does not trigger further 
 				effects. */
-				this.creature.heal(-transferAmount);
+				this.creature.heal(-transferAmount, false, false);
 
-				// TODO: Should we show messages/hints for this transfer beyond health lost/gained?
+				// Rather than individual loss/gain health logs, show a single custom log.
+				this.game.log(
+					`%CreatureName${this.creature.id}% transfers${transferAmount} health to %CreatureName${target.id}%`,
+				);
 
 				if (this.isUpgraded()) {
 					const regrowthBuffEffect = new Effect(
@@ -329,9 +331,7 @@ export default (G) => {
 
 					this.creature.addEffect(
 						regrowthBuffEffect,
-						// TODO: What should this say?
-						`%CreatureName${this.creature.id}% is brimming with health`,
-						// TODO: Should we show a hint?
+						`%CreatureName${this.creature.id}% gains 10 regrowth points`,
 						'',
 						false,
 						true,

--- a/src/abilities/Golden-Wyrm.js
+++ b/src/abilities/Golden-Wyrm.js
@@ -236,18 +236,21 @@ export default (G) => {
 		/**
 		 * Fourth Ability: Visible Stigmata
 		 *
-		 * Heals an ally at the cost of own health. If the target unit is missing less
-		 * than the max heal amount (50), only the missing amount will be transferred.
-		 * Cannot target full health units.
+		 * Heals an ally at the cost of own health.
 		 *
-		 * When upgraded, each use buffs Golden Wyrm with 10 regrowth points.
+		 * Targeting rules:
+		 * - If the target unit is missing less than the max heal amount (50), only
+		 *   the missing amount will be transferred.
+		 * - Cannot target full health units.
+		 * - Requires at least 51 remaining health to use.
+		 *
+		 * When upgraded each use buffs Golden Wyrm with 10 regrowth points.
 		 */
 		{
 			trigger: 'onQuery',
 
 			_targetTeam: Team.ally,
 
-			// TODO: Can this value be sourced from data.json?
 			_maxTransferAmount: 50,
 
 			require: function () {
@@ -255,8 +258,11 @@ export default (G) => {
 					return false;
 				}
 
-				// Golden Wyrm needs to be left with at least 1 hp after the ability.
+				/* Golden Wyrm needs to be left with at least 1 hp after the ability. We
+				can't use ability.costs because that is a fixed value, whereas this ability
+				has a dynamic health cost. */
 				if (this.creature.health < this._maxTransferAmount + 1) {
+					this.message = 'Not enough health';
 					return false;
 				}
 

--- a/src/abilities/Golden-Wyrm.js
+++ b/src/abilities/Golden-Wyrm.js
@@ -312,7 +312,7 @@ export default (G) => {
 
 				// Rather than individual loss/gain health logs, show a single custom log.
 				this.game.log(
-					`%CreatureName${this.creature.id}% transfers${transferAmount} health to %CreatureName${target.id}%`,
+					`%CreatureName${this.creature.id}% transfers ${transferAmount} health to %CreatureName${target.id}%`,
 				);
 
 				if (this.isUpgraded()) {
@@ -341,15 +341,21 @@ export default (G) => {
 
 			/**
 			 * Determine the area of effect to query and activate the ability. The area
-			 * of effect is the 3 hexes to the front of the creature:
-			 * ⬡⬢
-			 *  👹⬢
-			 * ⬡⬢
+			 * of effect are the hexes directly adjacent around the 3-sized creature.
 			 *
 			 * @returns Refer to HexGrid.getHexMap()
 			 */
 			_getHexes() {
-				return this.creature.getHexMap(matrices.front1hex);
+				const map = [
+					[1, 1, 1, 1, 0],
+					[1, 0, 0, 0, 1],
+					[1, 1, 1, 1, 0],
+				];
+				const xOffset = this.creature.y % 2 === 0 ? 0 : 1;
+
+				return G.grid.getHexMap(this.creature.x - xOffset, this.creature.y - 1, -2, false, map);
+
+				// return this.creature.getHexMap(map);
 			},
 
 			/**

--- a/src/abilities/Golden-Wyrm.js
+++ b/src/abilities/Golden-Wyrm.js
@@ -318,7 +318,7 @@ export default (G) => {
 
 				// Rather than individual loss/gain health logs, show a single custom log.
 				this.game.log(
-					`%CreatureName${this.creature.id}% transfers ${transferAmount} health to %CreatureName${target.id}%`,
+					`%CreatureName${this.creature.id}% gives ${transferAmount} health to %CreatureName${target.id}%`,
 				);
 
 				if (this.isUpgraded()) {

--- a/src/abilities/Golden-Wyrm.js
+++ b/src/abilities/Golden-Wyrm.js
@@ -236,15 +236,21 @@ export default (G) => {
 		/**
 		 * Fourth Ability: Visible Stigmata
 		 *
-		 * Heals an ally at the cost of own health.
+		 * Heals an adjacent allied unit at the cost of the Golden Wyrm's own health,
+		 * essentially transferring health.
 		 *
 		 * Targeting rules:
+		 * - The target unit be an ally.
+		 * - The target unit must be in hexes directly adjacent to the Golden Wyrm.
 		 * - If the target unit is missing less than the max heal amount (50), only
 		 *   the missing amount will be transferred.
 		 * - Cannot target full health units.
-		 * - Requires at least 51 remaining health to use.
 		 *
-		 * When upgraded each use buffs Golden Wyrm with 10 regrowth points.
+		 * Other rules:
+		 * - Requires at least 51 remaining health to use so the Golden Wyrm doesn't
+		 *   kill itself.
+		 *
+		 * When upgraded each use buffs Golden Wyrm with 10 permanent regrowth points.
 		 */
 		{
 			trigger: 'onQuery',
@@ -342,6 +348,8 @@ export default (G) => {
 			/**
 			 * Determine the area of effect to query and activate the ability. The area
 			 * of effect are the hexes directly adjacent around the 3-sized creature.
+			 * This is a total of 10 hexes assuming the Golden Wyrm is not adjacent to
+			 * the edge of the board.
 			 *
 			 * @returns Refer to HexGrid.getHexMap()
 			 */
@@ -352,10 +360,15 @@ export default (G) => {
 					[1, 1, 1, 1, 0],
 				];
 				const xOffset = this.creature.y % 2 === 0 ? 0 : 1;
+				const hexes = G.grid.getHexMap(
+					this.creature.x - xOffset,
+					this.creature.y - 1,
+					-2,
+					false,
+					map,
+				);
 
-				return G.grid.getHexMap(this.creature.x - xOffset, this.creature.y - 1, -2, false, map);
-
-				// return this.creature.getHexMap(map);
+				return hexes;
 			},
 
 			/**

--- a/src/creature.js
+++ b/src/creature.js
@@ -1379,7 +1379,7 @@ export class Creature {
 	 * effect :		Effect :	Effect object
 	 *
 	 */
-	addEffect(effect, specialString, specialHint) {
+	addEffect(effect, specialString, specialHint, disableLog = false, disableHint = false) {
 		let game = this.game;
 
 		if (!effect.stackable && this.findEffect(effect.name).length !== 0) {
@@ -1394,15 +1394,20 @@ export class Creature {
 		this.updateAlteration();
 
 		if (effect.name !== '') {
-			if (specialHint || effect.specialHint) {
-				this.hint(specialHint, 'msg_effects');
-			} else {
-				this.hint(effect.name, 'msg_effects');
+			if (!disableHint) {
+				if (specialHint || effect.specialHint) {
+					this.hint(specialHint, 'msg_effects');
+				} else {
+					this.hint(effect.name, 'msg_effects');
+				}
 			}
-			if (specialString) {
-				game.log(specialString);
-			} else {
-				game.log('%CreatureName' + this.id + '% is affected by ' + effect.name);
+
+			if (!disableLog) {
+				if (specialString) {
+					game.log(specialString);
+				} else {
+					game.log('%CreatureName' + this.id + '% is affected by ' + effect.name);
+				}
 			}
 		}
 	}

--- a/src/utility/hexgrid.js
+++ b/src/utility/hexgrid.js
@@ -20,7 +20,6 @@ export class HexGrid {
 	 *
 	 * // Jquery attributes
 	 * $display : 		Grid container
-	 * $creatureW : 	Creature Wrapper container
 	 * $inpthexesW : 	Input Hexagons container
 	 * $disphexesW : 	Display Hexagons container
 	 * $overhexesW : 	Overlay Hexagons container
@@ -1289,26 +1288,5 @@ export class HexGrid {
 			this.cleanHex(hexInstance);
 			hexInstance.overlayVisualState('creature selected player' + game.activeCreature.team);
 		}
-	}
-
-	debugHex(hexes) {
-		let i = 0;
-
-		$j('.debug').remove();
-		hexes.forEach((hex) => {
-			let a = this.$creatureW
-				.append('<div class=".debug" id="debug' + i + '"></div>')
-				.children('#debug' + i);
-
-			a.css({
-				position: 'absolute',
-				width: 20,
-				height: 20,
-				'background-color': 'yellow',
-			});
-			a.css(hex.displayPos);
-
-			i++;
-		});
 	}
 }


### PR DESCRIPTION
This MR adds Golden Wyrm's ultimate ability as described in https://github.com/FreezingMoon/AncientBeast/issues/1810.

There are outstanding questions in that issue, plus some more raised during development so this is a draft MR. More changes coming soon.

![CleanShot 2021-12-14 at 22 16 33](https://user-images.githubusercontent.com/199204/145996681-159b7416-9064-46b2-b0aa-b57f0c1e6f0e.gif)

Example log:

![CleanShot 2021-12-14 at 21 35 29@2x](https://user-images.githubusercontent.com/199204/145996759-853ddbcb-db18-47ad-a7d1-db5f0023e85d.png)

Cannot be used when ally at full health:

![CleanShot 2021-12-14 at 21 37 21@2x](https://user-images.githubusercontent.com/199204/145996808-86641648-9ad0-4b2f-9691-c9afc7de67fe.png)

Cannot be used when Golden Wyrm under 51 health:

![CleanShot 2021-12-14 at 22 06 05@2x](https://user-images.githubusercontent.com/199204/145996938-9beda42a-bdb3-455f-bd7a-d3bbbe4d4b88.png)

Upgraded ability buffs regrowth:

![CleanShot 2021-12-14 at 22 39 59@2x](https://user-images.githubusercontent.com/199204/146000906-dd987548-cd68-46cd-8542-7dbbee885f33.png)

<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1959"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

