### PR TITLE
Queue shout, closes #2249

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -99,6 +99,7 @@ export default class Game {
 			'sounds/drums',
 			'sounds/upgrade',
 			'sounds/mudbath',
+			'sounds/AncientBeast',
 		];
 		this.inputMethod = 'Mouse';
 

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -2278,10 +2278,10 @@ export class UI {
 			ui.queue.xray(-1);
 		};
 
-		const onTurnEndClick = () => {
+		const onTurnEndClick = throttle(() => {
 			const ancientBeastSound = ui.game.soundLoaded[8];
 			ui.game.soundsys.playSound(ancientBeastSound, ui.game.soundsys.effectsGainNode);
-		};
+		}, 2000);
 
 		const onTurnEndMouseEnter = ifGameNotFrozen(() => {
 			ui.game.grid.showGrid(true);

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -2278,7 +2278,10 @@ export class UI {
 			ui.queue.xray(-1);
 		};
 
-		const onTurnEndClick = () => {};
+		const onTurnEndClick = () => {
+			const ancientBeastSound = ui.game.soundLoaded[8];
+			ui.game.soundsys.playSound(ancientBeastSound, ui.game.soundsys.effectsGainNode);
+		};
 
 		const onTurnEndMouseEnter = ifGameNotFrozen(() => {
 			ui.game.grid.showGrid(true);

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -1260,7 +1260,7 @@ export class HexGrid {
 
 	showCurrentCreatureMovementInOverlay(creature) {
 		//lastQueryOpt is same thing as used in redoQuery
-		this.lastQueryOpt.hexes.forEach((hex) => {
+		this.lastQueryOpt?.hexes?.forEach((hex) => {
 			hex.overlayVisualState('hover h_player' + creature.team);
 		});
 	}


### PR DESCRIPTION
Plays the "Ancient Beast" shout when the "turn end vignette" in the queue is clicked. See #2249

----

This PR also makes the `src/ui/queue.ts`'s events consistent with the rest of the system. Previously the queue emitted DOM events. Much of the game – notably the UI – relies on Phaser signals for events. The queue now accepts a `QueueEventHandlers` object on instantiation.

With the updated instantiation in `interface.js`, the queue is set to emit the following Phaser signals on `game.signals.ui`:

* msg : 'vignettecreatureclick', payload: creature
* msg : 'vignettecreaturemouseenter', payload: creature
* msg : 'vignettecreaturemouseleave', payload: creature
* msg : 'vignettedelayclick', payload: none
* msg : 'vignettedelaymouseenter', payload: none
* msg : 'vignettedelaymouseleave', payload: none
* msg : 'vignetteturnendlick', payload: turnNumber
* msg : 'vignetteturnendmouseenter', payload: turnNumber
* msg : 'vignetteturnendmouseleave', payload: turnNumber
