### PR TITLE
1808 - Golden Wyrm "Executioner Axe" ability

### DIFF
--- a/src/abilities/Golden-Wyrm.js
+++ b/src/abilities/Golden-Wyrm.js
@@ -72,7 +72,8 @@ export default (G) => {
 		 *
 		 * Targeting rules:
 		 * - The target unit be an enemy.
-		 * - The target unit must be in hexes directly adjacent to the Golden Wyrm.
+		 * - The target unit must be in the 3 front hexes, or 3 back hexes adjacent
+		 *   to the Golden Wyrm.
 		 *
 		 * Other rules:
 		 * - If the unit has 45 remaining health or lower, it will be instantly killed
@@ -165,15 +166,12 @@ export default (G) => {
 			},
 
 			/**
-			 * Determine the area of effect to query and activate the ability. The area
-			 * of effect are the hexes directly adjacent around the 3-sized creature.
-			 * This is a total of 10 hexes assuming the Golden Wyrm is not adjacent to
-			 * the edge of the board.
+			 * The area of effect is the front and back 3 hexes for a total of 6 hexes.
 			 *
-			 * @returns {Hex[]} Refer to Creature.adjacentHexes()
+			 * @returns {Hex[]} Refer to Creature.getHexMap()
 			 */
 			_getHexes() {
-				return this.creature.adjacentHexes(1);
+				return this.creature.getHexMap(matrices.frontnback3hex);
 			},
 		},
 

--- a/src/abilities/Golden-Wyrm.js
+++ b/src/abilities/Golden-Wyrm.js
@@ -64,44 +64,50 @@ export default (G) => {
 			},
 		},
 
-		// 	Second Ability: Executioner Axe
+		/**
+		 * Second Ability: Executioner Axe
+		 *
+		 * Damage an adjacent enemy unit with slash damage, instantly killing it if
+		 * its remaining health is <= 45.
+		 *
+		 * Targeting rules:
+		 * - The target unit be an enemy.
+		 * - The target unit must be in hexes directly adjacent to the Golden Wyrm.
+		 *
+		 * Other rules:
+		 * - If the unit has 45 remaining health or lower, it will be instantly killed
+		 *   unless protected by the Dodge or Shielded damage mitigation effects.
+		 * - The execution damage is "pure" and cannot be reduced via resistances.
+		 *
+		 * When upgraded, a successful execution attack will allow the ability to be
+		 * used again. Each use requires the full 25 energy cost.
+		 */
 		{
-			//	Type : Can be "onQuery", "onStartPhase", "onDamage"
 			trigger: 'onQuery',
 
-			damages: {
-				slash: 40,
-			},
+			_executeHealthThreshold: 45,
+
 			_targetTeam: Team.enemy,
 
-			// 	require() :
 			require: function () {
 				if (!this.testRequirements()) {
 					return false;
 				}
 
-				//At least one target
 				if (
-					!this.atLeastOneTarget(this.creature.adjacentHexes(1), {
+					!this.atLeastOneTarget(this._getHexes(), {
 						team: this._targetTeam,
 					})
 				) {
 					return false;
 				}
+
 				return true;
 			},
 
-			// 	query() :
 			query: function () {
-				let wyrm = this.creature;
-				let ability = this;
-
-				let map = [
-					[0, 0, 0, 0],
-					[0, 1, 0, 1],
-					[1, 0, 0, 1], //origin line
-					[0, 1, 0, 1],
-				];
+				const wyrm = this.creature;
+				const ability = this;
 
 				G.grid.queryCreature({
 					fnOnConfirm: function () {
@@ -110,52 +116,61 @@ export default (G) => {
 					team: this._targetTeam,
 					id: wyrm.id,
 					flipped: wyrm.flipped,
-					hexes: G.grid.getHexMap(wyrm.x - 2, wyrm.y - 2, 0, false, map),
+					hexes: this._getHexes(),
 				});
 			},
 
-			//	activate() :
 			activate: function (target) {
-				let ability = this;
-				ability.end();
+				this.end();
 
-				let damage = new Damage(
-					ability.creature, // Attacker
-					ability.damages, // Damage Type
-					1, // Area
-					[], // Effects
-					G,
-				);
-
-				let dmg = target.takeDamage(damage);
-
-				if (dmg.status == '') {
-					// Regrowth bonus
-					ability.creature.addEffect(
-						new Effect(
-							'Regrowth++', // Name
-							ability.creature, // Caster
-							ability.creature, // Target
-							'onStartPhase', // Trigger
-							{
-								effectFn: function (effect) {
-									effect.deleteEffect();
-								},
-								alterations: {
-									regrowth: Math.round(dmg.damages.total / 4),
-								},
-							}, //Optional arguments
-							G,
-						),
+				if (target.health <= this._executeHealthThreshold) {
+					const executeDamage = new Damage(
+						this.creature,
+						{
+							// Pure damage bypasses resistances, but can still be shielded or dodged.
+							pure: target.health,
+						},
+						1,
+						[],
+						G,
 					);
-				}
+					const damageResult = target.takeDamage(executeDamage);
 
-				//remove frogger bonus if its found
-				ability.creature.effects.forEach(function (effect) {
-					if (effect.name == 'Frogger Bonus') {
-						this.deleteEffect();
+					// Damage could be shielded or blocked, so double check target has died.
+					if (damageResult.kill) {
+						this.game.log(`%CreatureName${target.id}% showed weakness and was executed!`);
+						target.hint('Executed', 'damage');
+
+						if (this.isUpgraded()) {
+							this.setUsed(false);
+							// Refresh UI to show ability still able to be used.
+							this.game.UI.selectAbility(-1);
+						}
 					}
-				});
+				} else {
+					const normalDamage = new Damage(
+						this.creature,
+						{
+							slash: 30,
+						},
+						1,
+						[],
+						G,
+					);
+					target.takeDamage(normalDamage);
+				}
+			},
+
+			/**
+			 * Determine the area of effect to query and activate the ability. The area
+			 * of effect are the hexes directly adjacent around the 3-sized creature.
+			 * This is a total of 10 hexes assuming the Golden Wyrm is not adjacent to
+			 * the edge of the board.
+			 *
+			 * @returns {Hex[]} Refer to Creature.adjacentHexes()
+			 */
+			_getHexes() {
+				return this.creature.adjacentHexes(1);
 			},
 		},
 
@@ -242,13 +257,13 @@ export default (G) => {
 		 * Targeting rules:
 		 * - The target unit be an ally.
 		 * - The target unit must be in hexes directly adjacent to the Golden Wyrm.
-		 * - If the target unit is missing less than the max heal amount (50), only
-		 *   the missing amount will be transferred.
 		 * - Cannot target full health units.
 		 *
 		 * Other rules:
 		 * - Requires at least 51 remaining health to use so the Golden Wyrm doesn't
 		 *   kill itself.
+		 * - If the target unit is missing less than the max heal amount (50), only
+		 *   the missing amount will be transferred.
 		 *
 		 * When upgraded each use buffs Golden Wyrm with 10 permanent regrowth points.
 		 */
@@ -311,8 +326,8 @@ export default (G) => {
 
 				target.heal(transferAmount, false, false);
 
-				/* Damage Golden Wyrm using `.heal()` instead of `.takeDamage()` to apply 
-				raw damage that bypasses dodge, shielded, etc and does not trigger further 
+				/* Damage Golden Wyrm using `.heal()` instead of `.takeDamage()` to apply
+				raw damage that bypasses dodge, shielded, etc and does not trigger further
 				effects. */
 				this.creature.heal(-transferAmount, false, false);
 
@@ -351,24 +366,10 @@ export default (G) => {
 			 * This is a total of 10 hexes assuming the Golden Wyrm is not adjacent to
 			 * the edge of the board.
 			 *
-			 * @returns Refer to HexGrid.getHexMap()
+			 * @returns {Hex[]} Refer to Creature.adjacentHexes()
 			 */
 			_getHexes() {
-				const map = [
-					[1, 1, 1, 1, 0],
-					[1, 0, 0, 0, 1],
-					[1, 1, 1, 1, 0],
-				];
-				const xOffset = this.creature.y % 2 === 0 ? 0 : 1;
-				const hexes = G.grid.getHexMap(
-					this.creature.x - xOffset,
-					this.creature.y - 1,
-					-2,
-					false,
-					map,
-				);
-
-				return hexes;
+				return this.creature.adjacentHexes(1);
 			},
 
 			/**

--- a/src/abilities/Golden-Wyrm.js
+++ b/src/abilities/Golden-Wyrm.js
@@ -109,7 +109,7 @@ export default (G) => {
 				const wyrm = this.creature;
 				const ability = this;
 
-				G.grid.queryCreature({
+				this.game.grid.queryCreature({
 					fnOnConfirm: function () {
 						ability.animation(...arguments);
 					},
@@ -132,13 +132,16 @@ export default (G) => {
 						},
 						1,
 						[],
-						G,
+						this.game,
 					);
+					/* Suppress the death message, to be replaced by a custom log. Setting
+					`noLog` on Damage wouldn't work as it would suppress Shielded/Dodged messages. */
+					this.game.UI.chat.suppressMessage(/is dead/i, 1);
 					const damageResult = target.takeDamage(executeDamage);
 
 					// Damage could be shielded or blocked, so double check target has died.
 					if (damageResult.kill) {
-						this.game.log(`%CreatureName${target.id}% showed weakness and was executed!`);
+						this.game.log(`%CreatureName${target.id}% has been executed!`);
 						target.hint('Executed', 'damage');
 
 						if (this.isUpgraded()) {
@@ -155,7 +158,7 @@ export default (G) => {
 						},
 						1,
 						[],
-						G,
+						this.game,
 					);
 					target.takeDamage(normalDamage);
 				}

--- a/src/effect.js
+++ b/src/effect.js
@@ -68,18 +68,19 @@ export class Effect {
 
 	deleteEffect() {
 		const targetIdx = this.target.effects.indexOf(this);
-		if (!this.target.effects[targetIdx]) {
-			console.warn('Failed to find effect on target.');
+		if (this.target.effects[targetIdx]) {
+			this.target.effects.splice(targetIdx, 1);
+		} else {
+			console.warn('Failed to find effect on target.', this);
 		}
-		this.target.effects.splice(targetIdx, 1);
 
 		const gameIdx = this.game.effects.indexOf(this);
-		if (!this.target.effects[gameIdx]) {
-			console.warn('Failed to find effect on game.');
+		if (this.game.effects[gameIdx]) {
+			this.game.effects.splice(gameIdx, 1);
+		} else {
+			console.warn('Failed to find effect on game.', this);
 		}
-		this.game.effects.splice(gameIdx, 1);
 
 		this.target.updateAlteration();
-		console.log('Effect ' + this.name + ' deleted');
 	}
 }

--- a/src/ui/chat.js
+++ b/src/ui/chat.js
@@ -24,6 +24,7 @@ export class Chat {
 		});
 		this.messages = [];
 		this.isOpen = false;
+		this.messagesToSuppress = [];
 
 		$j('#combatwrapper, #toppanel, #dash, #endscreen').bind('click', () => {
 			game.UI.chat.hide();
@@ -89,6 +90,20 @@ export class Chat {
 		let messagesNo = this.messages.length;
 		let currentTime = ifNoTimestamp ? null : this.getCurrentTime();
 
+		const suppressedMessageIndex = this.messagesToSuppress.findIndex((message) =>
+			message.pattern.test(msg),
+		);
+		if (suppressedMessageIndex > -1) {
+			const message = this.messagesToSuppress[suppressedMessageIndex];
+			message.times = message.times - 1;
+
+			if (message.times <= 0) {
+				this.messagesToSuppress.splice(suppressedMessageIndex, 1);
+			}
+
+			return;
+		}
+
 		// Check if the last message was the same as the current one
 		if (this.messages[messagesNo - 1] && this.messages[messagesNo - 1].message === msg) {
 			let lastMessage = this.messages[messagesNo - 1];
@@ -111,5 +126,18 @@ export class Chat {
 		}
 
 		this.$content.parent().scrollTop(this.$content.height());
+	}
+
+	/**
+	 * Suppress a message from being output to the chat log.
+	 *
+	 * @param {RegExp} pattern If the chat log message matches this pattern, it will be suppressed.
+	 * @param {number} times Suppress the message this many times.
+	 */
+	suppressMessage(pattern, times = 1) {
+		this.messagesToSuppress.push({
+			pattern,
+			times,
+		});
 	}
 }

--- a/src/utility/hexgrid.js
+++ b/src/utility/hexgrid.js
@@ -1289,4 +1289,14 @@ export class HexGrid {
 			hexInstance.overlayVisualState('creature selected player' + game.activeCreature.team);
 		}
 	}
+
+	/**
+	 * Log and visually highlight an array of hexes.
+	 *
+	 * @param {Hex[]} hexes
+	 */
+	debugHexes(hexes) {
+		console.log({ hexes }, hexes.map((hex) => hex.coord).join(', '));
+		hexes.forEach((hex) => hex.displayVisualState('creature selected player1'));
+	}
 }

--- a/src/utility/hexgrid.js
+++ b/src/utility/hexgrid.js
@@ -1291,11 +1291,12 @@ export class HexGrid {
 	}
 
 	/**
-	 * Log and visually highlight an array of hexes.
+	 * Internal debugging method to log and visually highlight (in blue) an array
+	 * of hexes.
 	 *
 	 * @param {Hex[]} hexes
 	 */
-	debugHexes(hexes) {
+	__debugHexes(hexes) {
 		console.log({ hexes }, hexes.map((hex) => hex.coord).join(', '));
 		hexes.forEach((hex) => hex.displayVisualState('creature selected player1'));
 	}


### PR DESCRIPTION
This MR adds the "Executioner Axe" ability to the Golden Wyrm creature, as described in https://github.com/FreezingMoon/AncientBeast/issues/1808.

![CleanShot 2021-12-17 at 20 03 25](https://user-images.githubusercontent.com/199204/146530659-5a7f4190-8648-42e0-8b1d-c7cb7fbf2d85.gif)

Combat log:

![CleanShot 2021-12-17 at 20 03 46](https://user-images.githubusercontent.com/199204/146530718-d94b6efb-6204-431c-81bd-5c2eaf0c2b9b.png)

Cannot execute Shielded unit (AFAIK there are no dodging units):

![CleanShot 2021-12-17 at 20 05 16](https://user-images.githubusercontent.com/199204/146530737-622ba4ff-bcdc-4237-81ec-1d8f48c2ebab.gif)

Targetable area:

![CleanShot 2021-12-17 at 20 12 16](https://user-images.githubusercontent.com/199204/146530780-fa714fe1-5c1e-4c2f-81ea-ef216ce6bdc3.png)

Upgraded ability executing multiple units:

![CleanShot 2021-12-17 at 20 19 50](https://user-images.githubusercontent.com/199204/146530837-d7eee77a-0718-4e84-921d-427661247ce9.gif)

A creature with > 45 only take slash damage:

![CleanShot 2021-12-17 at 20 21 33](https://user-images.githubusercontent.com/199204/146530898-3cb1afb5-84ed-40f6-9fc9-f10ecbf229c1.gif)


<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1972"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

