### PR TITLE
Shows s-resize on inactive creature hover

### DIFF
--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -990,7 +990,7 @@ export class HexGrid {
 
 				$j('canvas').css('cursor', 'not-allowed');
 				
-				//If creature and inactive
+				// If creature and inactive
 				if (hex.creature instanceof Creature && hex.creature !== game.activeCreature) {
 					$j('canvas').css('cursor', 's-resize');
 				}

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -989,6 +989,11 @@ export class HexGrid {
 				hex.overlayVisualState('hover');
 
 				$j('canvas').css('cursor', 'not-allowed');
+				
+				//If creature and inactive
+				if (hex.creature instanceof Creature && hex.creature !== game.activeCreature) {
+					$j('canvas').css('cursor', 's-resize');
+				}
 			}
 		};
 


### PR DESCRIPTION
This fixes issue #2245

I added an if statement that checks if the hex is an inactive creature. The if statement is placed in the out of reach if statement for ONMOUSEOVER. This should solve the issue and when an active creatures abilty is targeting an inactive creature it should still show the pointer cursor.

