### PR TITLE
Bugfix: Player 2 Chimera, Snow Bunny, Gumble ability target undefined…

### DIFF
--- a/src/abilities/Chimera.js
+++ b/src/abilities/Chimera.js
@@ -153,6 +153,25 @@ export default (G) => {
 				ability.end();
 
 				let target = arrayUtils.last(path).creature;
+
+				{
+					// TODO:
+					// target is undefined when Player 2 Chimera uses this ability.
+					// arrayUtils.last(path).creature is undefined.
+					// This block fixes the error, but it's an ugly fix.
+					if (!target) {
+						const attackingCreature = ability.creature;
+						const creatures = path
+							.map((hex) => hex.creature)
+							.filter((c) => c && c != attackingCreature);
+						if (creatures.length === 0) {
+							return;
+						} else {
+							target = creatures[0];
+						}
+					}
+				}
+
 				let hexes = G.grid.getHexLine(target.x, target.y, args.direction, target.flipped);
 
 				let damage = new Damage(

--- a/src/abilities/Gumble.js
+++ b/src/abilities/Gumble.js
@@ -303,6 +303,23 @@ export default (G) => {
 				G.Phaser.camera.shake(0.02, 300, true, G.Phaser.camera.SHAKE_HORIZONTAL, true);
 
 				let target = arrayUtils.last(path).creature;
+				{
+					// TODO:
+					// target is undefined when Player 2 creature uses this ability.
+					// arrayUtils.last(path).creature is undefined.
+					// This block fixes the error, but it's an ugly fix.
+					if (!target) {
+						const attackingCreature = ability.creature;
+						const creatures = path
+							.map((hex) => hex.creature)
+							.filter((c) => c && c != attackingCreature);
+						if (creatures.length === 0) {
+							return;
+						} else {
+							target = creatures[0];
+						}
+					}
+				}
 				let melee = path[0].creature === target;
 
 				let d = melee

--- a/src/abilities/Snow-Bunny.js
+++ b/src/abilities/Snow-Bunny.js
@@ -325,6 +325,23 @@ export default (G) => {
 				ability.end();
 
 				let target = arrayUtils.last(path).creature;
+				{
+					// TODO:
+					// target is undefined when Player 2 creature uses this ability.
+					// arrayUtils.last(path).creature is undefined.
+					// This block fixes the error, but it's an ugly fix.
+					if (!target) {
+						const attackingCreature = ability.creature;
+						const creatures = path
+							.map((hex) => hex.creature)
+							.filter((c) => c && c != attackingCreature);
+						if (creatures.length === 0) {
+							return;
+						} else {
+							target = creatures[0];
+						}
+					}
+				}
 				// No blow size penalty if upgraded and target is frozen
 				let dist = 5 - (this.isUpgraded() && target.isFrozen() ? 0 : target.size);
 				let dir = [];


### PR DESCRIPTION
Bugfix for #2218. 

The problem for the 3 creature types appears to lie in

    let target = arrayUtils.last(path).creature;

It returns `undefined`, though `path` is defined and *does* hold a creature. I believe it's simply pulling from the wrong end for player 2 creatures, but I'm having a hard time getting my head around the logic of the function.