### PR TITLE
Use TS sources in source maps, #2310

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,7 +35,7 @@ module.exports = (env, argv) => {
 				return '[path][name].[ext]';
 			},
 		},
-		devtool: production ? undefined : 'eval',
+		devtool: production ? undefined : 'inline-source-map',
 		module: {
 			rules: [
 				{ test: /\.js$/, use: ['babel-loader'], exclude: /node_modules/ },


### PR DESCRIPTION
Source map line numbers and code are currently getting transformed by Webpack, making it difficult to figure out where source code is coming from, even if it's showing up in the console.

## Example

A random example with the current setup: ./src/abilities/Chimera.js – Reportedly line 127 
Line number is wrong and this is not the actual source from `Chimera.js`:

    activate: function activate(path, args) {
      var ability = this;
      ability.end();
      var target = _utility_arrayUtils__WEBPACK_IMPORTED_MODULE_3__.last(path).creature;


With the change. Line 150, the correct line number. With the actual source from `Chimera.js`:

    activate: function (path, args) {
        let ability = this;
        ability.end();
        let target = arrayUtils.last(path).creature;

https://webpack.js.org/guides/typescript/#source-maps

## Unfortunately ...

Note that this change does alter how sources show up in the console initially – unfortunately, the change *does* make that harder to read.

Before – shows useful webpack filenames on top:
<img width="539" alt="Screenshot 2023-05-19 at 14 33 30" src="https://github.com/FreezingMoon/AncientBeast/assets/20469369/a65e8440-d0de-4127-b4b0-1251dab86fa4">

After – shows useless line numbers on top:
<img width="851" alt="Screenshot 2023-05-19 at 14 34 06" src="https://github.com/FreezingMoon/AncientBeast/assets/20469369/923a3b61-e7dc-4f29-983c-76df3e517029">

So, that's a drawback, but having actual source maps is a big plus.