### PR TITLE
Bugfix: depth sorting, fixes #2220

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -249,7 +249,7 @@ export class Player {
 		this.hasLost = true;
 
 		// Remove all player creatures from queues
-		for (let i = 1; i < count; i++) {
+		for (let i = 0; i < count; i++) {
 			creature = game.creatures[i];
 
 			if (creature.player.id == this.id) {

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -1372,7 +1372,7 @@ export class HexGrid {
 		const creatures = this.game.creatures;
 
 		for (let y = 0, leny = this.hexes.length; y < leny; y++) {
-			for (let i = 1, len = creatures.length; i < len; i++) {
+			for (let i = 0, len = creatures.length; i < len; i++) {
 				if (creatures[i].y == y) {
 					this.creatureGroup.remove(creatures[i].grp);
 					this.creatureGroup.addAt(creatures[i].grp, index++);


### PR DESCRIPTION
player and hexgrid were/are depending on the implementation of `game.creatures` to start at 1, so the "zero-th" creature wasn't included in the depth sort when the creature indexing was changed.

Now they depend on it to start a 0.

It's probably not a good idea to have them dependent on a change in`game.creature`'s implementation, but that's outside of the scope of this fix.