### PR TITLE
1949 - Display full ability info in hover

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -1046,7 +1046,8 @@
 									<div class="abilityinfo_content">
 										<div class="shortcut">passive ability</div>
 										<span class="title"></span>
-										<p></p>
+										<p class="description"></p>
+										<p class="full-info"></p>
 									</div>
 								</div>
 							</div>
@@ -1057,7 +1058,8 @@
 									<div class="abilityinfo_content">
 										<div class="shortcut">hotkey W</div>
 										<span class="title"></span>
-										<p></p>
+										<p class="description"></p>
+										<p class="full-info"></p>
 									</div>
 								</div>
 							</div>
@@ -1068,7 +1070,8 @@
 									<div class="abilityinfo_content">
 										<div class="shortcut">hotkey E</div>
 										<span class="title"></span>
-										<p></p>
+										<p class="description"></p>
+										<p class="full-info"></p>
 									</div>
 								</div>
 							</div>
@@ -1079,7 +1082,8 @@
 									<div class="abilityinfo_content">
 										<div class="shortcut">hotkey R</div>
 										<span class="title"></span>
-										<p></p>
+										<p class="description"></p>
+										<p class="full-info"></p>
 									</div>
 								</div>
 							</div>

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -1737,7 +1737,8 @@ export class UI {
 			};
 			let $desc = btn.$button.next('.desc');
 			$desc.find('span.title').text(ab.title);
-			$desc.find('p').html(ab.desc);
+			$desc.find('p.description').html(ab.desc);
+			$desc.find('p.full-info').html(ab.info);
 			btn.changeState(); // Apply changes
 		});
 	}


### PR DESCRIPTION
This MR addresses https://github.com/FreezingMoon/AncientBeast/issues/1949 by displaying the full ability info when hovering the abilities of the active unit.

![CleanShot 2021-12-16 at 09 09 34](https://user-images.githubusercontent.com/199204/146279271-f62fde53-ccf9-4b1b-956c-85885333353a.gif)



<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1966"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

