### PR TITLE
Show unit name tooltip on click

### DIFF
--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -884,7 +884,6 @@ export class HexGrid {
 						hex,
 					);
 
-
 					// Shout unit's name, show tooltip with unit's name and start a cooldown.
 					if (!this.onShoutCooldown) {
 						this.onShoutCooldown = true;
@@ -896,7 +895,6 @@ export class HexGrid {
 							this.onShoutCooldown = false;
 						}, 1200);
 					}
-
 				} else {
 					// If nothing
 					o.fnOnCancel(hex, o.args); // ON CANCEL

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -884,11 +884,14 @@ export class HexGrid {
 						hex,
 					);
 
-					// Shout unit's name and start a cooldown.
+
+					// Shout unit's name, show tooltip with unit's name and start a cooldown.
 					if (!this.onShoutCooldown) {
 						this.onShoutCooldown = true;
-						const unitOnClickedHexName = game.retrieveCreatureStats(hex.creature.type).name;
+						const unitOnClickedHexName = hex.creature.name;
 						game.soundsys.playShout(unitOnClickedHexName);
+						hex.creature.hint(unitOnClickedHexName, 'creature_name');
+
 						setTimeout(() => {
 							this.onShoutCooldown = false;
 						}, 1200);


### PR DESCRIPTION
Addressing [#2244](https://github.com/FreezingMoon/AncientBeast/issues/2244)

Both the shout and the tooltip display go hand in hand, hence why I put the tooltip display inside the shout logic.
Also I found a simpler way to get the unit's name.