### PR TITLE
Refactored updateFatigue into Creature

### DIFF
--- a/src/abilities/Headless.js
+++ b/src/abilities/Headless.js
@@ -85,8 +85,6 @@ export default (G) => {
 				} else {
 					target.addEffect(effect, `%CreatureName${target.id}% loses -5 endurance`);
 				}
-				// Display potentially new "Fragile" status when losing maximum endurance.
-				this.game.UI.updateFatigue();
 			},
 
 			_getHexes: function () {

--- a/src/creature.js
+++ b/src/creature.js
@@ -277,7 +277,7 @@ export class Creature {
 	 * @param {boolean} disableMaterializationSickness Do not affect the creature with Materialization Sickness.
 	 */
 	summon(disableMaterializationSickness = false) {
-		let game = this.game;
+		const game = this.game;
 
 		/* Without Sickness the creature should act in the current turn, except the dark
 		priest who must always be in the next queue to properly start the game. */
@@ -354,9 +354,9 @@ export class Creature {
 		this.oldHealth = this.health;
 		this.noActionPossible = false;
 
-		let game = this.game;
-		let stats = this.stats;
-		let varReset = function () {
+		const game = this.game;
+		const stats = this.stats;
+		const varReset = function () {
 			this.game.onReset(this);
 			// Variables reset
 			this.updateAlteration();
@@ -392,7 +392,7 @@ export class Creature {
 		// Frozen or dizzy effect
 		if (this.isFrozen() || this.isDizzy()) {
 			varReset();
-			let interval = setInterval(() => {
+			const interval = setInterval(() => {
 				if (!game.turnThrottle) {
 					clearInterval(interval);
 					game.skipTurn({
@@ -412,7 +412,7 @@ export class Creature {
 
 		this.materializationSickness = false;
 
-		let interval = setInterval(() => {
+		const interval = setInterval(() => {
 			// if (!game.freezedInput) { remove for muliplayer
 			clearInterval(interval);
 			if (game.turn >= game.minimumTurnBeforeFleeing) {
@@ -433,7 +433,7 @@ export class Creature {
 	 *
 	 */
 	deactivate(wait) {
-		let game = this.game;
+		const game = this.game;
 		this.delayed = Boolean(wait);
 		this.hasWait = this.delayed;
 		this.status.frozen = false;
@@ -473,7 +473,7 @@ export class Creature {
 	}
 
 	delay(excludeActiveCreature) {
-		let game = this.game;
+		const game = this.game;
 
 		game.queue.delay(this);
 		this.delayable = false;
@@ -488,7 +488,7 @@ export class Creature {
 	 *
 	 */
 	queryMove(o) {
-		let game = this.game;
+		const game = this.game;
 
 		if (this.dead) {
 			// Creatures can die during their turns from trap effects; make sure this
@@ -585,17 +585,17 @@ export class Creature {
 			o.range = game.grid.getFlyingRange(this.x, this.y, remainingMove, this.size, this.id);
 		}
 
-		let selectNormal = function (hex, args) {
+		const selectNormal = function (hex, args) {
 			args.creature.tracePath(hex);
 		};
-		let selectFlying = function (hex, args) {
+		const selectFlying = function (hex, args) {
 			args.creature.tracePosition({
 				x: hex.x,
 				y: hex.y,
 				overlayClass: 'creature moveto selected player' + args.creature.team,
 			});
 		};
-		let select = o.noPath || this.movementType() === 'flying' ? selectFlying : selectNormal;
+		const select = o.noPath || this.movementType() === 'flying' ? selectFlying : selectNormal;
 
 		if (this.noActionPossible) {
 			game.grid.querySelf({
@@ -631,7 +631,7 @@ export class Creature {
 	 *
 	 */
 	previewPosition(hex) {
-		let game = this.game;
+		const game = this.game;
 
 		game.grid.cleanOverlay('hover h_player' + this.team);
 		if (!game.grid.hexes[hex.y][hex.x].isWalkable(this.size, this.id)) {
@@ -663,10 +663,9 @@ export class Creature {
 	 *
 	 */
 	updateHex() {
-		let count = this.size,
-			i;
+		const count = this.size;
 
-		for (i = 0; i < count; i++) {
+		for (let i = 0; i < count; i++) {
 			this.hexagons.push(this.game.grid.hexes[this.y][this.x - i]);
 		}
 
@@ -772,29 +771,29 @@ export class Creature {
 	 *
 	 */
 	moveTo(hex, opts) {
-		let game = this.game,
-			defaultOpt = {
-				callback: function () {
-					return true;
-				},
-				callbackStepIn: function () {
-					return true;
-				},
-				animation: this.movementType() === 'flying' ? 'fly' : 'walk',
-				ignoreMovementPoint: false,
-				ignorePath: false,
-				customMovementPoint: 0,
-				overrideSpeed: 0,
-				turnAroundOnComplete: true,
+		const game = this.game;
+		const defaultOpt = {
+			callback: function () {
+				return true;
 			},
-			path;
+			callbackStepIn: function () {
+				return true;
+			},
+			animation: this.movementType() === 'flying' ? 'fly' : 'walk',
+			ignoreMovementPoint: false,
+			ignorePath: false,
+			customMovementPoint: 0,
+			overrideSpeed: 0,
+			turnAroundOnComplete: true,
+		};
+		let path;
 
 		opts = $j.extend(defaultOpt, opts);
 
 		// Teleportation ignores moveable
 		if (this.stats.moveable || opts.animation === 'teleport') {
-			let x = hex.x;
-			let y = hex.y;
+			const x = hex.x;
+			const y = hex.y;
 
 			if (opts.ignorePath || opts.animation == 'fly') {
 				path = [hex];
@@ -815,7 +814,7 @@ export class Creature {
 			game.log('This creature cannot be moved');
 		}
 
-		let interval = setInterval(() => {
+		const interval = setInterval(() => {
 			// Check if creature's movement animation is completely finished.
 			if (!game.freezedInput) {
 				clearInterval(interval);
@@ -834,9 +833,9 @@ export class Creature {
 	 *
 	 */
 	tracePath(hex) {
-		let x = hex.x,
-			y = hex.y,
-			path = this.calculatePath(x, y); // Store path in grid to be able to compare it later
+		const x = hex.x;
+		const y = hex.y;
+		const path = this.calculatePath(x, y); // Store path in grid to be able to compare it later
 
 		if (path.length === 0) {
 			return; // Break if empty path
@@ -852,7 +851,7 @@ export class Creature {
 		}); // Trace path
 
 		// Highlight final position
-		let last = arrayUtils.last(path);
+		const last = arrayUtils.last(path);
 
 		this.tracePosition({
 			x: last.x,
@@ -863,7 +862,7 @@ export class Creature {
 	}
 
 	tracePosition(args) {
-		let defaultArgs = {
+		const defaultArgs = {
 			x: this.x,
 			y: this.y,
 			overlayClass: '',
@@ -886,7 +885,7 @@ export class Creature {
 				}
 			}
 			if (canDraw) {
-				let hex = this.game.grid.hexes[args.y][args.x - i];
+				const hex = this.game.grid.hexes[args.y][args.x - i];
 				this.game.grid.cleanHex(hex);
 				hex.overlayVisualState(args.overlayClass);
 				hex.displayVisualState(args.displayClass);
@@ -903,7 +902,7 @@ export class Creature {
 	 *
 	 */
 	calculatePath(x, y) {
-		let game = this.game;
+		const game = this.game;
 
 		return search(
 			game.grid.hexes[this.y][this.x],
@@ -925,9 +924,9 @@ export class Creature {
 	 *
 	 */
 	calcOffset(x, y) {
-		let game = this.game,
-			offset = game.players[this.team].flipped ? this.size - 1 : 0,
-			mult = game.players[this.team].flipped ? 1 : -1; // For FLIPPED player
+		const game = this.game;
+		const offset = game.players[this.team].flipped ? this.size - 1 : 0;
+		const mult = game.players[this.team].flipped ? 1 : -1; // For FLIPPED player
 
 		for (let i = 0; i < this.size; i++) {
 			// Try next hexagons to see if they fit
@@ -965,13 +964,14 @@ export class Creature {
 	 *
 	 */
 	adjacentHexes(dist, clockwise) {
-		let game = this.game;
+		const game = this.game;
 
 		// TODO Review this algo to allow distance
 		if (clockwise) {
-			let hexes = [],
-				c;
-			let o = this.y % 2 === 0 ? 1 : 0;
+			const hexes = [];
+			const o = this.y % 2 === 0 ? 1 : 0;
+
+			let c;
 
 			if (this.size == 1) {
 				c = [
@@ -1084,7 +1084,7 @@ export class Creature {
 				];
 			}
 
-			let total = c.length;
+			const total = c.length;
 			for (let i = 0; i < total; i++) {
 				const { x, y } = c[i];
 				if (game.grid.hexExists(y, x)) {
@@ -1096,8 +1096,8 @@ export class Creature {
 		}
 
 		if (this.size > 1) {
-			let hexes = this.hexagons[0].adjacentHex(dist);
-			let lasthexes = this.hexagons[this.size - 1].adjacentHex(dist);
+			const hexes = this.hexagons[0].adjacentHex(dist);
+			const lasthexes = this.hexagons[this.size - 1].adjacentHex(dist);
 
 			hexes.forEach((hex) => {
 				if (arrayUtils.findPos(this.hexagons, hex)) {
@@ -1164,7 +1164,7 @@ export class Creature {
 	 * amount :	Damage :	Amount of health point to restore
 	 */
 	heal(amount, isRegrowth, log = true) {
-		let game = this.game;
+		const game = this.game;
 		// Cap health point
 		amount = Math.min(amount, this.stats.health - this.health);
 
@@ -1215,14 +1215,14 @@ export class Creature {
 	 * return :	Object :	Contains damages dealt and if creature is killed or not
 	 */
 	takeDamage(damage, o) {
-		let game = this.game;
+		const game = this.game;
 
 		if (this.dead) {
 			console.info(`${this.name} (${this.id}) is already dead, aborting takeDamage call.`);
 			return;
 		}
 
-		let defaultOpt = {
+		const defaultOpt = {
 			ignoreRetaliation: false,
 			isFromTrap: false,
 		};
@@ -1246,8 +1246,8 @@ export class Creature {
 		// Calculation
 		if (damage.status === '') {
 			// Damages
-			let dmg = damage.applyDamage();
-			let dmgAmount = dmg.total;
+			const dmg = damage.applyDamage();
+			const dmgAmount = dmg.total;
 
 			if (!isFinite(dmgAmount)) {
 				// Check for Damage Errors
@@ -1266,7 +1266,7 @@ export class Creature {
 			this.addFatigue(dmgAmount);
 
 			// Display
-			let nbrDisplayed = dmgAmount ? '-' + dmgAmount : 0;
+			const nbrDisplayed = dmgAmount ? '-' + dmgAmount : 0;
 			this.hint(nbrDisplayed, 'damage d' + dmgAmount);
 
 			if (!damage.noLog) {
@@ -1347,7 +1347,7 @@ export class Creature {
 	}
 
 	updateHealth(noAnimBar) {
-		let game = this.game;
+		const game = this.game;
 
 		if (this == game.activeCreature && !noAnimBar) {
 			game.UI.healthBar.animSize(this.health / this.stats.health);
@@ -1399,7 +1399,7 @@ export class Creature {
 	 *
 	 */
 	addEffect(effect, specialString, specialHint, disableLog = false, disableHint = false) {
-		let game = this.game;
+		const game = this.game;
 
 		if (!effect.stackable && this.findEffect(effect.name).length !== 0) {
 			return false;
@@ -1456,7 +1456,7 @@ export class Creature {
 	 * @return {void}
 	 */
 	removeEffect(name) {
-		let totalEffects = this.effects.length;
+		const totalEffects = this.effects.length;
 
 		for (let i = 0; i < totalEffects; i++) {
 			if (this.effects[i].name === name) {
@@ -1469,12 +1469,12 @@ export class Creature {
 	}
 
 	hint(text, cssClass) {
-		let game = this.game,
-			tooltipSpeed = 250,
-			tooltipDisplaySpeed = 500,
-			tooltipTransition = Phaser.Easing.Linear.None;
+		const game = this.game;
+		const tooltipSpeed = 250;
+		const tooltipDisplaySpeed = 500;
+		const tooltipTransition = Phaser.Easing.Linear.None;
 
-		let hintColor = {
+		const hintColor = {
 			confirm: {
 				fill: '#ffffff',
 				stroke: '#000000',
@@ -1495,7 +1495,7 @@ export class Creature {
 			},
 		};
 
-		let style = $j.extend(
+		const style = $j.extend(
 			{
 				font: 'bold 20pt Play',
 				fill: '#ff0000',
@@ -1530,7 +1530,7 @@ export class Creature {
 			true,
 		);
 
-		let hint = game.Phaser.add.text(0, 50, text, style);
+		const hint = game.Phaser.add.text(0, 50, text, style);
 		hint.anchor.setTo(0.5, 0.5);
 
 		hint.alpha = 0;
@@ -1582,8 +1582,8 @@ export class Creature {
 		// Stacking
 		this.hintGrp.forEach(
 			(grpHintElem) => {
-				let index = this.hintGrp.total - this.hintGrp.getIndex(grpHintElem) - 1;
-				let offset = -50 * index;
+				const index = this.hintGrp.total - this.hintGrp.getIndex(grpHintElem) - 1;
+				const offset = -50 * index;
 
 				if (grpHintElem.tweenPos) {
 					grpHintElem.tweenPos.stop();
@@ -1613,7 +1613,7 @@ export class Creature {
 	updateAlteration() {
 		this.stats = { ...this.baseStats };
 
-		let buffDebuffArray = [...this.effects, ...this.dropCollection];
+		const buffDebuffArray = [...this.effects, ...this.dropCollection];
 
 		buffDebuffArray.forEach((buff) => {
 			$j.each(buff.alterations, (key, value) => {
@@ -1662,7 +1662,7 @@ export class Creature {
 	 *
 	 */
 	die(killer) {
-		let game = this.game;
+		const game = this.game;
 
 		game.log('%CreatureName' + this.id + '% is dead');
 
@@ -1672,11 +1672,11 @@ export class Creature {
 		game.onCreatureDeath(this);
 
 		this.killer = killer.player;
-		let isDeny = this.killer.flipped == this.player.flipped;
+		const isDeny = this.killer.flipped == this.player.flipped;
 
 		// Drop item
 		if (game.unitDrops == 1 && this.drop) {
-			let offsetX = this.player.flipped ? this.x - this.size + 1 : this.x;
+			const offsetX = this.player.flipped ? this.x - this.size + 1 : this.x;
 			/* All properties aside from `name` are assumed to be alterations to the creature's
 			statistics. */
 			const { name, ...alterations } = this.drop;
@@ -1727,9 +1727,9 @@ export class Creature {
 
 		if (this.player.isAnnihilated()) {
 			// Remove humiliation as annihilation is an upgrade
-			let total = this.killer.score.length;
+			const total = this.killer.score.length;
 			for (let i = 0; i < total; i++) {
-				let s = this.killer.score[i];
+				const s = this.killer.score[i];
 				if (s.type == 'humiliation') {
 					if (s.player == this.team) {
 						this.killer.score.splice(i, 1);
@@ -1750,7 +1750,7 @@ export class Creature {
 		}
 
 		// Kill animation
-		let tweenSprite = game.Phaser.add
+		const tweenSprite = game.Phaser.add
 			.tween(this.sprite)
 			.to(
 				{
@@ -1760,7 +1760,7 @@ export class Creature {
 				Phaser.Easing.Linear.None,
 			)
 			.start();
-		let tweenHealth = game.Phaser.add
+		const tweenHealth = game.Phaser.add
 			.tween(this.healthIndicatorGroup)
 			.to(
 				{
@@ -1805,7 +1805,7 @@ export class Creature {
 	 * shortcut convenience function to grid.getHexMap
 	 */
 	getHexMap(map, invertFlipped) {
-		let x = (this.player.flipped ? !invertFlipped : invertFlipped)
+		const x = (this.player.flipped ? !invertFlipped : invertFlipped)
 			? this.x + 1 - this.size
 			: this.x;
 		return this.game.grid.getHexMap(
@@ -1818,20 +1818,20 @@ export class Creature {
 	}
 
 	findEffect(name) {
-		let ret = [];
+		const result = [];
 
 		this.effects.forEach((effect) => {
 			if (effect.name == name) {
-				ret.push(effect);
+				result.push(effect);
 			}
 		});
 
-		return ret;
+		return result;
 	}
 
 	// Make units transparent
 	xray(enable) {
-		let game = this.game;
+		const game = this.game;
 
 		if (enable) {
 			game.Phaser.add
@@ -1869,7 +1869,7 @@ export class Creature {
 	 * @return {string} "normal", "hover", or "flying"
 	 */
 	movementType() {
-		let totalAbilities = this.abilities.length;
+		const totalAbilities = this.abilities.length;
 
 		// If the creature has an ability that modifies movement type, use that,
 		// otherwise use the creature's base movement type

--- a/src/creature.js
+++ b/src/creature.js
@@ -1464,6 +1464,8 @@ export class Creature {
 				break;
 			}
 		}
+
+		this.#updateFatigue();
 	}
 
 	hint(text, cssClass) {


### PR DESCRIPTION
This is a small refactor.

Previously, creatures called `game.UI.updateFatigue()` to update and set their own `creature.fatigueText`. That's a Demeter violation. That function has now been moved into creature and made private. 

When called, if the `creature.fatigueText` is updated, the creature fires a signal, which is picked up by game.UI. Previously, game.UI was called directly. Sending signals rather than calling methods favors decoupling.

The small deletion in `Headless` was possible because `creature.#updateFatigue` is called at the end of `creature.addEffect`.

I also made signal handlers private methods in creature.