### PR TITLE
Enable arrows/tabs/focus on pre-match configuration screen, fixes #2367

### DIFF
--- a/src/script.ts
+++ b/src/script.ts
@@ -84,7 +84,6 @@ $j(() => {
 		});
 	}
 
-	disableScrollAndArrowKeys(document.getElementById('pre-match')); // Disable scroll and arrow keys for preMatch element
 	disableScrollAndArrowKeys(document.getElementById('loader')); // Disable scroll and arrow keys for loader element
 
 	// Add listener for Fullscreen API

--- a/src/style/pre-match.less
+++ b/src/style/pre-match.less
@@ -413,14 +413,16 @@ body {
 		font-weight: bold;
 		cursor: pointer;
 		transition: filter 0.15s ease-in-out;
+		outline: 0;
 
 		&:hover {
 			filter: brightness(135%);
 		}
 
 		&:focus {
-			outline: 0;
 			color: white;
+			filter: brightness(135%);
+			text-shadow: 0 0 10px rgb(214, 98, 94);
 		}
 
 		&.disabled {


### PR DESCRIPTION
[A previous PR had explicitly disabled tabs/arrows (and all other key presses and several other default behaviors) on the pre-match configuration DOM element](https://github.com/FreezingMoon/AncientBeast/blob/34ce519e7f07cc8f41d2eb9e65fd70c18a333dc6/src/script.ts#L87), leading to #2367. This PR re-enables them.

I'm guessing the defaults were overridden for a reason though. Are there default behaviors that *should* be disabled?

As this was a usability-oriented issue, I also exaggerated the "focus" style of the "Start" button, as it was very subtle and difficult to notice.