### PR TITLE
2056 - fix bouncing avatar going offscreen, avatar click disable whil…

### DIFF
--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -894,6 +894,10 @@ div.section.info {
 	cursor: help;
 }
 
+.vignette.bouncing {
+	pointer-events: none;
+}
+
 /*-----------Pause Overlay-------------*/
 /* Pause has been disabled from game */
 #pause {

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -2491,27 +2491,31 @@ export class UI {
 			$queueItem = this.$queue.find('.vignette[creatureid="' + creaID + '"]:first');
 		}
 
-		const maxBounceHeight = screen.height / 4;
-		const isBounceHeightExceeded = parseInt($queueItem.css('top'), 10) > maxBounceHeight;
-		let maxBounce = maxBounceHeight;
+		if ($queueItem.hasClass('bouncing')) return;
+		$queueItem.addClass('bouncing');
+
+		let maxBounce = screen.height / 4;
 		let bounceTime = 280; // Time in ms, how long it takes portrait to move down when bouncing, increase to slow down bounce
 
 		let timerId = setInterval(() => {
-			if ($queueItem.length > 0 && !isBounceHeightExceeded) {
+			if ($queueItem.length > 0) {
 				$queueItem.stop();
 				$queueItem.animate(
 					{
 						top: '+=' + maxBounce.toString(10) + 'px',
 					},
-					bounceTime,
-					'',
-					() => {
-						$queueItem.animate(
-							{
-								top: '-=' + $queueItem.css('top'),
-							},
-							bounceTime - 100,
-						);
+					{
+						duration: bounceTime,
+						complete: () => {
+							$queueItem.animate(
+								{
+									top: '-=' + $queueItem.css('top'),
+								},
+								{
+									duration: bounceTime - 100,
+								},
+							);
+						},
 					},
 				);
 			}
@@ -2519,6 +2523,7 @@ export class UI {
 		}, bounceTime * 2 - 100);
 
 		setTimeout(() => {
+			$queueItem.removeClass('bouncing');
 			clearInterval(timerId);
 		}, bounceTime * 6 - 300);
 	}


### PR DESCRIPTION
This fixes issue #2056

Avatar no longer bounces offscreen. Problem was in animations stacking up while clicking and condition for stopping animation having wrong value (therefore never triggering). Fixed by not starting animation if the avatar is bouncing, instead of checking if avatar crossed maximum allowed height.

Also disabled clicking on avatar if the avatar is bouncing (so that the menu won't be opened).

<a href="https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast/pull/2095"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

