### PR TITLE
fix unit queue not showing info box for new spawned units #2299

### DIFF
--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -2255,7 +2255,7 @@ export class UI {
 
 		const onCreatureMouseEnter = ifGameNotFrozen((creature) => {
 			const creatures = ui.game.creatures.filter((c) => c instanceof Creature);
-			const otherCreatures = creatures.filter((c) => c !== creature);
+			const otherCreatures = creatures.filter((c) => c.id !== creature.id);
 
 			otherCreatures.forEach((c) => {
 				c.xray(true);
@@ -2263,8 +2263,6 @@ export class UI {
 					hex.cleanOverlayVisualState();
 				});
 			});
-
-			creature.xray(false);
 			creature.hexagons.forEach((hex) => {
 				hex.overlayVisualState('hover h_player' + creature.team);
 			});

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -2226,7 +2226,7 @@ export class UI {
 		const unitFormatter = (creature) => {
 			const name = capitalize(creature.name);
 			const trapOrLocation = capitalize(
-				creature.hexagons[0].trap ? creature.hexagons[0].trap.name : ui.game.combatLocation,
+				creature?.hexagons[0]?.trap ? creature?.hexagons[0]?.trap?.name : ui.game.combatLocation,
 			);
 			const nameColorClasses =
 				creature && creature.player ? `p${creature.player.id} player-text bright` : '';


### PR DESCRIPTION
This fixes issue [#2299 ](https://github.com/FreezingMoon/AncientBeast/issues/2299)

hoovering over newly spawned units on the queue will show the quick info box
<img width="961" alt="image" src="https://github.com/FreezingMoon/AncientBeast/assets/74435254/e72de854-6d8d-462b-bd78-5db04be8677f">



