### PR TITLE
showMovementRange(id) -> showMovementRange(creature)

### DIFF
--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -2253,7 +2253,7 @@ export class UI {
 				hex.overlayVisualState('hover h_player' + creature.team);
 			});
 
-			ui.game.grid.showMovementRange(creature.id);
+			ui.game.grid.showMovementRange(creature);
 			ui.queue.xray(creature.id);
 		});
 

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -1242,9 +1242,7 @@ export class HexGrid {
 		});
 	}
 
-	// TODO: Rewrite methods used here to only require the creature as an argument.
-	showMovementRange(id) {
-		const creature = this.game.creatures[id];
+	showMovementRange(creature) {
 		const hexes = this.findCreatureMovementHexes(creature);
 
 		// Block all hexes


### PR DESCRIPTION
This PR removes a small `TODO` from the codebase.

`hexgrid.ts` has a couple functions that take full creatures and one that takes a `creature.id`: `showMovementRange`. `showMovementRange` currently only has one caller and the caller has access to the full creature, so the API was made consistent: now all methods take a full creature.