### PR TITLE
Shout on unit click

### DIFF
--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -106,6 +106,11 @@ export class HexGrid {
 	 */
 	lastClickedHex: Hex;
 
+	/**
+	 * Prevents multiple shouts at the same time when a unit is clicked.
+	 */
+	onShoutCooldown: boolean;
+
 	display: Phaser.Group;
 	gridGroup: Phaser.Group;
 	trapGroup: Phaser.Group;
@@ -174,6 +179,9 @@ export class HexGrid {
 		}
 
 		this.selectedHex = this.hexes[0][0];
+
+		// If true, clicking on a unit won't shout its name.
+		this.onShoutCooldown = false;
 
 		// If true, clicking a monster will instantly kill it.
 		this._executionMode = false;
@@ -875,6 +883,18 @@ export class HexGrid {
 							: game.UI.xrayQueue.bind(game.UI),
 						hex,
 					);
+
+					// Shout unit's name and start a cooldown.
+					if (!this.onShoutCooldown) {
+						this.onShoutCooldown = true;
+						const unitOnClickedHexName = game.retrieveCreatureStats(hex.creature.type).name;
+						game.soundsys.playShout(unitOnClickedHexName);
+						setTimeout(() => {
+							this.onShoutCooldown = false;
+						}, 1200);
+
+					}
+
 				} else {
 					// If nothing
 					o.fnOnCancel(hex, o.args); // ON CANCEL

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -892,7 +892,6 @@ export class HexGrid {
 						setTimeout(() => {
 							this.onShoutCooldown = false;
 						}, 1200);
-
 					}
 
 				} else {


### PR DESCRIPTION
This fixes issue [#2243](https://github.com/FreezingMoon/AncientBeast/issues/2243)

Introduced onShoutCooldown flag, if it's false we can shout the name.
After shouting the name, we set onShoutCooldown to true to prevent multiple shouts, it'll be set to false again (that is, we will be able to shout again) after 1200 milliseconds (found this to be a good cooldown).

My wallet address is: will create one tomorrow.
