### PR TITLE
Destroy drop before overwriting reference, fixes #2271

### DIFF
--- a/src/drops.js
+++ b/src/drops.js
@@ -94,7 +94,18 @@ export class Drop {
 			type: 'pickupDrop',
 		});
 
-		let tween = game.Phaser.add
+		this.destroy();
+	}
+
+	destroy() {
+		// TODO: Reaching out to `Hex` in this way is a Demeter violation and
+		// would best be avoided. Slimming down `Hex` is currently underway
+		// however. Remove when no longer necessary.
+		if (this.hex.drop === this) {
+			this.hex.drop = undefined;
+		}
+
+		let tween = this.game.Phaser.add
 			.tween(this.display)
 			.to(
 				{

--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -78,7 +78,7 @@ export class Hex {
 	 */
 	reachable: boolean;
 	direction: Direction;
-	drop: Drop;
+	#drop: Drop;
 	displayClasses: string;
 	overlayClasses: string;
 	width: number;
@@ -214,6 +214,31 @@ export class Hex {
 		this.displayPos.y = this.displayPos.y * 0.75 + 30;
 
 		this.trap = undefined;
+	}
+
+	set drop(d) {
+		if (this.#drop && d !== this.#drop) {
+			/**
+			 * NOTE: Currently, the #drop reference here in Hex
+			 * is the only place that a Drop "lives". If it's
+			 * removed here, there are no other references and it
+			 * becomes inaccessible. Therefore, we'll destroy this.#drop
+			 * if it exists, before setting a new this.#drop.
+			 *
+			 * NOTE: Currently, calling d.destroy() on a Drop
+			 * will make it try to unset the drop value. This
+			 * could lead to infinite recursion. So, unset
+			 * this.#drop before calling destroy().
+			 */
+			const dOld = this.#drop;
+			this.#drop = undefined;
+			dOld.destroy();
+		}
+		this.#drop = d;
+	}
+
+	get drop() {
+		return this.#drop;
 	}
 
 	onSelectFn(arg0: this) {


### PR DESCRIPTION
This fixes the bug report #2271 

## The fix

* Adds a `destroy()` method to `Drops.ts` which removes its sprite.
* When a reference to a `Drop` is about to be overwritten in `Hex`, the existing `Drop`'s `destroy()` method is called.