### PR TITLE
game.debugMode converted to boolean

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -17,6 +17,7 @@ import Phaser, { Signal } from 'phaser';
 import MatchI from './multiplayer/match';
 import Gameplay from './multiplayer/gameplay';
 import { sleep } from './utility/time';
+import { toBool } from './utility/string';
 
 /* Game Class
  *
@@ -85,7 +86,7 @@ export default class Game {
 		this.session = null;
 		this.client = null;
 		this.connect = null;
-		this.debugMode = process.env.DEBUG_MODE;
+		this.debugMode = toBool(process.env.DEBUG_MODE);
 		this.multiplayer = false;
 		this.matchInitialized = false;
 		this.realms = ['A', 'E', 'G', 'L', 'P', 'S', 'W'];

--- a/src/utility/string.js
+++ b/src/utility/string.js
@@ -17,3 +17,40 @@ export function zfill(num, size) {
  * @returns {string} Capitalized string.
  */
 export const capitalize = (string) => string.charAt(0).toUpperCase() + string.slice(1);
+
+/**
+ * Convert a string to a boolean.
+ *
+ * @example toBool("true") -> true
+ * @example toBool(" TRUE ") -> true
+ * @example toBool("yes") -> true
+ * @example toBool("1") -> true
+ * @example toBool(true) -> true
+ * @example toBool("anything else") -> false
+ * @example toBool("false") -> false
+ * @example toBool([1, 2, 3]) -> false
+ * @example toBool({"a": 1}) -> false
+ *
+ * @param {string} string To convert to boolean.
+ * @returns {boolean} true if the trimmed, lowercase string is in ["true", "yes", "1"], else false
+ */
+export const toBool = (string) => {
+	// NOTE: Guard against repeatedly calling `toBool`.
+	if (string === true) {
+		return string;
+	}
+
+	if (typeof string === 'string') {
+		switch (string.toLowerCase().trim()) {
+			case 'true':
+			case 'yes':
+			case '1':
+				return true;
+
+			default:
+				return false;
+		}
+	}
+
+	return false;
+};


### PR DESCRIPTION
# Bug description

game.debugMode was being used as a boolean, but the actual value was a string. 

If `DEBUG_MODE=false` is set in `.env`, game.debugMode is truthy.


# Steps to reproduce

* Copy /.env.example as /.env
* Set `DEBUG_MODE=false`
* Restart dev server. (NB: .env variables do not refresh when the game is live reloaded or when the game page is refreshed in the browser.)

Notice that `0/0` is being logged in the browser console. That comes from this line:

[		if (game.debugMode) {
			console.log(this.timeCursor + '/' + this.data.length);
		}
](https://github.com/FreezingMoon/AncientBeast/blob/893e174728e0b86a374738147a96ad4f68525842/src/utility/gamelog.js#L92)

Since `game.debugMode` is a string and not a boolean, and the string `"false"` is truthy, the code above will `console.log`.

# Background

game.debugMode is expected to be a boolean for all occurrences matching `debugMode` in the codebase:

https://github.com/FreezingMoon/AncientBeast/blob/893e174728e0b86a374738147a96ad4f68525842/src/damage.js#L47

https://github.com/FreezingMoon/AncientBeast/blob/893e174728e0b86a374738147a96ad4f68525842/src/utility/gamelog.js#L61

https://github.com/FreezingMoon/AncientBeast/blob/893e174728e0b86a374738147a96ad4f68525842/src/utility/gamelog.js#L92

# Fix

The fix adds a `toBool` function to /src/utilities/string.js to convert strings to booleans. `true` is returned if the trimmed, lowercased string argument is one of:

* "1"
* "true"
* "yes"

`false` is returned otherwise.

`game.debugMode` is set to `toBool(process.env.DEBUG_MODE);`