### PR TITLE
Fix Don't scroll page

### DIFF
--- a/src/script.ts
+++ b/src/script.ts
@@ -59,12 +59,19 @@ $j(() => {
 	function disableScrollAndArrowKeys(element: JQuery) {
 		element.attr('tabindex', '0'); // Set tabindex to make element focusable
 
-		element.on('wheel', (e: JQuery.Event) => {
-			e.preventDefault();
-		});
+		element.on('mouseover', () => {
+			// Add event listener for mouse over game area
+			element.focus(); // Focus the element
+			element.on('wheel', (e: JQuery.Event) => {
+				e.preventDefault();
+			});
+			element.on('keydown', (e: JQuery.Event) => {
+				e.preventDefault();
+			});
 
-		element.on('keydown', (e: JQuery.Event) => {
-			e.preventDefault();
+			element.on('mouseout', () => {
+				element.blur(); // Remove focus from the element when mouse leaves game area
+			});
 		});
 	}
 

--- a/src/script.ts
+++ b/src/script.ts
@@ -55,19 +55,21 @@ $j(() => {
 	window.addEventListener('blur', G.onBlur.bind(G), false);
 	window.addEventListener('focus', G.onFocus.bind(G), false);
 
-	// Add event listener to disable scroll in pre-game
-	let preMatch = $j('#pre-match');
-	preMatch.attr('tabindex', '0'); // set tabindex to make element focusable
+	// Function to disable scroll and arrow keys
+	function disableScrollAndArrowKeys(element: JQuery) {
+		element.attr('tabindex', '0'); // set tabindex to make element focusable
 
-	// Disable scroll
-	preMatch.on('wheel', (e) => {
-		e.preventDefault();
-	});
+		element.on('wheel', (e: JQuery.Event) => {
+			e.preventDefault();
+		});
 
-	// Disable up/down keys
-	preMatch.on('keydown', (e) => {
-		e.preventDefault();
-	});
+		element.on('keydown', (e: JQuery.Event) => {
+			e.preventDefault();
+		});
+	}
+
+	disableScrollAndArrowKeys($j('#pre-match')); // Disable scroll and arrow keys for preMatch element
+	disableScrollAndArrowKeys($j('#loader')); // Disable scroll and arrow keys for loader element
 
 	// Add listener for Fullscreen API
 	let fullscreen = new Fullscreen($j('#fullscreen'));

--- a/src/script.ts
+++ b/src/script.ts
@@ -52,9 +52,22 @@ $j(() => {
 	locationSelector.eq(randomLocationIndex).prop('checked', true).trigger('click');
 
 	// Disable initial game setup until browser tab has focus
-
 	window.addEventListener('blur', G.onBlur.bind(G), false);
 	window.addEventListener('focus', G.onFocus.bind(G), false);
+
+	// Add event listener to disable scroll in pre-game
+	let preMatch = $j('#pre-match');
+	preMatch.attr('tabindex', '0'); // set tabindex to make element focusable
+
+	// Disable scroll
+	preMatch.on('wheel', (e) => {
+		e.preventDefault();
+	});
+
+	// Disable up/down keys
+	preMatch.on('keydown', (e) => {
+		e.preventDefault();
+	});
 
 	// Add listener for Fullscreen API
 	let fullscreen = new Fullscreen($j('#fullscreen'));

--- a/src/script.ts
+++ b/src/script.ts
@@ -57,7 +57,7 @@ $j(() => {
 
 	// Function to disable scroll and arrow keys
 	function disableScrollAndArrowKeys(element: JQuery) {
-		element.attr('tabindex', '0'); // set tabindex to make element focusable
+		element.attr('tabindex', '0'); // Set tabindex to make element focusable
 
 		element.on('wheel', (e: JQuery.Event) => {
 			e.preventDefault();


### PR DESCRIPTION
This fixes issue #741

Description:
Add event listener to disable scrolling and arrow key events in pre-match screen.

Previously, users could scroll and use the up/down arrow keys in the pre-match screen.
This pull request adds an event listener to disable scrolling and arrow key events in the pre-match screen.

The `preMatch` element is given a `tabindex` attribute to make it focusable, and the `wheel` and `keydown` events are both handled to prevent default browser behavior. 

My wallet address is: 0x3521D12DAe3C0033D509a790522C9e5E7132e056