### PR TITLE
Added .env options to disable music and console.logging #2192 #2193

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
 # Game
 ENABLE_SERVICE_WORKER=false
+
+# Debug
+# If DEBUG_MODE is not set to true, other DEBUG_* settings are false
 DEBUG_MODE=true
+DEBUG_DISABLE_GAME_STATUS_CONSOLE_LOG=false
+DEBUG_DISABLE_MUSIC=false
 
 # Server
 MULTIPLAYER_KEY=mudvayne

--- a/src/game.js
+++ b/src/game.js
@@ -87,6 +87,9 @@ export default class Game {
 		this.client = null;
 		this.connect = null;
 		this.debugMode = toBool(process.env.DEBUG_MODE);
+		this.debugDisableGameStatusConsoleLog =
+			this.debugMode && toBool(process.env.DEBUG_DISABLE_GAME_STATUS_CONSOLE_LOG);
+		this.debugDisableMusic = this.debugMode && toBool(process.env.DEBUG_DISABLE_MUSIC);
 		this.multiplayer = false;
 		this.matchInitialized = false;
 		this.realms = ['A', 'E', 'G', 'L', 'P', 'S', 'W'];
@@ -554,6 +557,10 @@ export default class Game {
 		});
 
 		this.soundsys.playMusic();
+		if (this.debugDisableMusic) {
+			this.musicPlayer.audio.pause();
+		}
+
 		if (this.gamelog.data) {
 			// TODO: Remove the need for a timeout here by having a proper
 			// "game is ready to play" event that can trigger log replays if
@@ -804,7 +811,9 @@ export default class Game {
 			}
 		}
 
-		console.log(stringConsole);
+		if (!this.debugDisableGameStatusConsoleLog) {
+			console.log(stringConsole);
+		}
 		this.UI.chat.addMsg(stringLog, htmlclass, ifNoTimestamp);
 	}
 

--- a/src/utility/gamelog.js
+++ b/src/utility/gamelog.js
@@ -58,7 +58,7 @@ export class GameLog {
 		let fun = () => {
 			this.timeCursor++;
 
-			if (game.debugMode) {
+			if (game.debugMode && !game.debugDisableGameStatusConsoleLog) {
 				console.log(this.timeCursor + '/' + this.data.length);
 			}
 
@@ -89,7 +89,7 @@ export class GameLog {
 		}
 
 		this.timeCursor++;
-		if (game.debugMode) {
+		if (game.debugMode && !game.debugDisableGameStatusConsoleLog) {
 			console.log(this.timeCursor + '/' + this.data.length);
 		}
 


### PR DESCRIPTION
This adds two quality-of-life debug options to .env.example:

* disable console logging for status updates
* disable autoplay for music

`DEBUG_MODE` overrides these two options. It must be `true`, otherwise the options are set to `false` in `game`.

Fixes #2192 #2193