### PR TITLE
Control debug mode via .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Game
 ENABLE_SERVICE_WORKER=false
+DEBUG_MODE=true
 
 # Server
 MULTIPLAYER_KEY=mudvayne

--- a/src/game.js
+++ b/src/game.js
@@ -85,7 +85,7 @@ export default class Game {
 		this.session = null;
 		this.client = null;
 		this.connect = null;
-		this.debugMode = false;
+		this.debugMode = process.env.DEBUG_MODE;
 		this.multiplayer = false;
 		this.matchInitialized = false;
 		this.realms = ['A', 'E', 'G', 'L', 'P', 'S', 'W'];


### PR DESCRIPTION
This PR makes a tiny change to allow the game debug mode to be enabled via `.env` rather than requiring a code change. This makes my life a bit easier, so I don't have to stash the code change when changing branches.

![image](https://user-images.githubusercontent.com/199204/147461308-3f1cac41-8182-44ad-bad7-17bee6c54c3c.png)

Debug mode currently doesn't control much, but it does console log the damage calculation which is handy for debugging and testing. In the future this setting could log more verbose data.

<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1992"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

