### PR TITLE
Fixed "Heavy Development" status text not showing

### DIFF
--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -1170,7 +1170,7 @@ export class UI {
 			// Materialize button
 			this.materializeButton.changeState(ButtonStateEnum.disabled);
 			$j('#materialize_button p').text(game.msg.ui.dash.heavyDev);
-
+			$j('#materialize_button').show();
 			$j('#card .sideA').addClass('disabled').off('click');
 		}
 	}


### PR DESCRIPTION
[Issue Link](https://github.com/FreezingMoon/AncientBeast/issues/1961)

To recreate issue: ->materialize unit->right click unit->left click on unit deployed unit in dashboard -> left click on a locked unit
Result: No status text showing




<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/2042"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

