### PR TITLE
show quick info box when hoovering the unit queue

### DIFF
--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -2223,6 +2223,22 @@ export class UI {
 		 */
 		const ifGameNotFrozen = utils.ifGameNotFrozen(ui.game);
 
+		const unitFormatter = (creature) => {
+			const name = capitalize(creature.name);
+			const trapOrLocation = capitalize(
+				creature.hexagons[0].trap ? creature.hexagons[0].trap.name : ui.game.combatLocation,
+			);
+			const nameColorClasses =
+				creature && creature.player ? `p${creature.player.id} player-text bright` : '';
+			return `<div class="vignette hex">
+			<div class="hexinfo frame">
+			<p class="name ${nameColorClasses}">${name}</p>
+			<p>${trapOrLocation}</p>
+			</div>
+			</div>
+			`;
+		};
+
 		const onCreatureClick = ifGameNotFrozen((creature) => {
 			/**
 			 * NOTE:
@@ -2255,6 +2271,7 @@ export class UI {
 
 			ui.game.grid.showMovementRange(creature);
 			ui.queue.xray(creature.id);
+			ui.quickInfo.set(unitFormatter(creature));
 		});
 
 		const onCreatureMouseLeave = (maybeCreature) => {
@@ -2272,6 +2289,7 @@ export class UI {
 			});
 
 			ui.queue.xray(-1);
+			ui.quickInfo.clear();
 		};
 
 		const onTurnEndClick = throttle(() => {


### PR DESCRIPTION

This Adresses [#2258](https://github.com/FreezingMoon/AncientBeast/issues/2258);
If your pull request tries to address a specific issue from the repository, please reference to it.

show the quickInfo box on the top right when hoovering over the unit queue 

<img width="971" alt="image" src="https://github.com/FreezingMoon/AncientBeast/assets/74435254/93c5ab8e-2ab6-4e3a-b371-55f7a7bf7e42">

