### PR TITLE
Add Hammer Time effect to tooltip

### DIFF
--- a/src/data/units.json
+++ b/src/data/units.json
@@ -3212,7 +3212,12 @@
 				},
 				"costs": {
 					"energy": 24
-				}
+				},
+				"effects": [
+					{
+						"special": "10 %pierce% if moving"
+					}
+				]
 			},
 			{
 				"title": "War Horn",


### PR DESCRIPTION
This PR adds extra information to the Nutcase "Hammer Time" tooltip as requested in https://github.com/FreezingMoon/AncientBeast/issues/608

![CleanShot 2021-12-22 at 16 57 54](https://user-images.githubusercontent.com/199204/147049561-fbec5fb2-92b2-4bb1-80a6-b6fe6e5e97dc.png)



<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1982"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

