### PR TITLE
Improved Fix to Issue #2001.

### DIFF
--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -135,6 +135,9 @@ export class UI {
 							action: 'skip',
 						});
 
+						// Prevents upgrade animation from carrying on into opponent's turn and disabling their button
+						clearTimeout(this.animationUpgradeTimeOutID);
+
 						game.skipTurn();
 						this.lastViewedCreature = '';
 						this.queryUnit = '';
@@ -1889,16 +1892,16 @@ export class UI {
 				// After 2s remove the background and update the button if it's not a passive
 				setTimeout(() => {
 					btn.$button.removeClass('upgradeIcon');
-				}, 1200);
+				}, 2000);
 
 				// Then remove the animation
-				setTimeout(() => {
+				this.animationUpgradeTimeOutID = setTimeout(() => {
 					btn.$button.removeClass('upgradeTransition');
 					// Issue #2001 here, if Timeout takes too long, it will extend pass a skipped turn and disable opponent's Godlet Printer
 					if (ab.isUpgradedPerUse()) {
 						btn.changeState(ButtonStateEnum.disabled);
 					}
-				}, 1500);
+				}, 2500);
 
 				ab.setUpgraded(); // Set the ability to upgraded
 			}

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -1892,7 +1892,7 @@ export class UI {
 				// After 2s remove the background and update the button if it's not a passive
 				setTimeout(() => {
 					btn.$button.removeClass('upgradeIcon');
-				}, 2000);
+				}, 1200);
 
 				// Then remove the animation
 				this.animationUpgradeTimeOutID = setTimeout(() => {
@@ -1900,7 +1900,7 @@ export class UI {
 					if (ab.isUpgradedPerUse()) {
 						btn.changeState(ButtonStateEnum.disabled);
 					}
-				}, 2500);
+				}, 1500);
 
 				ab.setUpgraded(); // Set the ability to upgraded
 			}

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -1897,7 +1897,6 @@ export class UI {
 				// Then remove the animation
 				this.animationUpgradeTimeOutID = setTimeout(() => {
 					btn.$button.removeClass('upgradeTransition');
-					// Issue #2001 here, if Timeout takes too long, it will extend pass a skipped turn and disable opponent's Godlet Printer
 					if (ab.isUpgradedPerUse()) {
 						btn.changeState(ButtonStateEnum.disabled);
 					}


### PR DESCRIPTION
Added a clearTimeout whenever the turn is skipped. This means that if the turn is skipped while an ability is in the process of upgrading, it will skip disabling the button. Also reset the animation times to their original durations. While the Upgrade Icon will still overflow onto the next turn, it seems to be solely an aesthetic issue. 


<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/2011"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

