### PR TITLE
Speed up Vehemoth "Flat Frons" charge

### DIFF
--- a/src/abilities/Vehemoth.js
+++ b/src/abilities/Vehemoth.js
@@ -216,6 +216,7 @@ export default (G) => {
 					knockbackHexes.splice(path.length);
 
 					vehemoth.moveTo(destination, {
+						overrideSpeed: 100,
 						callback: function () {
 							let knockbackHex = null;
 							for (let i = 0; i < knockbackHexes.length; i++) {


### PR DESCRIPTION
This PR speeds up the animation of the Vehemoth's "Flat Frons" upgraded ability charge animation to the same value as Scavenger's "War Horn" charge.

Before:

![CleanShot 2021-12-24 at 12 51 35](https://user-images.githubusercontent.com/199204/147310122-7c0e1cc5-8d19-4e36-9f65-a940b57e4533.gif)

After:

![CleanShot 2021-12-24 at 12 50 47](https://user-images.githubusercontent.com/199204/147310146-a2c05fd3-0047-4e88-9157-f0a5654ec488.gif)

<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1987"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

