### PR TITLE
Package.json: only report linter errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
 		"start:dev": "cross-env NODE_ENV=development webpack-dev-server",
 		"assetLister": "node ./assetLister.js",
 		"lint": "eslint \"src/**/*.{js,ts}\"",
+		"lint-error": "eslint --quiet \"src/**/*.{js,ts}\"",
 		"lint-fix": "eslint --fix \"src/**/*.{js,ts}\"",
 		"eslint-check": "eslint --print-config .eslintrc.json | eslint-config-prettier-check",
 		"test": "npm run lint && npm run build && jest",

--- a/src/ability.js
+++ b/src/ability.js
@@ -151,7 +151,7 @@ export class Ability {
 		if (!this._disableCooldowns) {
 			this.setUsed(true); // Should always be here
 		}
-		game.UI.updateInfos(); // Just in case
+		game.signals.creature.dispatch('abilityend', { creature: this.creature });
 		game.UI.btnDelay.changeState('disabled');
 		game.activeCreature.delayable = false;
 		game.UI.selectAbility(-1);

--- a/src/game.js
+++ b/src/game.js
@@ -186,7 +186,7 @@ export default class Game {
 			oncePerDamageChain: /\boncePerDamageChain\b/,
 		};
 
-		const signalChannels = ['ui', 'metaPowers', 'creature'];
+		const signalChannels = ['ui', 'metaPowers', 'creature', 'hex'];
 		this.signals = this.setupSignalChannels(signalChannels);
 	}
 
@@ -336,6 +336,19 @@ export default class Game {
 
 		// Get JSON files
 		this.dataLoaded(dataJson);
+	}
+
+	get activePlayer() {
+		if (this.multiplayer) {
+			if (this.players && this.match && this.match.userTurn) {
+				return this.players[this.match.userTurn];
+			}
+			return undefined;
+		}
+		if (this.activeCreature && this.activeCreature.player) {
+			return this.activeCreature.player;
+		}
+		return undefined;
 	}
 
 	startLoading() {
@@ -767,6 +780,7 @@ export default class Game {
 				// Updates UI to match new creature
 				this.UI.updateActivebox();
 				this.updateQueueDisplay();
+				this.signals.creature.dispatch('activate', { creature: this.activeCreature });
 				if (this.multiplayer && this.playersReady) {
 					this.gameplay.updateTurn();
 				} else {

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -739,7 +739,7 @@
 
 				<div id="rightpanel">
 					<div style="position:relative">
-					<div id="playerbutton" class="togglescore vignette active frame button">
+					<div id="playerbutton" class="quickinfowrapper togglescore vignette active frame button">
 						<div class="frame"></div>
 						<div id="playerinfo">
 							<p class="name"></p>

--- a/src/script.ts
+++ b/src/script.ts
@@ -372,10 +372,10 @@ export function getGameConfig() {
 		turnTimePool: parseInt($j('input[name="turnTime"]:checked').val() as string, 10),
 		timePool: parseInt($j('input[name="timePool"]:checked').val() as string, 10) * 60,
 		background_image: $j('input[name="combatLocation"]:checked').val(),
+		combatLocation: $j('input[name="combatLocation"]:checked').val(),
 		fullscreenMode: $j('#fullscreen').hasClass('fullscreenMode'),
 	};
 	const config = G.gamelog.gameConfig || defaultConfig;
-
 	return config;
 }
 

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -472,15 +472,11 @@
 
 #playerbutton {
 	cursor: pointer;
-	background: rgba(0, 0, 0, 0.55);
 	position: relative;
 	right: 0;
 	z-index: 2;
 	transition: opacity 0.5s ease;
-}
-
-#playerbutton div {
-	background-color: rgba(0, 0, 0, 0.55);
+	background-image: none;
 }
 
 #playerbutton .playerinfo,
@@ -496,6 +492,11 @@
 	text-align: right;
 	text-shadow: 1px 1px 0 #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
 	top: 0;
+	background-color: rgba(0, 0, 0, 0.55);
+}
+
+#playerbutton .hexinfo {
+	text-align: center;
 }
 
 #playerbutton .vignette {

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -438,35 +438,92 @@
 	background-image: url('~assets/icons/exit.svg');
 }
 
+.p0.player-text.bright {
+	color: #f55;
+}
+
+.p1.player-text.bright {
+	color: #88f;
+}
+
+.p2.player-text.bright {
+	color: #fa5;
+}
+
+.p3.player-text.bright {
+	color: #5f5;
+}
+
+.p0.player-text {
+	color: rgba(255, 0, 0, 1);
+}
+
+.p1.player-text {
+	color: rgba(0, 0, 255, 1);
+}
+
+.p2.player-text {
+	color: rgba(255, 172, 0, 1);
+}
+
+.p3.player-text {
+	color: rgba(0, 255, 0, 1);
+}
+
 #playerbutton {
 	cursor: pointer;
 	background: rgba(0, 0, 0, 0.55);
 	position: relative;
 	right: 0;
 	z-index: 2;
+	transition: opacity 0.5s ease;
 }
 
-#playerinfo {
+#playerbutton div {
+	background-color: rgba(0, 0, 0, 0.55);
+}
+
+#playerbutton .playerinfo,
+#playerbutton .hexinfo {
 	color: white;
 	display: block;
 	font-size: 12px;
 	font-weight: bold;
 	height: 100px;
-	margin: 1px -5px;
-	position: fixed;
+	width: 90px;
+	margin: 1px 0px;
+	padding: 0 5px;
 	text-align: right;
 	text-shadow: 1px 1px 0 #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
 	top: 0;
-	width: 100px;
-	z-index: 2;
 }
 
-#playerinfo p {
+#playerbutton .vignette {
+	height: 100px;
+	width: 100px;
+	padding: 0;
+	margin: 0;
+}
+
+.playerinfo p,
+.hexinfo p {
 	margin: 4px;
 }
 
-#playerinfo .name {
+.playerinfo .name,
+.hexinfo .name {
 	font-size: 15px;
+}
+
+.hexinfo .name {
+	padding-top: 18px;
+	padding-bottom: 2px;
+	margin: inherit 4px 0px 12px;
+	border-bottom: 1px solid #555;
+}
+
+.hexinfo .vignette.hex .frame {
+	background-image: url('~assets/interface/frame.png');
 }
 
 .alert {
@@ -890,9 +947,7 @@ div.section.info {
 	background-color: darkturquoise;
 }
 
-#playeravatar.vignette,
-#playerbutton.vignette,
-#playerbutton.vignette .frame {
+#playeravatar.vignette {
 	height: 100px;
 	width: 100px;
 }
@@ -953,6 +1008,11 @@ div.section.info {
 
 .vignette.delaymarker .frame {
 	background-image: url('~assets/interface/frame.png'), url('~assets/icons/delay.svg');
+	background-color: rgba(0, 0, 0, 0.85);
+}
+
+.vignette.hex .frame {
+	background-image: url('~assets/interface/frame.png');
 	background-color: rgba(0, 0, 0, 0.85);
 }
 

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -2161,34 +2161,30 @@ export class UI {
 		const quickInfo = new QuickInfo(quickInfoDomElement);
 
 		/**
-		 * NOTE: throttling here because we want to
+		 * NOTE: Throttling here because we want to
 		 * skip a hex 'mouse out' if there's a
-		 * 'mouse over' soon after.
+		 * 'mouse enter' soon after. We don't want a
+		 * transition between 2 different hexes that
+		 * have the same contents.
 		 */
 		const throttledSet = throttle(
-			(str, isBase) => {
-				if (isBase) {
-					quickInfo.setBase(str);
-				} else {
-					quickInfo.setOverlay(str);
-				}
+			(str) => {
+				quickInfo.set(str);
 			},
 			50,
 			{ leading: false },
 		);
 
-		const [BASE, OVERLAY] = [true, false];
-
 		const showCurrentPlayer = () => {
-			throttledSet(playerFormatter(ui.game.activePlayer), BASE);
+			throttledSet(playerFormatter(ui.game.activePlayer));
 		};
 
 		const showHex = (hex) => {
-			throttledSet(hexFormatter(hex), OVERLAY);
+			throttledSet(hexFormatter(hex));
 		};
 
 		ui.game.signals.creature.add((message) => {
-			if (['abilityend', 'activate'].indexOf(message) !== -1) {
+			if (['abilityend', 'activate'].includes(message)) {
 				showCurrentPlayer();
 			}
 		});
@@ -2201,7 +2197,7 @@ export class UI {
 					'toggleScore',
 					'toggleMetaPowers',
 					'closeInterfaceScreens',
-				].indexOf(message) !== -1
+				].includes(message)
 			) {
 				showCurrentPlayer();
 			}

--- a/src/ui/quickinfo.ts
+++ b/src/ui/quickinfo.ts
@@ -1,57 +1,30 @@
 const CONST = {
-	zIndexBase: '1',
-	zIndexOverlay: '2',
-	zIndexOverlayRemoval: '3',
 	animationDuration: 250,
 	animationEasing: 'ease-in-out',
 };
 
 export class QuickInfo {
 	private el: HTMLElement;
-	private baseEl: HTMLElement;
-	private baseHash = '';
-
-	private overlayEl: HTMLElement;
-	private overlayHash = '';
+	private vignetteEl: HTMLElement;
+	private vignetteHash: string;
 
 	constructor(quickInfoElement: HTMLElement) {
 		this.el = quickInfoElement;
 		this.el.innerHTML = '';
 
-		this.baseEl = document.createElement('div');
-		this.baseEl.style.zIndex = CONST.zIndexBase;
-		this.el.appendChild(this.baseEl);
-
-		this.overlayEl = document.createElement('div');
-		this.overlayEl.style.zIndex = CONST.zIndexOverlay;
-		this.el.appendChild(this.overlayEl);
+		this.vignetteEl = document.createElement('div');
+		this.el.appendChild(this.vignetteEl);
 	}
 
-	setBase(str: string) {
-		this.clearOverlay();
-		if (this.baseHash !== str) {
-			this.baseHash = str;
+	set(str: string) {
+		if (this.vignetteHash !== str) {
+			this.clear();
+			this.vignetteHash = str;
 
 			const div = document.createElement('div');
 			div.innerHTML = str;
-			this.baseEl.innerHTML = '';
-			this.baseEl.appendChild(div);
-			div.animate([{ opacity: 0 }, { opacity: 1 }], {
-				easing: CONST.animationEasing,
-				duration: CONST.animationDuration,
-			});
-		}
-	}
-
-	setOverlay(str: string) {
-		if (this.overlayHash !== str) {
-			this.clearOverlay();
-			this.overlayHash = str;
-
-			const div = document.createElement('div');
-			div.innerHTML = str;
-			this.overlayEl.innerHTML = '';
-			this.overlayEl.appendChild(div);
+			this.vignetteEl.innerHTML = '';
+			this.vignetteEl.appendChild(div);
 			div.style.position = 'relative';
 			div.animate([{ right: '-100px' }, { right: '0px' }], {
 				easing: CONST.animationEasing,
@@ -60,15 +33,14 @@ export class QuickInfo {
 		}
 	}
 
-	private clearOverlay() {
-		if (this.overlayHash !== '') {
-			this.overlayHash = '';
+	private clear() {
+		if (this.vignetteHash !== '') {
+			this.vignetteHash = '';
 
 			const div = document.createElement('div');
-			div.append(this.overlayEl.firstChild);
-			this.overlayEl.innerHTML = '';
+			div.append(this.vignetteEl.firstChild);
+			this.vignetteEl.innerHTML = '';
 
-			div.style.zIndex = CONST.zIndexOverlayRemoval;
 			div.style.position = 'relative';
 			this.el.appendChild(div);
 			div.animate(

--- a/src/ui/quickinfo.ts
+++ b/src/ui/quickinfo.ts
@@ -1,0 +1,91 @@
+const CONST = {
+	zIndexBase: '1',
+	zIndexOverlay: '2',
+	zIndexOverlayRemoval: '3',
+	animationDuration: 250,
+	animationEasing: 'ease-in-out',
+};
+
+export class QuickInfo {
+	private el: HTMLElement;
+	private baseEl: HTMLElement;
+	private baseHash = '';
+
+	private overlayEl: HTMLElement;
+	private overlayHash = '';
+
+	constructor(quickInfoElement: HTMLElement) {
+		this.el = quickInfoElement;
+		this.el.innerHTML = '';
+
+		this.baseEl = document.createElement('div');
+		this.baseEl.style.zIndex = CONST.zIndexBase;
+		this.el.appendChild(this.baseEl);
+
+		this.overlayEl = document.createElement('div');
+		this.overlayEl.style.zIndex = CONST.zIndexOverlay;
+		this.el.appendChild(this.overlayEl);
+	}
+
+	setBase(str: string) {
+		this.clearOverlay();
+		if (this.baseHash !== str) {
+			this.baseHash = str;
+
+			const div = document.createElement('div');
+			div.innerHTML = str;
+			this.baseEl.innerHTML = '';
+			this.baseEl.appendChild(div);
+			div.animate([{ opacity: 0 }, { opacity: 1 }], {
+				easing: CONST.animationEasing,
+				duration: CONST.animationDuration,
+			});
+		}
+	}
+
+	setOverlay(str: string) {
+		if (this.overlayHash !== str) {
+			this.clearOverlay();
+			this.overlayHash = str;
+
+			const div = document.createElement('div');
+			div.innerHTML = str;
+			this.overlayEl.innerHTML = '';
+			this.overlayEl.appendChild(div);
+			div.style.position = 'relative';
+			div.animate([{ right: '-100px' }, { right: '0px' }], {
+				easing: CONST.animationEasing,
+				duration: CONST.animationDuration,
+			});
+		}
+	}
+
+	private clearOverlay() {
+		if (this.overlayHash !== '') {
+			this.overlayHash = '';
+
+			const div = document.createElement('div');
+			div.append(this.overlayEl.firstChild);
+			this.overlayEl.innerHTML = '';
+
+			div.style.zIndex = CONST.zIndexOverlayRemoval;
+			div.style.position = 'relative';
+			this.el.appendChild(div);
+			div.animate(
+				[
+					{ opacity: 1, right: '0px' },
+					{ opacity: 0, right: '50px' },
+					{ opacity: 0, right: '100px' },
+				],
+				{
+					easing: CONST.animationEasing,
+					duration: CONST.animationDuration,
+					fill: 'forwards',
+				},
+			);
+			setTimeout(() => {
+				div.remove();
+			}, CONST.animationDuration);
+		}
+	}
+}

--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -173,7 +173,7 @@ export class Hex {
 				if (game.freezedInput || game.UI.dashopen) {
 					return;
 				}
-
+				game.signals.hex.dispatch('over', { hex: this });
 				grid.selectedHex = this;
 				this.onSelectFn(this);
 			}, this);
@@ -182,6 +182,8 @@ export class Hex {
 				if (game.freezedInput || game.UI.dashopen || !pointer.withinGame) {
 					return;
 				}
+
+				game.signals.hex.dispatch('out', { hex: this });
 
 				grid.clearHexViewAlterations();
 				this.onHoverOffFn(this);

--- a/src/utility/trap.js
+++ b/src/utility/trap.js
@@ -1,4 +1,5 @@
 import * as $j from 'jquery';
+import { capitalize } from './string';
 
 /**
  * Trap Class
@@ -13,10 +14,11 @@ export class Trap {
 	 * y : 			Integer : 	Hex coordinates
 	 *
 	 */
-	constructor(x, y, type, effects, owner, opt, game) {
+	constructor(x, y, type, effects, owner, opt, game, name = '') {
 		this.game = game;
 		this.hex = game.grid.hexes[y][x];
 		this.type = type;
+		this.name = name || capitalize(type.split('-').join(' '));
 		this.effects = effects;
 		this.owner = owner;
 		this.creationTurn = game.turn;


### PR DESCRIPTION
This adds a line to `package.json` to show only linter errors. It's runnable with:

```
npm run lint-error
```

## Rationale

The linter generates >800 warnings on the current codebase, which makes CI-stopping errors difficult to find in the report. Hopefully, this small addition will make that a little easier.