### PR TITLE
Effect.ts: removed noLog

### DIFF
--- a/src/abilities/Gumble.js
+++ b/src/abilities/Gumble.js
@@ -48,7 +48,11 @@ export default (G) => {
 							alterations: alterations,
 							deleteTrigger: '',
 							stackable: false,
-							noLog: noLog,
+							effectFn: () => {
+								if (bonus !== this.lastBonus) {
+									G.log('Effect ' + this.name + ' triggered');
+								}
+							},
 						},
 						G,
 					),

--- a/src/abilities/Impaler.js
+++ b/src/abilities/Impaler.js
@@ -328,7 +328,6 @@ export default (G) => {
 										}
 									},
 									deleteTrigger: 'onEndPhase',
-									noLog: true,
 								},
 								G,
 							),

--- a/src/effect.ts
+++ b/src/effect.ts
@@ -38,9 +38,6 @@ export class Effect {
 	// Refactor to remove.
 	attacker: Creature | undefined = undefined;
 
-	// TODO: Remove this. Use the debug flags in .env.
-	noLog = false;
-
 	/* Constructor(name, owner, target, trigger, optArgs)
 	 *
 	 * name: name of the effect
@@ -86,10 +83,6 @@ export class Effect {
 	activate(arg?: any) {
 		if (!this.requireFn(arg)) {
 			return false;
-		}
-
-		if (!this.noLog) {
-			console.log('Effect ' + this.name + ' triggered');
 		}
 
 		if (arg instanceof Creature) {


### PR DESCRIPTION
This PR removes the `noLog` field from `Effect.ts`. Only two callers use it presently, and one of those had set `noLog` to `true`, which resulted in a no-op.

This is supports #2208 by removing ad hoc logging/debugging from the codebase.

## Alternative to `noLog`

If `Effect` logging is desired, the config object `optArgs` passed to the `Effect` constructor can contain an `effectFn` callback. `effectFn` is called in the same code block where `noLog` was checked and a message was logged.