### PR TITLE
game.js -> game.ts 

### DIFF
--- a/src/animations.ts
+++ b/src/animations.ts
@@ -4,6 +4,8 @@ import { Creature } from './creature';
 import { Hex } from './utility/hex';
 import { Ability } from './ability';
 
+// to fix @ts-expect-error 2554: properly type the arguments for the trigger functions in `game.ts`
+
 type AnimationOptions = {
 	customMovementPoint?: number;
 	overrideSpeed?: number;
@@ -247,7 +249,7 @@ export class Animations {
 				creature.faceHex(hex, creature.hexagons[0], false, false); // Determine facing
 			}
 		}
-
+		// @ts-expect-error 2554
 		game.onStepOut(creature, creature.hexagons[0]); // Trigger
 		game.grid.orderCreatureZ();
 	}

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -11,6 +11,8 @@ import { Player } from './player';
 import { Damage } from './damage';
 import { AugmentedMatrix } from './utility/matrices';
 
+// to fix @ts-expect-error 2554: properly type the arguments for the trigger functions in `game.ts`
+
 export type CreatureVitals = {
 	health: number;
 	regrowth: number;
@@ -535,6 +537,7 @@ export class Creature {
 			varReset();
 
 			// Trigger
+			// @ts-expect-error 2554
 			game.onStartPhase(this);
 		}
 
@@ -571,6 +574,7 @@ export class Creature {
 		// Effects triggers
 		if (!wait) {
 			this.turnsActive += 1;
+			// @ts-expect-error 2554
 			game.onEndPhase(this);
 		}
 
@@ -976,6 +980,7 @@ export class Creature {
 				clearInterval(interval);
 				opts.callback();
 				game.signals.creature.dispatch('movementComplete', { creature: this, hex });
+				// @ts-expect-error 2554
 				game.onCreatureMove(this, hex); // Trigger
 			}
 		}, 100);
@@ -1360,6 +1365,7 @@ export class Creature {
 			}
 		}
 
+		// @ts-expect-error 2554
 		game.onHeal(this, amount);
 	}
 
@@ -1460,6 +1466,7 @@ export class Creature {
 
 			// Trigger
 			if (!o.ignoreRetaliation) {
+				// @ts-expect-error 2554
 				game.onDamage(this, damage);
 			}
 
@@ -1815,6 +1822,7 @@ export class Creature {
 		this.dead = true;
 
 		// Triggers
+		// @ts-expect-error 2554
 		game.onCreatureDeath(this);
 
 		this.killer = killerCreature.player;

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -613,8 +613,8 @@ export class Creature {
 	/* queryMove()
 	 * launch move action query
 	 */
-	// TODO: type the argument
-	queryMove(o: QueryMoveOptions) {
+	// TODO: type `args` in `QueryMoveOptions`
+	queryMove(options?: QueryMoveOptions) {
 		const game = this.game;
 
 		if (this.dead) {
@@ -626,7 +626,7 @@ export class Creature {
 		// Once Per Damage Abilities recover
 		game.creatures.forEach((creature) => {
 			//For all Creature
-			if (creature instanceof Creature) {
+			if (creature) {
 				creature.abilities.forEach((ability) => {
 					if (game.triggers.oncePerDamageChain.test(ability.getTrigger())) {
 						ability.setUsed(false);
@@ -646,8 +646,7 @@ export class Creature {
 			remainingMove = 0;
 		}
 
-		o = $j.extend(
-			{
+		const defaultOptions = {
 				targeting: false,
 				noPath: false,
 				isAbility: false,
@@ -685,8 +684,8 @@ export class Creature {
 					});
 				},
 			},
-			o,
-		);
+			// overwrite any fields of `defaultOptions` that were provided in `options`
+			o = $j.extend(defaultOptions, options);
 
 		if (!o.isAbility) {
 			if (game.UI.selectedAbility != -1) {

--- a/src/game.ts
+++ b/src/game.ts
@@ -25,7 +25,7 @@ import { Effect } from './effect';
 
 /* NOTE
  *
- * to fix @ts-expect-error 2339, consider the note left on changing type definitions and initializations of empty objects
+ * to fix @ts-expect-error 2339, convert match.js -> match.ts
  */
 
 /* Game Class
@@ -88,7 +88,7 @@ export default class Game {
 	// need to make sure nothing breaks
 	configData: {};
 	match: MatchI | {};
-	gameplay: Gameplay | {};
+	gameplay: Gameplay;
 	session = null;
 	client = null;
 	connect = null;
@@ -161,7 +161,7 @@ export default class Game {
 		);
 		this.configData = {};
 		this.match = {};
-		this.gameplay = {};
+		this.gameplay = undefined;
 		this.session = null;
 		this.client = null;
 		this.connect = null;
@@ -1679,7 +1679,7 @@ export default class Game {
 		this.animationQueue = [];
 		this.configData = {};
 		this.match = {};
-		this.gameplay = {};
+		this.gameplay = undefined;
 		this.matchInitialized = false;
 		this.firstKill = false;
 		this.freezedInput = false;

--- a/src/game.ts
+++ b/src/game.ts
@@ -13,6 +13,7 @@ import { Creature } from './creature';
 import dataJson from './data/units.json';
 import 'pixi';
 import 'p2';
+// @ts-expect-error
 import Phaser, { Signal } from 'phaser';
 import MatchI from './multiplayer/match';
 import Gameplay from './multiplayer/gameplay';
@@ -1204,7 +1205,10 @@ export default class Game {
 			i;
 
 		for (i = totalCreatures - 1; i >= 0; i--) {
-			if (this.creatureData[i].type == type || this[i].realm + this.creatureData[i].level == type) {
+			if (
+				this.creatureData[i].type == type ||
+				this.creatureData[i].realm + this.creatureData[i].level == type
+			) {
 				if (!this.creatureData[i].type) {
 					// When type property is missing, create it using formula: concat(realm + level)
 					this.creatureData[i].type = this.creatureData[i].realm + this.creatureData[i].level;

--- a/src/game.ts
+++ b/src/game.ts
@@ -7,7 +7,7 @@ import { MusicPlayer } from './sound/musicplayer';
 import { Hex } from './utility/hex';
 import { HexGrid } from './utility/hexgrid';
 import { getUrl } from './assetLoader';
-import { Player } from './player';
+import { Player, PlayerColor } from './player';
 import { UI } from './ui/interface';
 import { Creature } from './creature';
 import dataJson from './data/units.json';
@@ -22,6 +22,7 @@ import { configure as configurePointFacade } from './utility/pointfacade';
 import { pretty as version } from './utility/version';
 import { Ability } from './ability';
 import { Effect } from './effect';
+import { GameConfig } from './script';
 
 /* NOTE
  *
@@ -315,7 +316,12 @@ export default class Game {
 	 * Load all required game files
 	 */
 
-	loadGame(setupOpt, matchInitialized, matchid, onLoadCompleteFn = () => {}) {
+	loadGame(
+		setupOpt: Partial<GameConfig>,
+		matchInitialized?: boolean,
+		matchid?: number,
+		onLoadCompleteFn = () => {},
+	) {
 		// Need to remove keydown listener before new game start
 		// to prevent memory leak and mixing hotkeys between start screen and game
 		$j(document).off('keydown');
@@ -355,7 +361,8 @@ export default class Game {
 		this.Phaser.load.onLoadComplete.add(onLoadCompleteFn);
 
 		// Health
-		const playerColors = ['red', 'blue', 'orange', 'green'];
+		const playerColors: PlayerColor[] = ['red', 'blue', 'orange', 'green'];
+
 		let i;
 		for (i = 0; i < 4; i++) {
 			this.Phaser.load.image('p' + i + '_health', getUrl('interface/rectangle_' + playerColors[i]));

--- a/src/game.ts
+++ b/src/game.ts
@@ -1741,7 +1741,6 @@ export default class Game {
 			const interval = setInterval(() => {
 				if (!game.freezedInput && !game.turnThrottle) {
 					clearInterval(interval);
-					// @ts-expect-error 2339
 					game.activeCreature.queryMove();
 					game.action(actions.shift(), {
 						callback: nextAction,

--- a/src/game.ts
+++ b/src/game.ts
@@ -39,6 +39,8 @@ import { GameConfig } from './script';
  * to really start the game.
  */
 
+type AnimationID = number;
+
 export default class Game {
 	/* Attributes
 	 *
@@ -82,7 +84,7 @@ export default class Game {
 	unitDrops: number;
 	minimumTurnBeforeFleeing: number;
 	availableCreatures: Creature[];
-	animationQueue: Animation[];
+	animationQueue: (Animation | AnimationID)[];
 	checkTimeFrequency: number;
 	gamelog: GameLog;
 	// for `{}`: could instead type them as `undefined | T`. This would simplify type narrowing, just

--- a/src/game.ts
+++ b/src/game.ts
@@ -13,7 +13,7 @@ import { Creature } from './creature';
 import dataJson from './data/units.json';
 import 'pixi';
 import 'p2';
-// @ts-expect-error
+// @ts-expect-error 2307
 import Phaser, { Signal } from 'phaser';
 import MatchI from './multiplayer/match';
 import Gameplay from './multiplayer/gameplay';
@@ -25,9 +25,18 @@ import { Ability } from './ability';
 import { Effect } from './effect';
 import { GameConfig } from './script';
 
-/* NOTE
+/* eslint-disable prefer-rest-params */
+
+/* NOTES/TODOS
  *
- * to fix @ts-expect-error 2339, convert match.js -> match.ts
+ * to fix @ts-expect-error
+ * 2339: convert match.js -> match.ts
+ * 2362: use `Date.valueOf()` when subtracting `number` type from a `Date` type
+ * 2307: cannot find module
+ * 2554: adjust `stopTimer()` definition
+ * 2683: `this` is implicitly `any`
+ *
+ * refactor the trigger functions to get rid of the `prefer-rest-params` linter errors
  */
 
 /* Game Class
@@ -88,10 +97,8 @@ export default class Game {
 	animationQueue: (Animation | AnimationID)[];
 	checkTimeFrequency: number;
 	gamelog: GameLog;
-	// for `{}`: could instead type them as `undefined | T`. This would simplify type narrowing, just
-	// need to make sure nothing breaks
-	configData: {};
-	match: MatchI | {};
+	configData: object;
+	match: MatchI | object;
 	gameplay: Gameplay;
 	session = null;
 	client = null;
@@ -127,10 +134,10 @@ export default class Game {
 	grid?: HexGrid;
 
 	startMatchTime?: Date;
-	$combatFrame?: JQuery<HTMLElement>;
+	$combatFrame?: JQuery<HTMLElement>; //eslint-disable-line no-undef
+	timeInterval?: NodeJS.Timer; //eslint-disable-line no-undef
 
-	timeInterval?: NodeJS.Timer;
-	windowResizeTimeout?: string | number | NodeJS.Timer;
+	windowResizeTimeout?: string | number | NodeJS.Timer; //eslint-disable-line no-undef
 
 	pauseStartTime?: Date;
 
@@ -669,14 +676,14 @@ export default class Game {
 		this.resizeCombatFrame(); // Resize while the game is starting
 		this.UI.resizeDash();
 
-		var resizeGame = function () {
-			// @ts-expect-error 653
+		const resizeGame = function () {
+			// @ts-expect-error 2683
 			clearTimeout(this.windowResizeTimeout);
-			// @ts-expect-error 653
+			// @ts-expect-error 2683
 			this.windowResizeTimeout = setTimeout(() => {
-				// @ts-expect-error 653
+				// @ts-expect-error 2683
 				this.resizeCombatFrame();
-				// @ts-expect-error 653
+				// @ts-expect-error 2683
 				this.UI.resizeDash();
 			}, 100);
 		}.bind(this);
@@ -948,7 +955,7 @@ export default class Game {
 		if (this.freezedInput && this.pause) {
 			this.pause = false;
 			this.freezedInput = false;
-			// @ts-expect-error
+			// @ts-expect-error 2362
 			this.pauseTime += new Date() - this.pauseStartTime;
 			$j('#pause').remove();
 			this.startTimer();
@@ -1425,7 +1432,7 @@ export default class Game {
 				effect.deleteEffect();
 				// Update UI in case effect changes it
 				if (effect.target) {
-					// @ts-expect-error
+					// @ts-expect-error 2339
 					// `this.effects` might be the wrong type or need to look at `EffectTarget` type definition
 					effect.target.updateHealth();
 				}
@@ -1543,7 +1550,7 @@ export default class Game {
 		}
 
 		for (i = 0; i < totalEffects; i++) {
-			// @ts-expect-error
+			// @ts-expect-error 2339
 			// `this.effects` might be the wrong type or need to look at `EffectTarget` type definition
 			this.effects[i].triggeredThisChain = false;
 		}

--- a/src/player.ts
+++ b/src/player.ts
@@ -29,18 +29,18 @@ type ScoreType =
 	| 'pickupDrop'
 	| 'upgrade';
 
-type PlayerID = 0 | 1 | 2 | 3;
-
-type PlayerName = `Player${1 | 2 | 3 | 4}`;
-
-type PlayerColor = 'red' | 'blue' | 'orange' | 'green';
-
 export type ScoreEvent = {
 	type: ScoreType;
 	creature?: Creature;
 	kills?: number;
 	ability?: AbilitySlot;
 };
+
+export type PlayerColor = 'red' | 'blue' | 'orange' | 'green';
+
+type PlayerID = 0 | 1 | 2 | 3;
+
+type PlayerName = `Player${1 | 2 | 3 | 4}`;
 
 type TotalScore = Record<ScoreType, number> & { total: number };
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -12,6 +12,8 @@ import { AbilitySlot } from './ability';
 /**
  * NOTE
  * need to convert game.js -> game.ts to get rid of @ts-expect-errors
+ *
+ * to fix @ts-expect-error 2554: properly type the arguments for the trigger functions in `game.ts`
  */
 
 type ScoreType =
@@ -157,6 +159,7 @@ export class Player {
 
 		this.creatures.push(creature);
 		creature.summon(!this._summonCreaturesWithMaterializationSickness);
+		// @ts-expect-error 2554
 		game.onCreatureSummon(creature);
 	}
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -98,7 +98,6 @@ export class Player {
 		this.hasLost = false;
 		this.hasFled = false;
 		this.bonusTimePool = 0;
-		// @ts-expect-error ts(2339)
 		this.totalTimePool = game.timePool * 1000;
 		this.startTime = new Date();
 
@@ -263,7 +262,6 @@ export class Player {
 	isLeader(): boolean {
 		const game = this.game;
 
-		// @ts-expect-error ts(2339)
 		for (let i = 0; i < game.playerMode; i++) {
 			// Each player
 			// If someone has a higher score
@@ -314,7 +312,6 @@ export class Player {
 		game.updateQueueDisplay();
 
 		// Test if allie Dark Priest is dead
-		// @ts-expect-error ts(2339)
 		if (game.playerMode > 2) {
 			// 2 vs 2
 			if (game.players[(this.id + 2) % 4].hasLost) {

--- a/src/script.ts
+++ b/src/script.ts
@@ -19,6 +19,8 @@ import {
 // Load the stylesheet
 import './style/main.less';
 
+export type GameConfig = ReturnType<typeof getGameConfig>;
+
 // Generic object we can decorate with helper methods to simply dev and user experience.
 // TODO: Expose this in a less hacky way.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Too many unknown types.


### PR DESCRIPTION
Part of #1969 

Opening this draft to get some feedback on how to move forward. Currently the game doesn't build due to the use of the `arguments` object in the various trigger functions defined in `game.ts`. This causes TS to throw errors when a trigger function is called with an argument, for example `game.onStartPhase(this)`. 

Is there a reason for using `arguments` instead of explicitly defining the arguments for each function? If not I can try to refactor the functions to type the arguments or I could `@ts-ignore` the current issues and tackle them in a future PR. 