### PR TITLE
Reset health indicator bounce after ability use

### DIFF
--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -900,7 +900,7 @@ export class HexGrid {
 				const offset = o.flipped ? o.size - 1 : 0;
 				const mult = o.flipped ? 1 : -1; // For flipped player
 				// If hex is reachable & creature, reset health indicator bounce
-				if(hex.creature instanceof Creature) {
+				if (hex.creature instanceof Creature) {
 					hex.creature.resetBounce();
 				}
 

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -900,7 +900,7 @@ export class HexGrid {
 				const offset = o.flipped ? o.size - 1 : 0;
 				const mult = o.flipped ? 1 : -1; // For flipped player
 				
-				// If hex is reachable & creature reset health indicator bounce
+				// If hex is reachable & creature, reset health indicator bounce
 				if(hex.creature instanceof Creature) {
 					hex.creature.resetBounce();
 				}

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -899,6 +899,11 @@ export class HexGrid {
 				// Offset Pos
 				const offset = o.flipped ? o.size - 1 : 0;
 				const mult = o.flipped ? 1 : -1; // For flipped player
+				
+				// If hex is reachable & creature reset health indicator bounce
+				if(hex.creature instanceof Creature) {
+					hex.creature.resetBounce();
+				}
 
 				for (let i = 0, size = o.size; i < size; i++) {
 					// Try next hexagons to see if they fits

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -898,12 +898,11 @@ export class HexGrid {
 				// Reachable hex
 				// Offset Pos
 				const offset = o.flipped ? o.size - 1 : 0;
-				const mult = o.flipped ? 1 : -1; // For flipped player
-				
+				const mult = o.flipped ? 1 : -1; // For flipped player		
 				// If hex is reachable & creature, reset health indicator bounce
 				if(hex.creature instanceof Creature) {
 					hex.creature.resetBounce();
-				}
+				};
 
 				for (let i = 0, size = o.size; i < size; i++) {
 					// Try next hexagons to see if they fits

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -898,11 +898,11 @@ export class HexGrid {
 				// Reachable hex
 				// Offset Pos
 				const offset = o.flipped ? o.size - 1 : 0;
-				const mult = o.flipped ? 1 : -1; // For flipped player		
+				const mult = o.flipped ? 1 : -1; // For flipped player
 				// If hex is reachable & creature, reset health indicator bounce
 				if(hex.creature instanceof Creature) {
 					hex.creature.resetBounce();
-				};
+				}
 
 				for (let i = 0, size = o.size; i < size; i++) {
 					// Try next hexagons to see if they fits


### PR DESCRIPTION
This fixes issue #2362 

The health indicator now resets after ONCLICK.

Since the bounce and reset were triggered in the hexgrid.ts file, I thought it would be best to fix the issue in the same file. While playing the game I noticed that using an ability and quickly hovering off was the only thing that made the indicator keep  bouncing. This fixes that problem, but if there are other instances that make this problem occur, I can try to change the code.

