### PR TITLE
Fix blue player Nutcase upgraded "War Horn" charge

### DIFF
--- a/src/abilities/Nutcase.js
+++ b/src/abilities/Nutcase.js
@@ -467,8 +467,9 @@ export default (G) => {
 				// However the Nutcase stops, he'll try and push to the next hex in the same direction.
 				const isChargingBackwards =
 					(nutcase.player.flipped && args.direction === Direction.Right) ||
-					args.direction === Direction.Left;
+					(!nutcase.player.flipped && args.direction === Direction.Left);
 				const nutcasePushHexes = nutcase.getHexMap(matrices.inlinefront2hex, isChargingBackwards);
+				G.grid.__debugHexes(nutcasePushHexes);
 				const targetPushHexes = pushPath.slice();
 
 				// Ensure the creature or target aren't already in the target's push location.

--- a/src/abilities/Nutcase.js
+++ b/src/abilities/Nutcase.js
@@ -469,7 +469,6 @@ export default (G) => {
 					(nutcase.player.flipped && args.direction === Direction.Right) ||
 					(!nutcase.player.flipped && args.direction === Direction.Left);
 				const nutcasePushHexes = nutcase.getHexMap(matrices.inlinefront2hex, isChargingBackwards);
-				G.grid.__debugHexes(nutcasePushHexes);
 				const targetPushHexes = pushPath.slice();
 
 				// Ensure the creature or target aren't already in the target's push location.


### PR DESCRIPTION
This PR fixes a bug where the blue player's Nutcase would not push in the right direction with the upgraded "War Horn" ability.

Before:

![CleanShot 2021-12-24 at 13 07 05](https://user-images.githubusercontent.com/199204/147311183-4209b902-a226-430b-b5a2-6cf0688f7681.gif)

After:

![CleanShot 2021-12-24 at 13 04 47](https://user-images.githubusercontent.com/199204/147311219-f122e1c0-ffa5-4a6b-a1f0-9e9dcc93f9b9.gif)

Red player Nutcase works as before:

![CleanShot 2021-12-24 at 13 09 08](https://user-images.githubusercontent.com/199204/147311264-ca2bff85-1b15-4c7d-a0af-8143c8a2b779.gif)


<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1988"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

