### PR TITLE
Close windows on right click

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -440,7 +440,7 @@ export default class Game {
 					break;
 				case 2:
 					// Right mouse button pressed
-					this.UI.showCreature(this.activeCreature.type, this.activeCreature.player.id);
+					//this.UI.showCreature(this.activeCreature.type, this.activeCreature.player.id);
 					break;
 			}
 		}, this);

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -7,6 +7,8 @@ import { Team, isTeam } from './team';
 import * as arrayUtils from './arrayUtils';
 import Game from '../game';
 import { Trap } from './trap';
+import { ButtonStateEnum } from '../ui/button'
+
 interface QueryOptions {
 	/**
 	 * Target team.
@@ -946,7 +948,18 @@ export class HexGrid {
 
 		// ONRIGHTCLICK
 		const onRightClickFn = (hex: Hex) => {
-			if (hex.creature instanceof Creature) {
+
+			const state = game.UI.btnSkipTurn.state == ButtonStateEnum.disabled ? (ButtonStateEnum.normal && ButtonStateEnum.slideIn) : ButtonStateEnum.disabled
+
+			game.UI.btnSkipTurn.changeState(state);
+			game.UI.btnDelay.changeState(state);
+			game.UI.btnAudio.changeState(state);
+			game.UI.btnFullscreen.changeState(state);
+
+
+			//game.UI.fullscreen
+
+			/*if (hex.creature instanceof Creature) {
 				game.UI.showCreature(hex.creature.type, hex.creature.player.id, 'grid');
 			} else {
 				if (game.activeCreature.isDarkPriest()) {
@@ -967,11 +980,11 @@ export class HexGrid {
 							game.activeCreature.player.id,
 							'emptyHex',
 						);
-					}
+					}start:dev
 				} else {
 					game.UI.showCreature(game.activeCreature.type, game.activeCreature.player.id, 'emptyHex');
 				}
-			}
+			}*/
 		};
 
 		this.forEachHex((hex) => {
@@ -1450,8 +1463,8 @@ export class HexGrid {
 			(!player.flipped
 				? creatureData.display['offset-x']
 				: 90 * creatureData.size -
-				  this.materialize_overlay.texture.width -
-				  creatureData.display['offset-x']) +
+				this.materialize_overlay.texture.width -
+				creatureData.display['offset-x']) +
 			this.materialize_overlay.texture.width / 2;
 		this.materialize_overlay.y =
 			hex.displayPos.y + creatureData.display['offset-y'] + this.materialize_overlay.texture.height;


### PR DESCRIPTION
Upon right click, the Delay, SkipTurn, Audio, and FullScreen buttons are hidden and unusable.This works by changing the state of the button when the right click button is clicked. Files modified are the hexgrid.ts and game.js. Previous functionality of the right-click button is commented out incase we want to use it or come back to it later on. This is the first iteration of this feature, in the next pull request, right click should be able to hide the abilities of the player.

Pull request regarding issue #1967

Before right click:

![contribution1](https://user-images.githubusercontent.com/57726472/167218563-d89431a8-a30e-42e2-bbc3-d4dd9523a234.png)

After right click:

![contrribution2](https://user-images.githubusercontent.com/57726472/167218692-ada73629-e2a5-4c0c-8d6d-4beb8d9815ee.png)



<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/2034"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

