### PR TITLE
Decrease Scavenger deadly toxin over time, #2330

### DIFF
--- a/src/abilities/Scavenger.js
+++ b/src/abilities/Scavenger.js
@@ -365,6 +365,10 @@ export default (G) => {
 
 				if (result.damageObj.status !== 'Shielded') {
 					// Add poison damage debuff
+
+					let nerf = 1;
+					let poisonDamage = ability.damages.poison;
+
 					let effect = new Effect(
 						this.title,
 						this.creature,
@@ -378,7 +382,7 @@ export default (G) => {
 									new Damage(
 										eff.owner,
 										{
-											poison: ability.damages.poison,
+											poison: poisonDamage - nerf,
 										},
 										1,
 										[],
@@ -386,6 +390,10 @@ export default (G) => {
 									),
 									{ isFromTrap: true },
 								);
+								nerf++;
+								if (nerf >= poisonDamage) {
+									eff.deleteEffect();
+								}
 							},
 						},
 						G,


### PR DESCRIPTION
@DreadKnight, I saw that #2330 was closed. I had the commit ready to go, so I figured there wouldn't be harm in submitting a PR so you could test it out. Go ahead and close if you don't want it. No problem either way.

Poison damage steps down by 1 until there's no poison damage.