### PR TITLE
Fix weird useless line in pre-match screen

### DIFF
--- a/src/style/pre-match.less
+++ b/src/style/pre-match.less
@@ -90,6 +90,10 @@
 	}
 }
 
+div#pre-match:focus {
+	outline: none;
+}
+
 body {
 	background: black url('~assets/interface/skulls.jpg') repeat;
 	margin: 0;


### PR DESCRIPTION
This fixes issue #2216

Description:
This pull request fixes an issue where a line would appear when hovering over the "pre-match" div. The issue was caused by the div being outlined when focused on, which caused the weird line issue. To fix this, I added a style rule to set the outline to none when the div is focused on, using the :focus pseudo-class selector in CSS. This should prevent the div from being outlined when focused on, and thus fix the issue with the weird line.

My wallet address is: 0x3521D12DAe3C0033D509a790522C9e5E7132e056