### PR TITLE
Regression fix, closes #2260

### DIFF
--- a/src/__tests__/creature.ts
+++ b/src/__tests__/creature.ts
@@ -10,6 +10,8 @@ describe('Creature', () => {
 		test('"materialized" creatures are automatically assigned separate ids', () => {
 			const creature0 = new Creature(getCreatureObjMock(), game);
 			const creature1 = new Creature(getCreatureObjMock(), game);
+			expect(creature0).toBeDefined();
+			expect(creature1).toBeDefined();
 			expect(creature0.id).not.toBe(creature1.id);
 			expect(game.creatures.length).toBe(2);
 		});
@@ -47,7 +49,7 @@ jest.mock('../assets', () => ({ children: [] }));
 jest.mock('../assetLoader');
 jest.mock('../utility/hex', () => {
 	return {
-		default: jest.fn(),
+		default: () => {},
 	};
 });
 

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -110,7 +110,7 @@ export class Creature {
 		// Engine
 		this.game = game;
 		this.name = obj.name;
-		this.id = game.creatureIdCounter++;
+		this.id = game.creatures.length;
 		this.x = obj.x - 0;
 		this.y = obj.y - 0;
 		this.pos = {
@@ -313,6 +313,23 @@ export class Creature {
 		// Hide it
 		this.healthIndicatorGroup.alpha = 0;
 
+		if (!this.temp) {
+			for (const other of game.creatures.filter((c) => c)) {
+				if (other.type === this.type && other.team === this.team && other.temp) {
+					/**
+					 *  NOTE:
+					 * `this` is the summoned version of `other`
+					 *
+					 * `this` is a summoned Creature: temp == false.
+					 * `other` is an "unmaterialized" Creature: temp == true.
+					 *
+					 * Use the "unmaterialized" creature's id so that `this` will replace
+					 * `other` in `game.creatures`.
+					 */
+					this.id = other.id;
+				}
+			}
+		}
 		// Adding Himself to creature arrays and queue
 		game.creatures[this.id] = this;
 
@@ -567,7 +584,6 @@ export class Creature {
 		// Clean up temporary creature if a summon was cancelled.
 		if (game.creatures[game.creatures.length - 1].temp) {
 			game.creatures.pop();
-			game.creatureIdCounter--;
 		}
 
 		let remainingMove = this.remainingMove;

--- a/src/game.js
+++ b/src/game.js
@@ -75,7 +75,6 @@ export default class Game {
 		this.pauseTime = 0;
 		this.unitDrops = 0;
 		this.minimumTurnBeforeFleeing = 12;
-		this.creatureIdCounter = 0;
 		this.availableCreatures = [];
 		this.animationQueue = [];
 		this.checkTimeFrequency = 1000;


### PR DESCRIPTION
Some updates to creature.js were lost in the transition from creature.js => creature.ts. 

This PR updates creature.ts to treat id's consistently between the `temp` version of a creature and its materialized counterpart. The update was part of a previous PR that was lost during the TypeScript rewrite of `creature`.