### PR TITLE
Bugfix: AB.getLog, circular reference. Resolves #2323

### DIFF
--- a/src/utility/gamelog.js
+++ b/src/utility/gamelog.js
@@ -143,7 +143,7 @@ export class GameLog {
 				if (this._debounce) {
 					return;
 				}
-				this.saveFile(JSON.stringify(dict), `${fileName}.ab`);
+				this.saveFile(json, `${fileName}.ab`);
 				break;
 			case 'hash':
 				output = hash;

--- a/src/utility/gamelog.js
+++ b/src/utility/gamelog.js
@@ -1,4 +1,3 @@
-import * as $j from 'jquery';
 import { isEmpty, getGameConfig } from '../script';
 import { DEBUG_DISABLE_GAME_STATUS_CONSOLE_LOG } from '../debug';
 
@@ -113,17 +112,25 @@ export class GameLog {
 	}
 
 	get(state) {
-		let today = new Date().toISOString().slice(0, 10);
-		let config = isEmpty(this.gameConfig) ? getGameConfig() : this.gameConfig,
-			dict = {
-				config: config,
-				log: this.data,
-			},
-			json = JSON.stringify(dict),
-			hash = 'AB-' + this.game.version + '@' + today + ':' + btoa(JSON.stringify(dict)),
-			output,
-			strOutput;
-
+		const today = new Date().toISOString().slice(0, 10);
+		const config = isEmpty(this.gameConfig) ? getGameConfig() : this.gameConfig;
+		const dict = {
+			config: config,
+			log: this.data,
+		};
+		// TODO:
+		// The `replacer` in `JSON.stringify` was added as a bugfix for #2323
+		// Some abilities have a circular reference that can't be stringified - `sourceCreature`.
+		// The fix doesn't really fit here, but it's currently the only place where it
+		// doesn't cause an error to be thrown and doesn't break game playback.
+		// The replacer should really be factored into individual abilities, to
+		// allow them to be serialized.
+		// Note that several options exist to serialize circular references, but
+		// when added here, they result in serialized strings larger than 100 MB.
+		const json = JSON.stringify(dict, (key, value) => (key === 'sourceCreature' ? {} : value));
+		const hash = 'AB-' + this.game.version + '@' + today + ':' + btoa(json);
+		let output;
+		let strOutput;
 		let fileName = `AB-${this.game.version}:${today}`;
 
 		switch (state) {


### PR DESCRIPTION
Bugfix for #2323 

`AB.getLog` was throwing an error when serializing certain abilities present in the log. The problematic abilities all contain a `sourceCreature` field, which holds a circular reference, making it unserializable with `JSON.stringify`.

Ideally, it would be left up to the individual abilities to ensure that they're serializable. However, there are several impacted abilities, and abilities are rather complex. What's more, the bug breaks an important development tool. To get things working again as quickly as possible, the fix was applied to gamelog. A TODO was left in the code.

Note that there are libraries that allow serialization of circular references, like flatted. They were applied here and *did* allow serialization without an error, but resulted in very large serialized files (> 100 MB) even for small logs (< 5 steps) if they contained an ability holding a `sourceCreature`. 

----

The `jQuery` reference was also removed.

----

Note there are CI errors, but they are unrelated to the file changed by this PR.