### PR TITLE
1809 Golden Wyrm "Dragon Flight" ability

### DIFF
--- a/src/abilities/Golden-Wyrm.js
+++ b/src/abilities/Golden-Wyrm.js
@@ -183,20 +183,31 @@ export default (G) => {
 		 * Move to a location within 10 hexes distance using flying movement (avoids
 		 * obstacles including units).
 		 *
+		 * The ability cannot be used if the Golden Wyrm has been made immoveable.
+		 *
 		 * Targeting rule:
-		 * - Target hexes must be within 10 hexes distance of ... what? Creature front? any direction?
+		 * - Target hexes must be within 10 adjacent hexes distance from any part of
+		 *   its 3-sized body.
 		 * - Target hexes must not be occupied by another unit.
 		 *
 		 * When upgraded the Golden Wyrm receives a +25 offense buff for its next Executioner
 		 * Axe ability. This buff lasts until the end of the turn, or if Executioner
 		 * Axe is used.
-		 *
 		 */
 		{
 			trigger: 'onQuery',
 
 			require: function () {
-				return this.testRequirements();
+				if (!this.testRequirements()) {
+					return false;
+				}
+
+				if (!this.creature.stats.moveable) {
+					this.message = G.msg.abilities.notMoveable;
+					return false;
+				}
+
+				return true;
 			},
 
 			query: function () {

--- a/src/abilities/Nutcase.js
+++ b/src/abilities/Nutcase.js
@@ -14,6 +14,7 @@ export default (G) => {
 	G.abilities[40] = [
 		/**
 		 * First Ability: Tentacle Bush
+		 *
 		 * When ending the Nutcase's turn, it gains the "Tentacle Bush" effect which:
 		 * - makes the Nutcase immovable until its next turn
 		 * - applies an effect against melee attackers


### PR DESCRIPTION
This PR adds the "Dragon Flight" ability to the Golden Wyrm creature, as described in https://github.com/FreezingMoon/AncientBeast/issues/1809.

Flying over a trap:

![CleanShot 2021-12-18 at 20 11 42](https://user-images.githubusercontent.com/199204/146637961-7c18fea9-a04f-4d99-8bcf-dca92413ffec.gif)

Flying distance:

<img width="664" alt="CleanShot 2021-12-18 at 20 34 16@2x" src="https://user-images.githubusercontent.com/199204/146638001-587cc48c-942f-4c9d-8e16-63c1280afa87.png">

Upgraded ability:

![CleanShot 2021-12-18 at 20 12 45](https://user-images.githubusercontent.com/199204/146638015-67de030d-78c5-41c1-a081-ae66d4d6b81e.gif)

Executioner axe damage after upgraded flight:

<img width="603" alt="CleanShot 2021-12-18 at 20 13 16@2x" src="https://user-images.githubusercontent.com/199204/146638060-9f49ffbb-f494-4f9b-b081-5744947cbcab.png">

Next turn, offense has returned to normal:

![CleanShot 2021-12-18 at 20 13 36@2x](https://user-images.githubusercontent.com/199204/146638071-99dae5db-ea91-46e6-a234-8c44e4d1a50a.png)

Ability cannot be used if immovable i.e. from Tentacle Bush:

<img width="405" alt="CleanShot 2021-12-18 at 20 27 22@2x" src="https://user-images.githubusercontent.com/199204/146638085-8bb96fbc-4b07-469f-948b-0086b567426d.png">



<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1975"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

