### PR TITLE
Prevent .DS_Store files from breaking asset lister

### DIFF
--- a/assetLister.js
+++ b/assetLister.js
@@ -6,6 +6,8 @@ const stat = promisify(fs.stat);
 const readDir = promisify(fs.readdir);
 const prettier = require('prettier');
 
+const ignoredFiles = [/\.DS_Store/];
+
 /**
  * Generate entity
  *
@@ -15,6 +17,7 @@ const prettier = require('prettier');
 function fileToEntity(filePath) {
 	const extension = path.extname(filePath);
 	const name = path.basename(filePath, extension);
+
 	return {
 		name,
 		url: path.relative(path.join(__dirname, 'assets'), filePath),
@@ -28,7 +31,13 @@ function fileToEntity(filePath) {
  * @return {Promise<any[]>} An array of asset objects.
  */
 async function readDirectory(dirPath) {
-	const children = await readDir(dirPath);
+	let children = await readDir(dirPath);
+
+	// Remove any files that should not be listed with assets.
+	children = children.filter((child) => {
+		return !ignoredFiles.some((pattern) => pattern.test(child));
+	});
+
 	return Promise.all(
 		children.map(async (child) => {
 			const childPath = path.join(dirPath, child);


### PR DESCRIPTION
This MR fixes MacOS `.DS_Store` files in the assets directories breaking the build.

Before:

![CleanShot 2021-12-17 at 20 51 30](https://user-images.githubusercontent.com/199204/146533938-6fb85648-08e0-4f27-9e52-5f6a7b437329.png)

![CleanShot 2021-12-17 at 20 55 00](https://user-images.githubusercontent.com/199204/146534121-489b9c41-571c-4d8a-a945-95f7318ae9a9.png)

After:

![CleanShot 2021-12-17 at 20 51 44](https://user-images.githubusercontent.com/199204/146534147-66b9ef9c-f780-4932-a4f5-05cf697236e3.png)



<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1973"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

