### PR TITLE
bugfix: (partial fix) highlighted hex receives action #2253

### DIFF
--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -156,7 +156,6 @@ export class HexGrid {
 		this.hexesGroup = game.Phaser.add.group(this.gridGroup, 'hexesGroup');
 		this.displayHexesGroup = game.Phaser.add.group(this.gridGroup, 'displayHexesGroup');
 		this.overlayHexesGroup = game.Phaser.add.group(this.gridGroup, 'overlayHexesGroup');
-		this.inputHexesGroup = game.Phaser.add.group(this.gridGroup, 'inputHexesGroup');
 		this.dropGroup = game.Phaser.add.group(this.display, 'dropGrp');
 		this.creatureGroup = game.Phaser.add.group(this.display, 'creaturesGrp');
 		// Parts of traps displayed over creatures


### PR DESCRIPTION
This is a partial fix for #2253. Namely, it fixes this part of the issue:

> In addition, the inaccuracy appears to be inconsistent. If a non-highlighted hex is clicked while e.g., summoning a creature, the creature will not be summoned where the "unmaterialized" creature was displayed. The same inconsistency seems to appear in all hex/mouse interactions: hovers and clicks are treated differently.

So, this is an improvement – the highlighted hexes is actioned when clicked. **But it's not a full fix – the hex directly under the mouse isn't always highlighted.**

