### PR TITLE
Triage: Not being able to materialize by obvious means, issue #2001.

### DIFF
--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -1889,15 +1889,16 @@ export class UI {
 				// After 2s remove the background and update the button if it's not a passive
 				setTimeout(() => {
 					btn.$button.removeClass('upgradeIcon');
-				}, 2000);
+				}, 1200);
 
 				// Then remove the animation
 				setTimeout(() => {
 					btn.$button.removeClass('upgradeTransition');
+					// Issue #2001 here, if Timeout takes too long, it will extend pass a skipped turn and disable opponent's Godlet Printer
 					if (ab.isUpgradedPerUse()) {
 						btn.changeState(ButtonStateEnum.disabled);
 					}
-				}, 2500);
+				}, 1500);
 
 				ab.setUpgraded(); // Set the ability to upgraded
 			}


### PR DESCRIPTION
Essentially the issue is that in Interface, UpdateAbilityUpgrades, the animation for a button upgrading will play for a set amount of time and then afterwards disable the button. However, the animation would play long enough that when a turn was skipped, it would continue for a short while, after which it would disable the button. Since it was the opponent's turn then, it would disable their button which is the issue. The issue occurs at any set ability upgrades, not just 1. 

All I've done for now is a quick fix by shortening the upgrade animation so that it no longer goes into the next turn. I've left the animation about the longest it can run without causing the issue. I changed the upgrade icon time too so that the animation still looks nice.


<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/2009"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

