### PR TITLE
Prevent accidentally navigating away from an in progress game

### DIFF
--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -672,6 +672,8 @@ export class UI {
 			$j('.timepool').text(time.getTimer(game.timePool));
 		}
 
+		this.confirmWindowUnload();
+
 		$j('#tabwrapper a').removeAttr('href'); // Empty links
 
 		this.btnExit.changeState(ButtonStateEnum.hidden);
@@ -2535,5 +2537,44 @@ export class UI {
 		$j('#loader').addClass('hide');
 		const queueElements = this.$queue.children();
 		[...queueElements].forEach((queueElement) => queueElement.remove());
+	}
+
+	/**
+	 * Make the user confirm attempts to navigate away (refresh, back button, close
+	 * tab, etc) to prevent accidentally ending the game.
+	 *
+	 * webpack-dev-server reloads in the development environment will bypass this check.
+	 */
+	confirmWindowUnload() {
+		this.ignoreNextConfirmUnload = false;
+
+		const confirmUnload = (event) => {
+			const confirmation =
+				'A game is in progress and cannot be restored, are you sure you want to leave?';
+
+			if (this.ignoreNextConfirmUnload) {
+				delete event['returnValue'];
+				return;
+			}
+
+			// https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload#example
+			event.preventDefault();
+			event.returnValue = confirmation;
+			return confirmation;
+		};
+
+		// Now that a game has started,
+		window.addEventListener('beforeunload', confirmUnload);
+
+		// If running in webpack-dev-server, allow Live Reload events to bypass this check.
+		if (process.env.NODE_ENV === 'development') {
+			// https://stackoverflow.com/a/61579190/1414008
+			window.addEventListener('message', ({ data: { type } }) => {
+				if (type === 'webpackInvalid') {
+					this.ignoreNextConfirmUnload = true;
+					window.location.reload();
+				}
+			});
+		}
 	}
 }

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -2563,7 +2563,6 @@ export class UI {
 			return confirmation;
 		};
 
-		// Now that a game has started,
 		window.addEventListener('beforeunload', confirmUnload);
 
 		// If running in webpack-dev-server, allow Live Reload events to bypass this check.


### PR DESCRIPTION
This MR adds checks to `window.beforeunload` to prevent accidentally navigating away from an in-progress game.

This has bitten me a few times while testing, when I've accidentally hit one of the back/forward side buttons on my mouse. Very annoying!

Refreshing page:

![CleanShot 2021-12-17 at 21 29 36](https://user-images.githubusercontent.com/199204/146541314-ea796262-dff5-44fe-9778-6a25b3cd14ff.png)

Closing tab:

![CleanShot 2021-12-17 at 21 57 45](https://user-images.githubusercontent.com/199204/146541583-96dab504-32fc-4b8b-81f1-fee30f67a932.png)

Allow `webpack-dev-server` live reload to bypass the check to preserve dev feedback loop:

![CleanShot 2021-12-17 at 21 53 06](https://user-images.githubusercontent.com/199204/146541373-d248b4c3-957a-4b63-b42f-ba446f6280a2.png)

<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1974"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

