### PR TITLE
Added beast audio to AncientBeast logo

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -42,9 +42,7 @@
 			</div>
 			<div id="gameSetupContainer">
 				<div id="gameTitle">
-					<a href="https://AncientBeast.com" tabindex="-1" rel="noopener">
-						<div></div>
-					</a>
+					<div></div>
 				</div>
 				<div id="websiteButton">
 					<a href="https://AncientBeast.com" tabindex="-1" target="_blank" rel="noopener">

--- a/src/script.ts
+++ b/src/script.ts
@@ -154,7 +154,7 @@ $j(() => {
 		forceTwoPlayerMode();
 	}
 
-	// Create new Object to play audio in pre-match screen. 
+	// Create new Object to play audio in pre-match screen
 	const beastAudio = new PreMatchAudioPlayer;
 
 	$j('#gameTitle').on('click', () => {

--- a/src/script.ts
+++ b/src/script.ts
@@ -3,6 +3,7 @@ import * as $j from 'jquery';
 import 'jquery.transit';
 import dataJson from './data/units.json';
 import Game from './game';
+import { PreMatchAudioPlayer } from './sound/pre-match-audio';
 import { Fullscreen } from './ui/fullscreen';
 
 import Connect from './multiplayer/connect';
@@ -152,6 +153,13 @@ $j(() => {
 		// TODO Remove after implementaion 2 vs 2 in multiplayer mode
 		forceTwoPlayerMode();
 	}
+
+	// Create new Object to play audio in pre-match screen. 
+	const beastAudio = new PreMatchAudioPlayer;
+
+	$j('#gameTitle').on('click', () => {
+		beastAudio.playBeast();
+	});
 
 	// Hide singleplayer option initially
 	$j('#singleplayer').hide();

--- a/src/sound/pre-match-audio.js
+++ b/src/sound/pre-match-audio.js
@@ -1,0 +1,12 @@
+export class PreMatchAudioPlayer {
+  constructor(){
+    var beastAudioFile = require("assets/sounds/AncientBeast.ogg");
+		this.beastAudio = new Audio(beastAudioFile);
+  }
+
+  playBeast(){
+    if (this.beastAudio.paused) {
+      this.beastAudio.play();
+    }
+  }
+}

--- a/src/sound/pre-match-audio.js
+++ b/src/sound/pre-match-audio.js
@@ -1,10 +1,10 @@
 export class PreMatchAudioPlayer {
-  constructor(){
+  constructor() {
     var beastAudioFile = require("assets/sounds/AncientBeast.ogg");
 		this.beastAudio = new Audio(beastAudioFile);
   }
 
-  playBeast(){
+  playBeast() {
     if (this.beastAudio.paused) {
       this.beastAudio.play();
     }


### PR DESCRIPTION
This fixes issue #2376 

I have created a new class that handles the playing of audio in the pre-match screen. I believe this class will be useful if someone wishes to expand on the audio features in the pre-match screen in the future.

Additionally, I made a modification to the text logo by removing the link to the website and replacing it with an onclick event that plays the beast audio.

Since audio is played from the new class it shouldn't cause any conflicts with #2228 

Overall, these updates contribute to the flexibility and interactivity of the pre-match screen, while also setting the groundwork for potential future enhancements.

