### PR TITLE
Summoned creature reuses unmaterialized creature.id  #2163

### DIFF
--- a/src/__tests__/creature.ts
+++ b/src/__tests__/creature.ts
@@ -1,0 +1,149 @@
+import { Creature } from '../creature';
+import { jest, expect, describe, test, beforeEach } from '@jest/globals';
+import { Player } from '../player';
+
+describe('Creature', () => {
+	describe('creature.id', () => {
+		let game;
+		beforeEach(() => (game = getGameMock()));
+
+		test('"materialized" creatures are automatically assigned separate ids', () => {
+			const creature0 = new Creature(getCreatureObjMock(), game);
+			const creature1 = new Creature(getCreatureObjMock(), game);
+			expect(creature0.id).not.toBe(creature1.id);
+			expect(game.creatures.length).toBe(2);
+		});
+
+		test('a "materialized" (not temp) creature will reuse an existing, matching "unmaterialized" creature id', () => {
+			const obj = getCreatureObjMock();
+			obj.temp = true;
+			const creatureTemp = new Creature(obj, game);
+			obj.temp = false;
+			const creatureNotTemp = new Creature(obj, game);
+			expect(creatureTemp.id).toBe(creatureNotTemp.id);
+		});
+	});
+
+	describe('game.creatures', () => {
+		test('a "materialized" creature will replace a matching "unmaterialized" creature in game.creatures', () => {
+			const game = getGameMock();
+			const obj = getCreatureObjMock();
+			obj.temp = true;
+			const creatureTemp = new Creature(obj, game);
+			expect(game.creatures.length).toBe(1);
+			expect(game.creatures.filter((c) => c)[0]).toStrictEqual(creatureTemp);
+
+			obj.temp = false;
+			const creatureNotTemp = new Creature(obj, game);
+			expect(game.creatures.length).toBe(1);
+			expect(game.creatures.filter((c) => c)[0]).not.toStrictEqual(creatureTemp);
+			expect(game.creatures.filter((c) => c)[0]).toStrictEqual(creatureNotTemp);
+		});
+	});
+});
+
+jest.mock('../ability');
+jest.mock('../assets', () => ({ children: [] }));
+jest.mock('../assetLoader');
+jest.mock('../utility/hex', () => {
+	return {
+		default: jest.fn(),
+	};
+});
+
+const getRandomString = (length: number) => {
+	return Array(length + 1)
+		.join((Math.random().toString(36) + '00000000000000000').slice(2, 18))
+		.slice(0, length);
+};
+
+const getCreatureObjMock = () => {
+	return {
+		stats: {
+			health: 10,
+		},
+		temp: false,
+		team: 0,
+		type: getRandomString(5),
+		display: {
+			'offset-x': true,
+		},
+		size: 2,
+		x: 4,
+		y: 4,
+	};
+};
+
+const getHexesMock = () => {
+	const arr = [];
+	for (let y = 0; y < 100; y++) {
+		const row = [];
+		for (let x = 0; x < 100; x++) {
+			row.push({
+				displayPos: { x, y },
+				creature: 0,
+			});
+		}
+		arr.push(row);
+	}
+	return arr;
+};
+
+import data from '../data/units.json';
+
+const getGameMock = () => {
+	let self = {
+		creatures: [],
+		players: [],
+		queue: {
+			addByInitiative: jest.fn(),
+			removeTempCreature: jest.fn(),
+		},
+		updateQueueDisplay: jest.fn(),
+		grid: {
+			orderCreatureZ: jest.fn(),
+			hexes: getHexesMock(),
+		},
+		Phaser: getPhaserMock(),
+		retrieveCreatureStats: (type: number) => {
+			for (const d of data) {
+				if (d.id === type) {
+					return d;
+				}
+			}
+			return {};
+		},
+		abilities: jest.fn(),
+		signals: {
+			metaPowers: {
+				add: jest.fn(),
+			},
+		},
+		plasma_amount: 10,
+	};
+	self.players = [new Player(0, self), new Player(1, self)];
+	return self;
+};
+
+const getPhaserMock = () => {
+	let self: any = {};
+	self.tween = () => self;
+	self.to = () => self;
+	self.start = () => self;
+	self.text = () => self;
+	self.anchor = self;
+	self.setTo = () => self;
+	self.group = () => self;
+	self.create = () => self;
+	self.sprite = self;
+	self.scale = self;
+	self.add = () => self;
+	self.texture = {
+		width: 10,
+		height: 10,
+	};
+
+	return {
+		add: self,
+	};
+};

--- a/src/abilities/Dark-Priest.js
+++ b/src/abilities/Dark-Priest.js
@@ -344,10 +344,6 @@ export default (G) => {
 				ability.end(false, true);
 
 				ability.creature.player.summon(creature, pos);
-				let crea = G.creatures.pop();
-				crea.id--;
-				G.creatures[crea.id] = crea;
-				G.creatureIdCounter--;
 				ability.creature.queryMove();
 			},
 		},

--- a/src/creature.js
+++ b/src/creature.js
@@ -54,7 +54,7 @@ export class Creature {
 		// Engine
 		this.game = game;
 		this.name = obj.name;
-		this.id = game.creatureIdCounter++;
+		this.id = game.creatures.length;
 		this.x = obj.x - 0;
 		this.y = obj.y - 0;
 		this.pos = {
@@ -257,7 +257,24 @@ export class Creature {
 		// Hide it
 		this.healthIndicatorGroup.alpha = 0;
 
-		// Adding Himself to creature arrays and queue
+		if (!this.temp) {
+			for (const other of game.creatures.filter((c) => c)) {
+				if (other.type === this.type && other.team === this.team && other.temp) {
+					/**
+					 *  NOTE:
+					 * `this` is the summoned version of `other`
+					 *
+					 * `this` is a summoned Creature: temp == false.
+					 * `other` is an "unmaterialized" Creature: temp == true.
+					 *
+					 * Use the "unmaterialized" creature's id so that `this` will replace
+					 * `other` in `game.creatures`.
+					 */
+					this.id = other.id;
+				}
+			}
+		}
+
 		game.creatures[this.id] = this;
 
 		this.delayable = true;
@@ -510,7 +527,6 @@ export class Creature {
 		// Clean up temporary creature if a summon was cancelled.
 		if (game.creatures[game.creatures.length - 1].temp) {
 			game.creatures.pop();
-			game.creatureIdCounter--;
 		}
 
 		let remainingMove = this.remainingMove;

--- a/src/game.js
+++ b/src/game.js
@@ -52,7 +52,6 @@ export default class Game {
 	 * // Normal attributes
 	 * playerMode :		Integer :	Number of players in the game
 	 * activeCreature :	Creature :	Current active creature object reference
-	 * creatureIdCounter :		Integer :	Creature ID counter used for creature creation
 	 * creatureData :		Array :		Array containing all data for the creatures
 	 *
 	 */
@@ -70,7 +69,6 @@ export default class Game {
 		this.preventSetup = false;
 		this.animations = new Animations(this);
 		this.queue = new CreatureQueue(this);
-		this.creatureIdCounter = 1;
 		this.creatureData = [];
 		this.pause = false;
 		this.gameState = 'initialized';
@@ -455,7 +453,6 @@ export default class Game {
 		this.trapId = 0;
 		this.effectId = 0;
 		this.dropId = 0;
-		this.creatureIdCounter = 1;
 
 		this.grid = new HexGrid({}, this); // Create Hexgrid
 
@@ -1542,7 +1539,6 @@ export default class Game {
 		this.preventSetup = false;
 		this.animations = new Animations(this);
 		this.queue = new CreatureQueue(this);
-		this.creatureIdCounter = 1;
 		this.creatureData = [];
 		this.pause = false;
 		this.gameState = 'initialized';


### PR DESCRIPTION
This addresses creature ids not remaining consistent between unmaterialized and materialized (summoned) creatures. With this change a summoned creature will take the same id as the unmaterialized creature it replaces.

Note that creature ids *can* still be reused by *different* creatures, which is perhaps not ideal. This remains necessary because ids must be contiguous in `game.creatures`. Other code within the codebase depends on that invariant currently.

This removes `game.creatureIdCounter` as discussed here:

https://github.com/FreezingMoon/AncientBeast/issues/2163#issuecomment-1507387817

----

## Details

Currently, there's a counter that increments when a new Creature is created:

https://github.com/FreezingMoon/AncientBeast/blob/1056917fd181f2ab3e3369b42983eda81b0983b0/src/game.js#L73

When a creature is created, it gets an id based on the counter ...

https://github.com/FreezingMoon/AncientBeast/blob/1056917fd181f2ab3e3369b42983eda81b0983b0/src/creature.js#L57

... and then inserts itself into `game.creatures` at `game.creatures[creature.id]` ...

https://github.com/FreezingMoon/AncientBeast/blob/1056917fd181f2ab3e3369b42983eda81b0983b0/src/creature.js#L261

Some effort has to be made to keep that counter consistent. Here's a priest decrementing the counter when a creature is summoned – because summoning a creature will remove a temp creature. (If the counter isn't reset "by hand" there will be a hole in `game.creatures` when the temp creature is removed.)

https://github.com/FreezingMoon/AncientBeast/blob/1056917fd181f2ab3e3369b42983eda81b0983b0/src/abilities/Dark-Priest.js#L350

It seems that the counter is unneeded bookkeeping. The creature id could simply be the length of `game.creatures` at the time that the Creature constructor is called; that will keep the `game.creatures[creature.id] === creature` invariant, and without needing a counter.

When the Creature constructor is called, if it's a full creature, it checks to see if there's a matching temp creature. A "match" for a full creature is a temp creature in `game.creatures` that's on the same team and of the same type. If such a temp creature exists, the full creature takes its id and removes the temp creature from `game.creatures` by inserting itself at `game.creatures[id]`.

It seems like it'd be simpler to do away with the `game.creatures[creature.id] === creature` invariant, but this incremental change keeps the current structure while making the code simpler.
