### PR TITLE
Added 'npm run lint-error' to report only linter errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
 		"start:dev": "cross-env NODE_ENV=development webpack-dev-server",
 		"assetLister": "node ./assetLister.js",
 		"lint": "eslint \"src/**/*.{js,ts}\"",
+		"lint-error": "eslint --quiet \"src/**/*.{js,ts}\"",
 		"lint-fix": "eslint --fix \"src/**/*.{js,ts}\"",
 		"eslint-check": "eslint --print-config .eslintrc.json | eslint-config-prettier-check",
 		"test": "npm run lint && npm run build && jest",


### PR DESCRIPTION
This adds a new script to `package.json` to omit warnings and report only errors:

```
npm run lint-error
```

## Rationale

Currently, the linter reports >800 warnings on the current code base, making errors difficult to find in the report. Hopefully this small addition will make errors somewhat easier to find and correct. 