### PR TITLE
string.js -> string.ts + zfill bugfix

### DIFF
--- a/src/__tests__/utility/string.ts
+++ b/src/__tests__/utility/string.ts
@@ -1,5 +1,26 @@
-import { toBool } from '../../utility/string';
+import { zfill, toBool } from '../../utility/string';
 import { expect, describe, test } from '@jest/globals';
+
+describe('zfill', () => {
+	test('zfill(num:number, size:number) pads zeros on the left if length of num < size', () => {
+		expect(zfill(1, 2)).toBe('01');
+		expect(zfill(1, 3)).toBe('001');
+		expect(zfill(30, 3)).toBe('030');
+		expect(zfill(30, 5)).toBe('00030');
+	});
+	test('zfill(num:number, size:number) does not fill if length of num >= size', () => {
+		expect(zfill(1, 1)).toBe('1');
+		expect(zfill(1001, 3)).toBe('1001');
+		expect(zfill(30, -3)).toBe('30');
+		expect(zfill(12345, 5)).toBe('12345');
+	});
+	test('zfill(num:number, size:number) places "-" on the left for negative numbers', () => {
+		expect(zfill(-1, 3)).toBe('-01');
+		expect(zfill(-1001, 7)).toBe('-001001');
+		expect(zfill(-30, -3)).toBe('-30');
+		expect(zfill(-12345, 7)).toBe('-012345');
+	});
+});
 
 describe('toBool', () => {
 	describe('"true" "yes" "1" are true', () => {

--- a/src/utility/string.ts
+++ b/src/utility/string.ts
@@ -1,11 +1,20 @@
-/** Zfill like in python
- * @param {number} num ?
- * @param {number} size ?
- * @returns {string} ?
+/**
+ * Pad left size of a number, if its length is less than a minimum size.
+ * Like Python's zfill()
+ *
+ * @example zfill(1234, 3) -> '1234'
+ * @example zfill(1234, 10) -> '0000001234'
+ * @example zfill(-1234, 10) -> '-000001234'
+ *
  */
-export function zfill(num, size) {
-	let s = '000000000' + num;
-	return s.substr(s.length - size);
+export function zfill(num: number, size: number): string {
+	if (num < 0) {
+		const s = Math.abs(num) + '';
+		return '-' + s.padStart(size - 1, '0');
+	} else {
+		const s = num + '';
+		return s.padStart(size, '0');
+	}
 }
 
 /**
@@ -13,10 +22,12 @@ export function zfill(num, size) {
  *
  * @example capitalize('hello world') -> 'Hello world'
  *
- * @param {string} string To capitalize.
+ * @param {string} str To capitalize.
  * @returns {string} Capitalized string.
  */
-export const capitalize = (string) => string.charAt(0).toUpperCase() + string.slice(1);
+export function capitalize(str: string): string {
+	return str.charAt(0).toUpperCase() + str.slice(1);
+}
 
 /**
  * Convert a string to a boolean.
@@ -31,17 +42,17 @@ export const capitalize = (string) => string.charAt(0).toUpperCase() + string.sl
  * @example toBool([1, 2, 3]) -> false
  * @example toBool({"a": 1}) -> false
  *
- * @param {string} string To convert to boolean.
+ * @param {string} str To convert to boolean.
  * @returns {boolean} true if the trimmed, lowercase string is in ["true", "yes", "1"], else false
  */
-export const toBool = (string) => {
+export function toBool(str: string | boolean): boolean {
 	// NOTE: Guard against repeatedly calling `toBool`.
-	if (string === true) {
-		return string;
+	if (str === true) {
+		return str;
 	}
 
-	if (typeof string === 'string') {
-		switch (string.toLowerCase().trim()) {
+	if (typeof str === 'string') {
+		switch (str.toLowerCase().trim()) {
 			case 'true':
 			case 'yes':
 			case '1':
@@ -53,4 +64,4 @@ export const toBool = (string) => {
 	}
 
 	return false;
-};
+}


### PR DESCRIPTION
This converts string.js to string.ts. It also fixes a bug and adds tests for `zfill`.

## `zfill` bug

The old `zfill` implementation had a bug. `zfill` is supposed to add zeroes to a number string until it's a given length. The old implementation would truncate the number string if the desired length was smaller than the passed string. (`zfill` is supposed to work like Python's `zfill`, which doesn't truncate.)