### PR TITLE
Fixed link on "Play Ancient Beast"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Play Ancient Beast](https://img.shields.io/badge/play-Ancient%20Beast-red.svg)](https://play.AncientBeast.com)
+[![Play Ancient Beast](https://img.shields.io/badge/play-Ancient%20Beast-red.svg)](https://ancientbeast.com/)
 [![Join Discord](https://img.shields.io/badge/join-Discord-9cf.svg)](https://discord.me/AncientBeast)
 [![Setup Gitpod](https://img.shields.io/badge/setup-Gitpod-blue)](https://gitpod.io/#https://github.com/FreezingMoon/AncientBeast)
 [![Donate via PayPal](https://img.shields.io/badge/donate-PayPal-yellow.svg)](https://paypal.me/AncientBeast)


### PR DESCRIPTION
Line 1. Changed "https://play.ancientbeast.com/" to "https://ancientbeast.com/"

I didn't find any issues on this error.
No need for wallet address because I don't think there's anything bountied for this.