### PR TITLE
fatigueText refactor

### DIFF
--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -2023,7 +2023,6 @@ export class UI {
 	 */
 	updateQueueDisplay() {
 		const game = this.game;
-		this.updateFatigue();
 		this.queue.setQueue(game.queue, game.activeCreature, game.turn);
 	}
 
@@ -2037,12 +2036,6 @@ export class UI {
 	}
 
 	updateFatigue() {
-		const game = this.game;
-		game.creatures.forEach((creature) => {
-			if (creature instanceof Creature) {
-				refactor.creature.updateFatigue(creature, game);
-			}
-		});
 		this.queue.refresh();
 	}
 
@@ -2225,46 +2218,5 @@ const utils = {
 				}
 			};
 		};
-	},
-};
-
-const refactor = {
-	creature: {
-		/** TODO:
-		 * This code was part of the UI class and used to include
-		 * updates to DOM elements controlled by /src/ui/interface.js,
-		 * but those DOM updates have now been factored out. Separating
-		 * this out for an eventual refactor into Creature, perhaps as
-		 * Creature.getFatigueText() or Creature.getStatsText()?
-		 */
-		updateFatigue(creature, game) {
-			let text;
-			if (creature.isFrozen()) {
-				text = creature.isInCryostasis() ? 'Cryostasis' : 'Frozen';
-			} else if (creature.isDizzy()) {
-				text = 'Dizzy';
-			} else if (creature.materializationSickness) {
-				text = 'Sickened';
-			} else if (creature.protectedFromFatigue || creature.stats.fatigueImmunity) {
-				text = 'Protected';
-			} else if (creature.isFragile()) {
-				text = 'Fragile';
-				// Display message if the creature has first become fragile
-				if (creature.fatigueText !== text) {
-					game.log('%CreatureName' + creature.id + '% has become fragile');
-				}
-			} else if (creature.isFatigued()) {
-				text = 'Fatigued';
-			} else {
-				text = creature.endurance + '/' + creature.stats.endurance;
-			}
-
-			if (creature.isDarkPriest()) {
-				// If Dark Priest
-				creature.abilities[0].require(); // Update protectedFromFatigue
-			}
-
-			creature.fatigueText = text;
-		},
 	},
 };


### PR DESCRIPTION
Refactors creatures' fatigueText from `/src/ui/interface.js` to `/src/creature.js`. 

`creature.fatigueText` is now a getter that computes the value when accessed. The value is no longer stored, in order to reduce state/synchronization problems.

It also adds a further TODO in `get fatigueText`. There appears to be a logical bug when logging when the creature has become "fragile."