### PR TITLE
TypeScript fix: Direction.None = -1

### DIFF
--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -7,6 +7,7 @@ import Phaser from 'phaser-ce';
 import { Drop } from '../drops';
 
 export enum Direction {
+	None = -1,
 	UpRight = 0,
 	Right = 1,
 	DownRight = 2,
@@ -124,7 +125,7 @@ export class Hex {
 		this.blocked = false;
 		this.creature = undefined;
 		this.reachable = true;
-		this.direction = -1; // Used for queryDirection
+		this.direction = Direction.None; // Used for queryDirection
 		this.drop = undefined; // Drop items
 		this.displayClasses = '';
 		this.overlayClasses = '';

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -273,7 +273,7 @@ export class HexGrid {
 
 		// Clean Direction
 		this.forEachHex((hex) => {
-			hex.direction = -1;
+			hex.direction = Direction.None;
 		});
 
 		options.choices = [];


### PR DESCRIPTION
This is a small cleanup PR.

`Direction` in `src/utility/hex.ts` didn't include a `None` direction. Sometimes `-1` was assigned to indicate "no direction", but `-1` wasn't a value in the `Direction` enum, this caused a TypeScript error.

This PR adds a `Direction.None = -1` to the enum and replaces the `-1` errors with `Direction.None`.