### PR TITLE
1812 Limit Vehemoth "Flat Frons" execute damage to Frozen targets

### DIFF
--- a/src/abilities/Vehemoth.js
+++ b/src/abilities/Vehemoth.js
@@ -275,8 +275,8 @@ export default (G) => {
 
 					// Damage could be shielded or blocked, so double check target has died.
 					if (damageResult.kill) {
-						this.game.log(`%CreatureName${target.id}% has been executed!`);
-						target.hint('Executed', 'damage');
+						this.game.log(`%CreatureName${target.id}% has been shattered!`);
+						target.hint('Shattered', 'damage');
 					}
 				} else {
 					target.takeDamage(damage);

--- a/src/creature.js
+++ b/src/creature.js
@@ -1867,4 +1867,14 @@ export class Creature {
 	isDarkPriest() {
 		return this.type === '--';
 	}
+
+	/**
+	 * The Frozen state skips a unit's next turn. The Frozen state is removed on the
+	 * following turn, or when receiving damage.
+	 *
+	 * @returns {boolean}
+	 */
+	isFrozen() {
+		return this.stats.frozen;
+	}
 }

--- a/src/data/units.json
+++ b/src/data/units.json
@@ -540,7 +540,7 @@
 	{
 		"id": 6,
 		"name": "Vehemoth",
-		"playable": false,
+		"playable": true,
 		"level": 7,
 		"realm": "S",
 		"size": 3,


### PR DESCRIPTION
This PR fixes https://github.com/FreezingMoon/AncientBeast/issues/1812 by checking targets are Frozen before allowing them to be executed by Flat Frons.

Flat Frons used on a target under the 39hp threshold, but not Frozen:

![CleanShot 2021-12-20 at 22 30 34](https://user-images.githubusercontent.com/199204/146770010-e6e7208e-511d-46de-968b-86f9aafa7028.gif)

Flat Frons used on a target under the 39hp threshold, and is Frozen:

![CleanShot 2021-12-20 at 22 41 16](https://user-images.githubusercontent.com/199204/146770063-55f781df-186d-46c1-86e8-12d074881900.gif)

Damage log:

<img width="433" alt="CleanShot 2021-12-20 at 22 41 43@2x" src="https://user-images.githubusercontent.com/199204/146770152-c27e634b-6d07-4ac3-b580-2928e87f36d3.png">

Flat Frons being used in an upgraded charge attack:

![CleanShot 2021-12-20 at 22 46 00](https://user-images.githubusercontent.com/199204/146770211-d87d8a93-610f-4d6b-8f29-806144e527ab.gif)


<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1978"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

