### PR TITLE
Comments explaining debug flags; formatting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,41 @@
-# Game
+# =============================================================================
+# IMPORTANT: 
+# For changes in this file to take effect, restart the server.
+# =============================================================================
+
+# =============================================================================
+# GAME 
+# =============================================================================
 ENABLE_SERVICE_WORKER=false
 
-# Debug
-# If DEBUG_MODE is not set to true, other DEBUG_* settings are false
+# =============================================================================
+# DEBUG
+# =============================================================================
+# The global debug flag
+# IMPORTANT:
+# If DEBUG_MODE is not set to true | yes | 1, 
+# other DEBUG_* settings will be set to false in game.
 DEBUG_MODE=true
+
+# If true, the game does not log gameplay updates to the console
+# Useful for keeping the console clean for your own debugging.
 DEBUG_DISABLE_GAME_STATUS_CONSOLE_LOG=false
+
+# If true, a game with default settings when loaded/reloaded.
+# Saves a button click on the home screen.
 DEBUG_AUTO_START_GAME=false
+
+# If true, music – but not SFX – is disabled by default.
+# Useful if you want to listen to your own audio while running Ancient Beast.
 DEBUG_DISABLE_MUSIC=false
+
+# If true, hotkeys are disabled. Useful if you use browser shortcuts
+# like Ctrl+Alt+C for developer tools, etc.
 DEBUG_DISABLE_HOTKEYS=false
 
-# Server
+# =============================================================================
+# SERVER
+# =============================================================================
 MULTIPLAYER_KEY=mudvayne
 MULTIPLAYER_IP=online.ancientbeast.com
 MULTIPLAYER_PORT=443


### PR DESCRIPTION
This is a cleanup PR adding comments and formatting to `.env.example`, mostly explaining the purpose of the `DEBUG_` flags.