### PR TITLE
Snow Bunny leap after taking damage from charge attacks

### DIFF
--- a/src/abilities/Vehemoth.js
+++ b/src/abilities/Vehemoth.js
@@ -219,7 +219,9 @@ export default (G) => {
 						callback: function () {
 							let knockbackHex = null;
 
-							// Damage before any other creature movement is complete and before knockback.
+							/* Damage before knockback any other creature movement 
+							to handle dead targets, Snow Bunny hop incorrectly avoiding 
+							damage, etc. */
 							const damageResult = ability._damageTarget(target);
 
 							if (damageResult.kill) {


### PR DESCRIPTION
This PR addresses https://github.com/FreezingMoon/AncientBeast/issues/1834 by fixing the other known charge ability (upgraded "Flat Frons") that was not properly applying damage to the Snow Bunny.

Nutcase's "War Horn" was already fixed in https://github.com/FreezingMoon/AncientBeast/pull/1977

This solution updates "Flat Frons" and so isn't a catch all solution to any charge ability that might be built later. That will require more significant reworking of the timing of abilities.

War horn in action against upgraded Bunny Hop:

![nutcase](https://user-images.githubusercontent.com/199204/147460657-b04f8987-72fe-40cb-9c1a-cd11ad9e0a1f.gif)

Flat Frons charge:

![snowbunny](https://user-images.githubusercontent.com/199204/147460635-1f99507c-732f-473b-8287-75ff9cbdc7e2.gif)

Flat Frons charge killing Bunny before knockback:

![snowbunny-death](https://user-images.githubusercontent.com/199204/147460689-49488a05-e14c-458b-a9c5-1561f646948b.gif)

<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1991"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

