### PR TITLE
Exclusive screens

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -272,7 +272,7 @@
 			<div id="scoreboard" class="framed-modal__wrapper hide">
 				<div class="framed-modal">
 					<div class="framed-modal__return">
-						<div class="togglescore button"></div>
+						<div class="togglescore close-button"></div>
 					</div>
 					<h1 id="scoreboardTitle"></h1>
 					<table id="score">
@@ -347,7 +347,7 @@
 			</div>
 			<div id="dash" class="selected0">
 				<div id="return">
-					<div class="toggledash button"></div>
+					<div class="toggledash close-button"></div>
 				</div>
 				<div id="playertabswrapper">
 					<div class="playertabs p0" player="0">
@@ -946,15 +946,22 @@
 						</div>
 					</div>
 				</div>
-				<div id="musicplayerwrapper">
-					<audio id="audio" preload="auto" controls="" style="width: 890px;"></audio><a style="cursor: pointer;"
-						id="mp_shuffle">Shuffle</a>
-						<div class="musicgenres active">Tags:</div>
-						<div class="musicgenres__items">
-							<% require('./assetLoader.js').getUrl('music').forEach(function(musicGenre) { %>
-								<span class="musicgenres__title" id="genre-<%= musicGenre.id %>"><%= musicGenre.id %></span>
-							<% }); %>
-						</div>
+			</div>
+
+			<div id="musicplayerwrapper" class="framed-modal__wrapper hide">
+				<div class="framed-modal framed-modal--fluid">
+					<div class="framed-modal__return">
+						<button class="toggle-music-player close-button"></button>
+					</div>
+					
+					<audio id="audio-player" preload="auto" controls="" style="width: 890px;"></audio>
+					<a style="cursor: pointer;" id="mp_shuffle">Shuffle</a>
+					<div class="musicgenres active">Tags:</div>
+					<div class="musicgenres__items">
+						<% require('./assetLoader.js').getUrl('music').forEach(function(musicGenre) { %>
+							<span class="musicgenres__title" id="genre-<%= musicGenre.id %>"><%= musicGenre.id %></span>
+						<% }); %>
+					</div>
 					<ul id="playlist" style="list-style-type:none; padding-left:0px;">
 						<% require('./assetLoader.js').getUrl('music').forEach(function(musicGenre) { %>
 							<% musicGenre.children.forEach(function(track) { %>
@@ -968,6 +975,7 @@
 					</div>
 				</div>
 			</div>
+
 			<div id="toppanel">
 				<div id="queue">
 					<div id="queuewrapper"></div>
@@ -984,7 +992,7 @@
 				</div>
 				<div id="rightpanel">
 					<div style="position:relative">
-						<div id="audio" class="button"></div>
+						<div id="audio" class="toggle-music-player button"></div>
 						<div class="desc">
 							<div class="arrow"></div>
 							<div class="shortcut">hotkey Shift + A</div>
@@ -1107,7 +1115,7 @@
 			<div id="meta-powers" class="framed-modal__wrapper hide">
 				<div class="framed-modal framed-modal--fluid">
 					<div class="framed-modal__return">
-						<div class="toggle-meta-powers button"></div>
+						<button class="toggle-meta-powers close-button"></button>
 					</div>
 					
 					<div class="meta-powers-header">

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -954,8 +954,11 @@
 						<button class="toggle-music-player close-button"></button>
 					</div>
 					
-					<audio id="audio-player" preload="auto" controls="" style="width: 890px;"></audio>
-					<a style="cursor: pointer;" id="mp_shuffle">Shuffle</a>
+					<div class="audio-player-controls">
+						<audio id="audio-player" preload="auto" controls=""></audio>
+						<button id="mp_shuffle">Shuffle</button>
+					</div>
+
 					<div class="musicgenres active">Tags:</div>
 					<div class="musicgenres__items">
 						<% require('./assetLoader.js').getUrl('music').forEach(function(musicGenre) { %>

--- a/src/sound/musicplayer.js
+++ b/src/sound/musicplayer.js
@@ -2,7 +2,7 @@ import * as $j from 'jquery';
 
 export class MusicPlayer {
 	constructor() {
-		this.audio = $j('#audio')[0];
+		this.audio = $j('#audio-player')[0];
 		this.playlist = $j('#playlist');
 		this.tracks = this.playlist.find('li.epic');
 

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -675,6 +675,24 @@ div.section.info {
 	color: white !important;
 }
 
+.audio-player-controls {
+	align-items: center;
+	display: flex;
+	gap: 16px;
+	justify-content: center;
+	margin-bottom: 16px;
+
+	#audio-player {
+		width: 100%;
+	}
+
+	#mp_shuffle {
+		background: none;
+		border: none;
+		cursor: pointer;
+	}
+}
+
 .musicgenres__title {
 	cursor: pointer;
 }

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -569,28 +569,24 @@ div.section.info {
 	width: 100px;
 }
 
-.togglescore.button,
-.toggledash.button,
-.toggle-meta-powers.button {
+.close-button {
+	border: none;
 	height: 100%;
 	width: 100%;
-	background-image: url('~assets/icons/close.svg');
+	background: url('~assets/icons/close.svg');
 	transition: all 0.5s;
-}
+	cursor: pointer;
 
-.togglescore.button:before,
-.toggledash.button:before,
-.toggle-meta-powers.button:before {
-	content: '';
-	width: 100%;
-	height: 100%;
-	background-image: none;
-}
+	&::before {
+		content: '';
+		width: 100%;
+		height: 100%;
+		background-image: none;
+	}
 
-.togglescore.button:hover,
-.toggledash.button:hover,
-.toggle-meta-powers.button:hover {
-	transform: rotate(-90deg);
+	&:hover {
+		transform: rotate(-90deg);
+	}
 }
 
 #playertabswrapper {
@@ -660,7 +656,6 @@ div.section.info {
 	background-color: rgba(0, 255, 0, 0.15);
 }
 
-#musicplayerwrapper,
 #tabwrapper {
 	top: 100px;
 	right: 0;

--- a/src/ui/chat.js
+++ b/src/ui/chat.js
@@ -1,6 +1,4 @@
 import * as $j from 'jquery';
-// Unused for now
-// import * as time from '../utility/time';
 import * as str from '../utility/string';
 
 export class Chat {
@@ -13,22 +11,49 @@ export class Chat {
 		this.game = game;
 		this.$chat = $j('#chat');
 		this.$content = $j('#chatcontent');
-		this.$chat.bind('click', () => {
-			game.UI.chat.toggle();
+		this.$chat.on('click', () => {
+			this.toggle();
 		});
-		this.$chat.bind('mouseenter', () => {
-			game.UI.chat.peekOpen();
+		this.$chat.on('mouseenter', () => {
+			this.peekOpen();
 		});
-		this.$chat.bind('mouseleave', () => {
-			game.UI.chat.peekClose();
+		this.$chat.on('mouseleave', () => {
+			this.peekClose();
 		});
 		this.messages = [];
 		this.isOpen = false;
 		this.messagesToSuppress = [];
 
-		$j('#combatwrapper, #toppanel, #dash, #endscreen').bind('click', () => {
-			game.UI.chat.hide();
+		$j('#combatwrapper, #toppanel, #dash, #endscreen').on('click', () => {
+			this.hide();
 		});
+
+		// Events
+		this.game.signals.ui.add(this._handleUiEvent, this);
+	}
+
+	/**
+	 * Handle events on the "ui" channel.
+	 *
+	 * @param {string} message Event name.
+	 * @param {object} payload Event payload.
+	 */
+	_handleUiEvent(message, payload) {
+		if (message === 'toggleDash') {
+			this.hide();
+		}
+
+		if (message === 'toggleScore') {
+			this.hide();
+		}
+
+		if (message === 'toggleMusicPlayer') {
+			this.hide();
+		}
+
+		if (message === 'toggleMetaPowers') {
+			this.hide();
+		}
 	}
 
 	show() {

--- a/src/ui/chat.js
+++ b/src/ui/chat.js
@@ -54,6 +54,10 @@ export class Chat {
 		if (message === 'toggleMetaPowers') {
 			this.hide();
 		}
+
+		if (message === 'closeInterfaceScreens') {
+			this.hide();
+		}
 	}
 
 	show() {

--- a/src/ui/meta-powers.js
+++ b/src/ui/meta-powers.js
@@ -35,7 +35,7 @@ export class MetaPowers {
 			this._restorePowers();
 		}
 
-		this._updatePowersList();
+		this._updateEnabledPowersPreview();
 	}
 
 	/**
@@ -49,6 +49,18 @@ export class MetaPowers {
 			this._toggleModal();
 		}
 
+		if (message === 'toggleDash') {
+			this._closeModal();
+		}
+
+		if (message === 'toggleScore') {
+			this._closeModal();
+		}
+
+		if (message === 'toggleMusicPlayer') {
+			this._closeModal();
+		}
+
 		if (message === 'closeInterfaceScreens') {
 			this._closeModal();
 		}
@@ -60,7 +72,7 @@ export class MetaPowers {
 	_bindElements() {
 		this.$els = {
 			modal: $j('#meta-powers'),
-			closeModal: $j('#meta-powers .framed-modal__return .button'),
+			closeModal: $j('#meta-powers .close-button'),
 			resetPowersButton: $j('#reset-toggled-powers'),
 			powersList: $j('#meta-powers-list'),
 			executeMonsterButton: $j('#execute-monster-button'),
@@ -131,7 +143,7 @@ export class MetaPowers {
 
 		this.game.signals.metaPowers.dispatch(`toggle${capitalize(stateKey)}`, enabled);
 
-		this._updatePowersList();
+		this._updateEnabledPowersPreview();
 		this._persistPowers();
 	}
 
@@ -169,7 +181,7 @@ export class MetaPowers {
 	/**
 	 * Display a list of enabled powers outside of the modal for easy reference.
 	 */
-	_updatePowersList() {
+	_updateEnabledPowersPreview() {
 		const list = Object.keys(this.toggles)
 			.reduce((acc, curr) => {
 				if (this.toggles[curr].enabled) {


### PR DESCRIPTION
This PR addresses https://github.com/FreezingMoon/AncientBeast/issues/1928 by preventing multiple "screens" such as score, dash, etc from being displayed at the same time.

![exclusive-screens](https://user-images.githubusercontent.com/199204/147708367-ba385a99-2631-4971-a722-cdbc2b73d67f.gif)

Other changes:

* All screens and chat can be closed with escape key.
* Refactoring of some CSS so it is shared between all screen close buttons.
* Improve responsiveness of music player screen.
* Un-nest the music player screen from the dashboard screen.


<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/1993"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

