### PR TITLE
build: use webpack clean option instead of rimraf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,6 @@
 				"less-loader": "^11.1.0",
 				"lint-staged": "^13.2.3",
 				"prettier": "2.5.1",
-				"rimraf": "^3.0.2",
 				"style-loader": "^3.3.1",
 				"terser-webpack-plugin": "^5.3.6",
 				"ts-loader": "^9.4.2",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
 		"less-loader": "^11.1.0",
 		"lint-staged": "^13.2.3",
 		"prettier": "2.5.1",
-		"rimraf": "^3.0.2",
 		"style-loader": "^3.3.1",
 		"terser-webpack-plugin": "^5.3.6",
 		"ts-loader": "^9.4.2",
@@ -80,8 +79,8 @@
 		"node": "18.12.x"
 	},
 	"scripts": {
-		"build": "npm run clean && npm run assetLister && webpack --mode=production",
-		"build:dev": "npm run clean && npm run assetLister && webpack --mode=development",
+		"build": "npm run assetLister && webpack --mode=production",
+		"build:dev": "npm run assetLister && webpack --mode=development",
 		"start": "cross-env NODE_ENV=production node server.js",
 		"start:dev": "cross-env NODE_ENV=development webpack-dev-server",
 		"assetLister": "node ./assetLister.js",
@@ -92,8 +91,7 @@
 		"eslint-check": "eslint --print-config .eslintrc.json | eslint-config-prettier-check",
 		"test": "npm run lint && npm run build && jest",
 		"jest": "jest",
-		"start:jest": "jest --watch",
-		"clean": "rimraf ./deploy"
+		"start:jest": "jest --watch"
 	},
 	"lint-staged": {
 		"*.{ts,js}": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,7 @@ module.exports = (env, argv) => {
 		output: {
 			path: path.resolve(__dirname, 'deploy'),
 			filename: '[name].[contenthash].bundle.js',
+			clean: true, // NOTE: Clean the output folder before each build.
 			assetModuleFilename: () => {
 				if (production) {
 					return 'assets/[contenthash].[ext]';
@@ -96,6 +97,15 @@ module.exports = (env, argv) => {
 					test: /\.(png|jpg|gif|svg|ogg|ico|cur|woff|woff2)$/,
 					type: 'asset/resource',
 				},
+				/*
+				{
+					test: /\.(png|jpg|gif|svg|ogg|ico|cur|woff|woff2)$/,
+					loader: 'image-loader',
+					options: {
+					  //limit: 8192, // inline images up to 8KB
+					},
+				}
+				*/
 			],
 		},
 		resolve: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,15 +97,6 @@ module.exports = (env, argv) => {
 					test: /\.(png|jpg|gif|svg|ogg|ico|cur|woff|woff2)$/,
 					type: 'asset/resource',
 				},
-				/*
-				{
-					test: /\.(png|jpg|gif|svg|ogg|ico|cur|woff|woff2)$/,
-					loader: 'image-loader',
-					options: {
-					  //limit: 8192, // inline images up to 8KB
-					},
-				}
-				*/
 			],
 		},
 		resolve: {


### PR DESCRIPTION
* Remove "clean" script from package.json
* Remove rimraf dev dependency
* Add "clean" option to webpack.config.js

Rationale: Webpack has built-in functionality to clean the output directory before building. There's no longer a need for the rimraf dependency.

Note that this PR also removes the "clean" script from package.json. [It was added in order to call rimraf.](https://github.com/FreezingMoon/AncientBeast/pull/1956/files) In the meantime, it's possible that some devs found it useful to clean without building; if there are complaints, it can be added again.

[Discussion](https://github.com/FreezingMoon/AncientBeast/pull/1956#issuecomment-1631708787)