### PR TITLE
Bugfix: Notify ui when updating status, addresses #2175

### DIFF
--- a/src/abilities/Headless.js
+++ b/src/abilities/Headless.js
@@ -86,6 +86,10 @@ export default (G) => {
 					target.addEffect(effect, `%CreatureName${target.id}% loses -5 endurance`);
 				}
 				// Display potentially new "Fragile" status when losing maximum endurance.
+				// TODO: Creatures are responsible for telling the UI if they potentially
+				// make a change that might update another creature's fatigue. But this is
+				// fragile. Ideally, this would be refactored so that the UI doesn't need
+				// to be told about an update.
 				this.game.UI.updateFatigue();
 			},
 

--- a/src/abilities/Stomper.js
+++ b/src/abilities/Stomper.js
@@ -536,6 +536,12 @@ export default (G) => {
 						);
 					}
 				}
+
+				// TODO: Creatures are responsible for telling the UI if they potentially
+				// make a change that might update another creature's fatigue. But this is
+				// fragile. Ideally, this would be refactored so that the UI doesn't need
+				// to be told about an update.
+				this.game.UI.updateFatigue();
 			},
 		},
 	];


### PR DESCRIPTION
Bugfix. Addresses #2175 

This is meant as a stopgap fix in lieu of a larger refactor. [See discussion in the issue thread.](https://github.com/FreezingMoon/AncientBeast/issues/2175#issuecomment-1494058573)

In addition to addressing the bug, it adds `TODO`s for potential refactoring in both `src/abilities/Headless.js` and `src/abilites/Stomper.js`.