### PR TITLE
Larva infest log tweak fix for #1971

### DIFF
--- a/src/abilities/Headless.js
+++ b/src/abilities/Headless.js
@@ -56,7 +56,6 @@ export default (G) => {
 
 				// require() has identified a valid target, so we can safely assume it is there.
 				const target = this._getHexes()[0].creature;
-
 				if (this.isUpgraded()) {
 					// Upgraded ability causes fatigue - endurance set to 0.
 					target.addFatigue(target.endurance);
@@ -76,8 +75,16 @@ export default (G) => {
 					},
 					G,
 				);
-
-				target.addEffect(effect, `%CreatureName${target.id}% loses -5 endurance`);
+				if (target.isFragile()) {
+					G.log(`%CreatureName${target.id}% is already fragile`);
+				} else if (target.endurance < 5 && target.endurance > 0) {
+					target.addEffect(
+						effect,
+						`%CreatureName${target.id}% loses -${target.endurance} endurance`,
+					);
+				} else {
+					target.addEffect(effect, `%CreatureName${target.id}% loses -5 endurance`);
+				}
 				// Display potentially new "Fragile" status when losing maximum endurance.
 				this.game.UI.updateFatigue();
 			},


### PR DESCRIPTION
Fix for issue #1971. Added check for if the target is already fragile to display corresponding message. Added check to display endurance lost if endurance is less than 5 but still greater than 0 and to display corresponding endurance lost.  



<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/2013"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

