### PR TITLE
ability.js -> ability.ts

### DIFF
--- a/src/creature.ts
+++ b/src/creature.ts
@@ -788,7 +788,12 @@ export class Creature {
 	 * Face creature at given hex
 	 *
 	 */
-	faceHex(faceto, facefrom, ignoreCreaHex, attackFix) {
+	faceHex(
+		faceto: Hex | Creature,
+		facefrom?: Hex | Creature,
+		ignoreCreaHex?: boolean,
+		attackFix?: boolean,
+	) {
 		if (!facefrom) {
 			facefrom = this.player.flipped ? this.hexagons[this.size - 1] : this.hexagons[0];
 		}

--- a/src/effect.ts
+++ b/src/effect.ts
@@ -31,6 +31,7 @@ export class Effect {
 	turnLifetime = 0;
 	deleteTrigger = 'onStartOfRound';
 	stackable = true;
+	special: string | undefined = undefined;
 	specialHint: string | undefined = undefined; // Special hint for log
 	deleteOnOwnerDeath = false;
 

--- a/src/game.js
+++ b/src/game.js
@@ -74,6 +74,7 @@ export default class Game {
 		this.pause = false;
 		this.gameState = 'initialized';
 		this.pauseTime = 0;
+		this.abilityUpgrades = 0;
 		this.unitDrops = 0;
 		this.minimumTurnBeforeFleeing = 12;
 		this.availableCreatures = [];


### PR DESCRIPTION
Converts ability.js to TypeScript

## Notes

### jQuery

This conserves the jQuery dependency as there's an `$.extend` deep clone here:

    		$j.extend(true, this, game.abilities[data.id][abilityID], data.ability_info[abilityID]);

### Types

The conversion isn't as useful as other TypeScript conversions, as the module relies heavily on `arguments` – converted to `...passed_args` – and ad hoc types passed from the various `/src/abilities` files.

This could potentially be improved by changing how the abilities are structured – see #2315 – but that's a large undertaking.