### PR TITLE
Added version utility methods and tests

### DIFF
--- a/src/__tests__/utility/version.ts
+++ b/src/__tests__/utility/version.ts
@@ -7,3 +7,46 @@ describe('version.full', () => {
 		expect(version.full).toBe(semver.valid(version.full));
 	});
 });
+
+describe('version.isValid', () => {
+	test('version.isValid(a:string) returns true if a is valid - number.number.number', () => {
+		expect(version.isValid('0.0.0')).toBe(true);
+		expect(version.isValid('1.0.0')).toBe(true);
+		expect(version.isValid('0.1.0')).toBe(true);
+		expect(version.isValid('0.0.1')).toBe(true);
+		expect(version.isValid('100.0.1')).toBe(true);
+		expect(version.isValid('100.0.1')).toBe(true);
+		expect(version.isValid('9999999.99999999.99999999')).toBe(true);
+	});
+});
+
+describe('version.isValid', () => {
+	test('version.isValid(a:string) returns false if a is invalid - !number.number.number', () => {
+		expect(version.isValid('0')).toBe(false);
+		expect(version.isValid('0.0')).toBe(false);
+		expect(version.isValid('v.0.0')).toBe(false);
+		expect(version.isValid('0.v.0')).toBe(false);
+		expect(version.isValid('0.0.v')).toBe(false);
+		expect(version.isValid('100-0-1')).toBe(false);
+		expect(version.isValid('100.0:1')).toBe(false);
+	});
+});
+
+describe('version.equals', () => {
+	test('version.equals(a:string) compares a to version.full', () => {
+		expect(version.equals(version.full)).toBe(true);
+		expect(version.equals('0.0.0')).toBe(false);
+	});
+	test('version.equals(a:string, b:string) returns true if strings are valid version and equal, else false', () => {
+		expect(version.equals(version.full, version.full)).toBe(true);
+		expect(version.equals('1.0.0', '1.0.0')).toBe(true);
+		expect(version.equals(version.full, '0.0.0')).toBe(false);
+	});
+	test('version.equals(a:string, b:string) returns false if either string is not a valid version string', () => {
+		const invalid_version = '1.0';
+		const valid_version = '1.0.0';
+		expect(version.equals(invalid_version, valid_version)).toBe(false);
+		expect(version.equals(valid_version, invalid_version)).toBe(false);
+		expect(version.equals(invalid_version)).toBe(false);
+	});
+});

--- a/src/utility/version.ts
+++ b/src/utility/version.ts
@@ -3,11 +3,22 @@ import packageInfo from '../../package.json';
 import { DEBUG } from '../debug';
 
 // NOTE: The version string is set by /package.json.
-
-export const full = packageInfo.version;
+export const full = semver.clean(packageInfo.version);
 export const major = semver.major(full);
 export const minor = semver.minor(full);
 export const patch = semver.patch(full);
 export const release = DEBUG ? 'alpha' : 'gold';
 export const major_minor = [major, minor].join('.');
 export const pretty = `v${major_minor}` + (release === 'alpha' ? '-α' : '');
+
+export function isValid(a: string) {
+	return semver.valid(a) !== null;
+}
+
+export function equals(a: string, b?: string) {
+	b = typeof b === 'undefined' ? full : b;
+	if (!semver.valid(a) || !semver.valid(b)) {
+		return false;
+	}
+	return semver.diff(a, b) === null;
+}


### PR DESCRIPTION
This PR adds a few utility methods to version that will be used in the upcoming `gameLog` update:

* `isValid(a:string)`: Is the version string valid? Will be used to check the version string in the saved log.
* `equals(a:string, b?:string)`: Are 2 version strings equal? Or is a single version string equal to the current version?