### PR TITLE
Added 'T' hotkey for Score Menu

### DIFF
--- a/src/ui/hotkeys.js
+++ b/src/ui/hotkeys.js
@@ -17,6 +17,10 @@ export class Hotkeys {
 		}
 	}
 
+	pressT() {
+		this.ui.dashopen ? this.ui.closeDash() : this.ui.btnToggleScore.triggerClick();
+	}
+
 	pressD(event) {
 		if (event.shiftKey) {
 			this.ui.btnToggleDash.triggerClick();
@@ -118,6 +122,11 @@ export function getHotKeys(hk) {
 		KeyS: {
 			onkeydown(event) {
 				hk.pressS(event);
+			},
+		},
+		KeyT: {
+			onkeydown() {
+				hk.pressT();
 			},
 		},
 		KeyD: {


### PR DESCRIPTION
This fixes issue #2112
Added a 'pressT' command in the hotkey.js
players now can display the score menu on the screen by pressing 't' or 'T'
Demo:
![git demo](https://user-images.githubusercontent.com/89825717/205743778-d13276d1-f88a-47d2-bf7e-192e59bcf2ae.gif)
