### PR TITLE
Show creature name in queue on mouseover #2157

### DIFF
--- a/src/__tests__/ui/queue.ts
+++ b/src/__tests__/ui/queue.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 import { Queue } from '../../ui/queue';
 import { expect, describe, test } from '@jest/globals';
 
@@ -11,4 +14,95 @@ describe('Queue', () => {
 		expect(queue).toBeDefined();
 		expect(div.innerHTML).toBe('');
 	});
+
+	test("xray(creatureId) applies .xray class to creature's vignette", () => {
+		const [div, queue, creatureQueue] = getDivQueueCreatureQueue();
+
+		const firstCreature = creatureQueue.queue[0];
+		expect(div.querySelector('.xray')).toBeNull();
+		queue.xray(firstCreature.id);
+		const creatureVignette0 = div.querySelector('.xray');
+		expect(creatureVignette0.getAttribute('creatureid')).toBe('' + firstCreature.id);
+		queue.xray(-1);
+		expect(div.querySelector('.xray')).toBeNull();
+	});
+
+	test('xray(creatureId) shows creature name', () => {
+		const [div, queue, creatureQueue] = getDivQueueCreatureQueue();
+
+		const firstCreature = creatureQueue.queue[0];
+		queue.xray(firstCreature.id);
+
+		const creatureVignette0: HTMLElement = div.querySelector('.xray');
+		expect(creatureVignette0.getAttribute('creatureid')).toBe('' + firstCreature.id);
+		expect(hasText(creatureVignette0, firstCreature.name)).toBe(true);
+		expect(hasText(creatureVignette0, firstCreature.fatigueText)).toBe(false);
+		queue.xray(-1);
+		expect(hasText(creatureVignette0, firstCreature.name)).toBe(false);
+		expect(hasText(creatureVignette0, firstCreature.fatigueText)).toBe(true);
+
+		const secondCreature = creatureQueue.queue[1];
+		queue.xray(secondCreature.id);
+		const creatureVignette1 = div.querySelector('.xray');
+		expect(hasText(creatureVignette1, secondCreature.name)).toBe(true);
+		expect(hasText(creatureVignette1, secondCreature.fatigueText)).toBe(false);
+		queue.xray(-1);
+		expect(hasText(creatureVignette1, secondCreature.name)).toBe(false);
+		expect(hasText(creatureVignette1, secondCreature.fatigueText)).toBe(true);
+	});
 });
+
+function getDivQueueCreatureQueue(): [HTMLElement, Queue, CreatureQueue] {
+	const div = document.createElement('div');
+	document.body.appendChild(div);
+	const creatureQueue = getCreatureQueueMock();
+
+	const queue = new Queue(div);
+	queue.setQueue(creatureQueue, creatureQueue.queue[0], 1);
+	return [div, queue, creatureQueue];
+}
+
+function textNodesUnder(el: HTMLElement) {
+	let n: Node;
+	const a = [];
+	const walk = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, null);
+	while ((n = walk.nextNode())) a.push(n);
+	return a;
+}
+
+function hasText(el, txt) {
+	const textNodes: Text[] = textNodesUnder(el);
+	return textNodes.reduce((tOrF, node) => tOrF || node.nodeValue === txt, false);
+}
+
+function getCreatureMock() {
+	return {
+		id: Math.floor(Math.random() * 10000000),
+		name: (Math.random() + 1).toString(36).substring(7),
+		fatigueText: (Math.random() + 1).toString(36).substring(7),
+	};
+}
+
+type CreatureQueue = {
+	game: any;
+	queue: Array<any>;
+	nextQueue: Array<any>;
+};
+
+function getCreatureQueueMock() {
+	const creatures = new Array(5).fill(0).map((_) => getCreatureMock());
+	const game = getGameMock();
+	const q = {
+		game,
+		queue: creatures,
+		nextQueue: Array.from(creatures),
+	};
+	return q;
+}
+
+function getGameMock() {
+	return {
+		turnNumber: 1,
+		activeCreature: getCreatureMock(),
+	};
+}

--- a/src/ui/queue.ts
+++ b/src/ui/queue.ts
@@ -263,7 +263,7 @@ class Vignette {
 			},
 			{ transform: `translateX(${x}px) translateY(0px) scale(1)` },
 		];
-		const animation = this.el.animate(keyframes, {
+		const animation = utils.animate(this.el, keyframes, {
 			duration: CONST.animDurationMS,
 			fill: 'forwards',
 		});
@@ -273,7 +273,7 @@ class Vignette {
 
 	animateUpdate(queuePosition, x) {
 		const keyframes = [{ transform: `translateX(${x}px) translateY(0px) scale(1)` }];
-		const animation = this.el.animate(keyframes, {
+		const animation = utils.animate(this.el, keyframes, {
 			duration: CONST.animDurationMS,
 			fill: 'forwards',
 		});
@@ -283,7 +283,7 @@ class Vignette {
 
 	animateDelete(queuePosition, x) {
 		const keyframes = [{ transform: `translateX(${x}px) translateY(-100px) scale(1)` }];
-		const animation = this.el.animate(keyframes, {
+		const animation = utils.animate(this.el, keyframes, {
 			duration: CONST.animDurationMS,
 			fill: 'forwards',
 		});
@@ -295,7 +295,7 @@ class Vignette {
 		const keyframes = [
 			{ transform: `translateX(${x - emptySpaceAtFrontOfQueue}px) translateY(0px) scale(1)` },
 		];
-		const animation = this.el.animate(keyframes, {
+		const animation = utils.animate(this.el, keyframes, {
 			duration: CONST.animDurationMS,
 			fill: 'forwards',
 		});
@@ -318,7 +318,7 @@ class Vignette {
 			keyframes.push(restingKeyframe);
 		}
 
-		const animation = this.el.animate(keyframes, { duration: BOUNCE_MS });
+		const animation = utils.animate(this.el, keyframes, { duration: BOUNCE_MS });
 		animation.commitStyles();
 		return animation;
 	}
@@ -350,6 +350,7 @@ class CreatureVignette extends Vignette {
 	creature;
 	isActiveCreature: boolean;
 	turnNumberIsCurrentTurn: boolean;
+	isXray = false;
 
 	constructor(creature, turnNumber, isActiveCreature = false, turnNumberIsCurrentTurn = true) {
 		super();
@@ -401,6 +402,12 @@ class CreatureVignette extends Vignette {
 			cl.remove('active');
 		}
 
+		if (this.isXray) {
+			cl.add('xray');
+		} else {
+			cl.remove('xray');
+		}
+
 		if (this.creature.temp) {
 			cl.add('unmaterialized');
 			cl.remove('materialized');
@@ -415,11 +422,14 @@ class CreatureVignette extends Vignette {
 
 		this.el.style.zIndex = this.creature.temp ? '1000' : this.queuePosition + 1 + '';
 
-		const stats = this.creature.fatigueText;
+		const stats = this.isXray ? this.creature.name : this.creature.fatigueText;
 		const statsClasses = ['stats', utils.toClassName(stats)].join(' ');
 		const statsEl = this.el.querySelector('div.stats');
 		statsEl.className = statsClasses;
 		statsEl.textContent = stats;
+		if (stats.length > 9) {
+			statsEl.textContent = stats.substring(0, 8) + '...';
+		}
 	}
 
 	animateInsert(queuePosition, x) {
@@ -436,7 +446,7 @@ class CreatureVignette extends Vignette {
 			},
 			{ transform: `translateX(${x}px) translateY(0px) scale(${scale})` },
 		];
-		const animation = this.el.animate(keyframes, {
+		const animation = utils.animate(this.el, keyframes, {
 			duration: CONST.animDurationMS,
 			fill: 'forwards',
 		});
@@ -447,7 +457,7 @@ class CreatureVignette extends Vignette {
 	animateUpdate(queuePosition, x) {
 		const scale = this.isActiveCreature ? 1.25 : 1.0;
 		const keyframes = [{ transform: `translateX(${x}px) translateY(0px) scale(${scale})` }];
-		const animation = this.el.animate(keyframes, {
+		const animation = utils.animate(this.el, keyframes, {
 			duration: CONST.animDurationMS,
 			fill: 'forwards',
 		});
@@ -459,7 +469,7 @@ class CreatureVignette extends Vignette {
 		this.el.style.zIndex = '-1';
 		const [x_, y, scale] = this.isActiveCreature ? [-this.getWidth(), 0, 1.25] : [x, -100, 1];
 		const keyframes = [{ transform: `translateX(${x_}px) translateY(${y}px) scale(${scale})` }];
-		const animation = this.el.animate(keyframes, {
+		const animation = utils.animate(this.el, keyframes, {
 			duration: CONST.animDurationMS,
 			fill: 'forwards',
 		});
@@ -474,7 +484,7 @@ class CreatureVignette extends Vignette {
 				transform: `translateX(${x - emptySpaceAtFrontOfQueue}px) translateY(0px) scale(${scale})`,
 			},
 		];
-		const animation = this.el.animate(keyframes, {
+		const animation = utils.animate(this.el, keyframes, {
 			duration: CONST.animDurationMS,
 			fill: 'forwards',
 		});
@@ -483,10 +493,10 @@ class CreatureVignette extends Vignette {
 	}
 
 	xray(creatureId: number) {
-		if (creatureId === this.creature.id) {
-			this.el.classList.add('xray');
-		} else {
-			this.el.classList.remove('xray');
+		const oldIsXray = this.isXray;
+		this.isXray = creatureId === this.creature.id;
+		if (oldIsXray !== this.isXray) {
+			this.updateDOM();
 		}
 	}
 
@@ -587,7 +597,7 @@ class DelayMarkerVignette extends Vignette {
 			},
 			{ transform: `translateX(${x}px) translateY(0px) scale(1)` },
 		];
-		const animation = this.el.animate(keyframes, {
+		const animation = utils.animate(this.el, keyframes, {
 			duration: CONST.animDurationMS * 2,
 			fill: 'forwards',
 		});
@@ -597,6 +607,21 @@ class DelayMarkerVignette extends Vignette {
 }
 
 const utils = {
+	animate: (el: HTMLElement, keyframes, options) => {
+		if (el.animate) {
+			return el.animate(keyframes, options);
+		} else {
+			return {
+				commitStyles: () => {
+					// pass
+				},
+				onfinish: (fn) => {
+					fn();
+				},
+			};
+		}
+	},
+
 	trueIfFirstElseFalse: () => {
 		let v = true;
 		return () => {


### PR DESCRIPTION
This shows the creature name in the vignette when the vignette or the creature is moused over.

Note that it shows the *truncated* names in some cases:

![Screenshot 2023-04-13 at 00 26 49 copy](https://user-images.githubusercontent.com/20469369/231601294-bce23d6e-ffbb-4480-a4ac-a0e9a3e98186.jpg)

Many of the creature's names are too long to fit in the text box at the present box size/text size. Truncating the names seemed preferable to changing the text styles for the names.

Feedback welcome.