### PR TITLE
remapping the "save as file" hotkey

### DIFF
--- a/src/ui/hotkeys.js
+++ b/src/ui/hotkeys.js
@@ -10,8 +10,6 @@ export class Hotkeys {
 	pressS(event) {
 		if (event.shiftKey) {
 			this.ui.btnToggleScore.triggerClick();
-		} else if (event.metaKey || event.ctrlKey) {
-			this.ui.game.gamelog.get('save');
 		} else {
 			this.ui.dashopen ? this.ui.gridSelectDown() : this.ui.btnSkipTurn.triggerClick();
 		}
@@ -63,8 +61,12 @@ export class Hotkeys {
 		}
 	}
 
-	pressX() {
-		this.ui.btnExit.triggerClick();
+	pressX(event) {
+		if (event.shiftKey && event.ctrlKey && event.metaKey) {
+			this.ui.game.gamelog.get('save');
+		} else {
+			this.ui.btnExit.triggerClick();
+		}
 	}
 
 	pressArrowUp() {
@@ -170,8 +172,8 @@ export function getHotKeys(hk) {
 			},
 		},
 		KeyX: {
-			onkeydown() {
-				hk.pressX();
+			onkeydown(event) {
+				hk.pressX(event);
 			},
 		},
 		ArrowUp: {


### PR DESCRIPTION
This fixes issue #2160. I remapped the "save progress as file" hotkey to Shift + Ctrl + Meta + X and deleted the old hotkey. The new mapping works locally on both Chrome and Brave.
