### PR TITLE
Creature delay bugfix and refactor, closes #2158 #2275

### DIFF
--- a/src/abilities/Dark-Priest.js
+++ b/src/abilities/Dark-Priest.js
@@ -266,10 +266,6 @@ export default (G) => {
 				const creatureHasMaterializationSickness =
 					dpriest.player.summonCreaturesWithMaterializationSickness;
 
-				// Removes temporary Creature from queue when Player chooses a
-				// different Creature to materialize
-				G.queue.removeTempCreature();
-
 				// Create full temporary Creature with placeholder position to show in queue
 				crea = $j.extend(
 					crea,
@@ -284,11 +280,8 @@ export default (G) => {
 				// Make temporary Creature invisible
 				fullCrea.sprite.alpha = 0;
 
-				// Provide full Creature to Queue
-				G.queue.tempCreature = fullCrea;
-
 				// Show temporary Creature in queue
-				G.queue.addByInitiative(fullCrea, !creatureHasMaterializationSickness);
+				G.queue.update();
 				G.updateQueueDisplay();
 
 				G.grid.forEachHex(function (hex) {

--- a/src/abilities/Knightmare.js
+++ b/src/abilities/Knightmare.js
@@ -216,7 +216,7 @@ export default (G) => {
 					return;
 				}
 
-				target.delay();
+				target.hinder();
 			},
 		},
 

--- a/src/abilities/Stomper.js
+++ b/src/abilities/Stomper.js
@@ -514,7 +514,7 @@ export default (G) => {
 						target.status.dizzy = true;
 						target.removeEffect('Earth Shaker');
 					} else {
-						target.delay(false);
+						target.hinder();
 						target.addEffect(
 							new Effect(
 								'Earth Shaker', // Name
@@ -524,8 +524,7 @@ export default (G) => {
 								{
 									// disable the ability to delay this unit as it has already been delayed
 									effectFn: () => {
-										target.delayed = true;
-										target.delayable = false;
+										target.hinder();
 									},
 									deleteTrigger: 'onEndPhase',
 									turnLifetime: 1,

--- a/src/ability.ts
+++ b/src/ability.ts
@@ -235,7 +235,6 @@ export class Ability {
 		}
 		game.signals.creature.dispatch('abilityend', { creature: this.creature });
 		game.UI.btnDelay.changeState('disabled');
-		game.activeCreature.delayable = false;
 		game.UI.selectAbility(-1);
 
 		if (this.getTrigger() === 'onQuery' && !deferredEnding) {

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -145,8 +145,9 @@ export class Creature {
 	dropCollection: Drop[];
 	protectedFromFatigue: boolean;
 	turnsActive: number;
-	delayable: boolean;
-	delayed: boolean;
+	private _nextGameTurnActive: number;
+	private _waitedTurn: number;
+	private _hinderedTurn: number;
 	materializationSickness: boolean;
 	noActionPossible: boolean;
 	destroy: any;
@@ -399,15 +400,17 @@ export class Creature {
 		}
 		// Adding Himself to creature arrays and queue
 		game.creatures[this.id] = this;
-
-		this.delayable = true;
-		this.delayed = false;
 		if (typeof obj.materializationSickness !== 'undefined') {
 			this.materializationSickness = obj.materializationSickness;
 		} else {
 			this.materializationSickness = this.isDarkPriest() ? false : true;
 		}
 		this.noActionPossible = false;
+
+		this._nextGameTurnActive =
+			!this.materializationSickness || this.isDarkPriest() ? this.game.turn : this.game.turn + 1;
+		this._waitedTurn = -1;
+		this._hinderedTurn = -1;
 	}
 
 	/**
@@ -420,15 +423,11 @@ export class Creature {
 		priest who must always be in the next queue to properly start the game. */
 		const alsoAddToCurrentQueue = disableMaterializationSickness && !this.isDarkPriest();
 
-		game.queue.addByInitiative(this, alsoAddToCurrentQueue);
-
 		if (disableMaterializationSickness) {
 			this.materializationSickness = false;
 		}
 
-		// Remove temporary Creature to prevent duplicates when the actual
-		// materialized Creature with correct position is added to the queue
-		game.queue.removeTempCreature();
+		game.queue.update();
 		game.updateQueueDisplay();
 
 		game.grid.orderCreatureZ();
@@ -564,61 +563,99 @@ export class Creature {
 		}, 1000);
 	}
 
-	/* deactivate(wait)
+	/**
+	 * Deactivate the creature. Called when the creature is active, then is no longer active.
 	 *
-	 * wait :	Boolean :	Deactivate while waiting or not
-	 *
-	 * Preview the creature position at the given coordinates
-	 *
+	 * @param {'wait' | 'turn-end'} reason: Why is the creature deactivated?
 	 */
-	deactivate(wait: boolean) {
+	deactivate(reason: 'wait' | 'turn-end') {
 		const game = this.game;
-		this.delayed = wait;
-		this.hasWait = this.delayed;
+		this.hasWait = this.isDelayed;
 		this.status.frozen = false;
 		this.status.cryostasis = false;
 		this.status.dizzy = false;
 
 		// Effects triggers
-		if (!wait) {
+		if (reason === 'turn-end') {
 			this.turnsActive += 1;
+			this._nextGameTurnActive = game.turn + 1;
 			// @ts-expect-error 2554
 			game.onEndPhase(this);
 		}
-
-		this.delayable = false;
 	}
 
-	/* wait()
-	 *
-	 * Move the creature to the end of the queue
-	 *
+	get isInCurrentQueue() {
+		return !this.dead && !this.temp && this._nextGameTurnActive <= this.game.turn;
+	}
+
+	get isInNextQueue() {
+		return !this.dead;
+	}
+
+	get isDelayedInNextQueue(): null | boolean {
+		if (!this.isInNextQueue) return null;
+		return !this.isInCurrentQueue && this.isDelayed;
+	}
+
+	/**
+	 * @deprecated Use isDelayed
 	 */
-	wait() {
-		let abilityAvailable = false;
+	get delayed() {
+		return this.isDelayed;
+	}
 
-		if (this.delayed) {
-			return;
-		}
+	get isDelayed() {
+		return this.isWaiting || this.isHindered;
+	}
 
-		// If at least one ability has not been used
-		this.abilities.forEach((ability) => {
-			abilityAvailable = abilityAvailable || !ability.used;
-		});
+	get isWaiting() {
+		return this._waitedTurn >= this.turnsActive;
+	}
 
-		if (this.remainingMove > 0 && abilityAvailable) {
-			this.delay();
-			this.deactivate(true);
+	get isHindered() {
+		return this._hinderedTurn >= this.turnsActive;
+	}
+
+	/**
+	 * @deprecated Use canWait
+	 */
+	get delayable() {
+		return this.canWait;
+	}
+
+	/**
+	 * Is waiting possible?
+	 */
+	get canWait() {
+		const hasUnusedAbilities = this.abilities.some((a) => !a.used);
+		return !this.isDelayed && this.remainingMove > 0 && hasUnusedAbilities;
+	}
+
+	/**
+	 * The creature waits. It will have its turn at the end of the round.
+	 * The player has decided to delay the creature until the end of the turn.
+	 */
+	wait(): void {
+		if (this.canWait) {
+			const game = this.game;
+
+			this._waitedTurn = this.turnsActive;
+			this.hint('Delayed', 'msg_effects');
+			game.queue.update();
+			game.updateQueueDisplay();
+			this.deactivate('wait');
 		}
 	}
 
-	delay() {
+	/**
+	 * A creature's turn is delayed as part of an attack from another creature.
+	 */
+	hinder(): void {
 		const game = this.game;
 
-		game.queue.delay(this);
-		this.delayable = false;
-		this.delayed = true;
+		this._hinderedTurn = this.turnsActive;
 		this.hint('Delayed', 'msg_effects');
+		game.queue.update();
 		game.updateQueueDisplay();
 	}
 
@@ -686,7 +723,6 @@ export class Creature {
 							},
 						});
 					}
-					args.creature.delayable = false;
 					game.UI.btnDelay.changeState('disabled');
 					args.creature.moveTo(hex, {
 						animation: args.creature.movementType() === 'flying' ? 'fly' : 'walk',
@@ -702,11 +738,7 @@ export class Creature {
 		if (!o.isAbility) {
 			if (game.UI.selectedAbility != -1) {
 				this.hint('Canceled', 'gamehintblack');
-
-				// If this Creature is Dark Priest, remove temporary Creature in queue
-				if (this.isDarkPriest()) {
-					game.queue.removeTempCreature();
-				}
+				game.queue.update();
 			}
 
 			$j('#abilities .ability').removeClass('active');
@@ -1632,6 +1664,7 @@ export class Creature {
 	}
 
 	hint(text: string, cssClass: string) {
+		if (typeof Phaser === 'undefined') return;
 		const game = this.game,
 			tooltipSpeed = 250,
 			tooltipDisplaySpeed = 500,
@@ -1941,7 +1974,7 @@ export class Creature {
 
 		this.cleanHex();
 
-		game.queue.remove(this);
+		game.queue.update();
 		game.updateQueueDisplay();
 		game.grid.updateDisplay();
 

--- a/src/creature_queue.ts
+++ b/src/creature_queue.ts
@@ -1,103 +1,52 @@
-import Game from './game';
 import { Creature } from './creature';
-import * as arrayUtils from './utility/arrayUtils';
 
 export class CreatureQueue {
-	game: Game;
+	private _getCreatures: () => Creature[];
 	queue: Creature[];
 	nextQueue: Creature[];
-	tempCreature: Creature | Record<string, never>;
 
-	constructor(game: Game) {
-		this.game = game;
+	constructor(getCreatures: () => Creature[]) {
+		this._getCreatures = getCreatures;
 		this.queue = [];
 		this.nextQueue = [];
-		this.tempCreature = {};
-	}
-
-	/**
-	 * Add a creature to the next turn's queue by initiative, and optionally the current
-	 * turn's queue.
-	 *
-	 * @param {Creature} creature The creature to add.
-	 * @param {boolean} alsoAddToCurrentQueue Also add the creature to the current
-	 * turn's queue. Doing so lets a creature act in the same turn it was summoned.
-	 */
-	addByInitiative(creature: Creature, alsoAddToCurrentQueue = true) {
-		const queues = [this.nextQueue];
-
-		if (alsoAddToCurrentQueue) {
-			queues.push(this.queue);
-		}
-
-		queues.forEach((queue) => {
-			for (let i = 0; i < queue.length; i++) {
-				const queueItem = queue[i];
-
-				if (queueItem.delayed || queueItem.getInitiative() < creature.getInitiative()) {
-					queue.splice(i, 0, creature);
-					return;
-				}
-			}
-
-			queue.push(creature);
-		});
-	}
-
-	dequeue() {
-		return this.queue.splice(0, 1)[0];
-	}
-
-	remove(creature: Creature) {
-		arrayUtils.removePos(this.queue, creature);
-		arrayUtils.removePos(this.nextQueue, creature);
-	}
-
-	// Removes temporary Creature from queue
-	removeTempCreature() {
-		if (this.tempCreature instanceof Creature) {
-			this.remove(this.tempCreature);
-		}
-	}
-
-	nextRound() {
-		// Copy next queue into current queue
-		this.queue = this.nextQueue.slice(0);
-		// Sort next queue by initiative (current queue may be reordered) descending
-		this.nextQueue = this.nextQueue.sort((a, b) => b.getInitiative() - a.getInitiative());
 	}
 
 	isCurrentEmpty() {
-		return this.queue.length === 0;
+		return this.getCurrentQueueLength() === 0;
 	}
 
-	isNextEmpty() {
-		return this.nextQueue.length === 0;
+	getCurrentQueueLength() {
+		return this._getCreatures().filter((c) => c.isInCurrentQueue).length;
 	}
 
-	delay(creature: Creature) {
-		// Find out if the creature is in the current queue or next queue; remove
-		// it from the queue and replace it at the end
-		const game = this.game,
-			inQueue = arrayUtils.removePos(this.queue, creature) || creature === game.activeCreature;
-		let queue = this.queue;
+	update() {
+		this._updateQueues();
+	}
 
-		if (!inQueue) {
-			queue = this.nextQueue;
-			arrayUtils.removePos(this.nextQueue, creature);
-		}
-		// Move creature to end of queue but in order w.r.t. other delayed creatures
-		for (let i = 0, len = queue.length; i < len; i++) {
-			if (!queue[i].delayed) {
-				continue;
-			}
+	private _updateQueues() {
+		this._updateCurrentQueue();
+		this._updateNextQueue();
+	}
 
-			if (queue[i].getInitiative() < creature.getInitiative()) {
-				queue.splice(i, 0, creature);
-				return;
-			}
-		}
+	private _updateCurrentQueue() {
+		const creatures = this._getCreatures().filter((c) => c.isInCurrentQueue);
+		const undelayed = creatures
+			.filter((c) => !c.isDelayed)
+			.sort((a, b) => b.getInitiative() - a.getInitiative());
+		const delayed = creatures
+			.filter((c) => c.isDelayed)
+			.sort((a, b) => b.getInitiative() - a.getInitiative());
+		this.queue = [].concat(undelayed, delayed);
+	}
 
-		queue.push(creature);
+	private _updateNextQueue() {
+		const creatures = this._getCreatures().filter((c) => c.isInNextQueue);
+		const undelayed = creatures
+			.filter((c) => !c.isDelayedInNextQueue)
+			.sort((a, b) => b.getInitiative() - a.getInitiative());
+		const delayed = creatures
+			.filter((c) => c.isDelayedInNextQueue)
+			.sort((a, b) => b.getInitiative() - a.getInitiative());
+		this.nextQueue = [].concat(undelayed, delayed);
 	}
 }

--- a/src/game.ts
+++ b/src/game.ts
@@ -153,7 +153,7 @@ export default class Game {
 		this.playersReady = false;
 		this.preventSetup = false;
 		this.animations = new Animations(this);
-		this.queue = new CreatureQueue(this);
+		this.queue = new CreatureQueue(() => this.creatures);
 		this.creatureData = [];
 		this.pause = false;
 		this.gameState = 'initialized';
@@ -745,23 +745,10 @@ export default class Game {
 	 * Replace the current queue with the next queue
 	 */
 	nextRound() {
-		let totalCreatures = this.creatures.length,
-			i;
-
 		this.turn++;
 		this.log('Round ' + this.turn, 'roundmarker', true);
-		this.queue.nextRound();
-
-		// Resets values
-		for (i = 0; i < totalCreatures; i++) {
-			if (this.creatures[i]) {
-				this.creatures[i].delayable = true;
-				this.creatures[i].delayed = false;
-			}
-		}
-
+		this.queue.update();
 		this.onStartOfRound();
-
 		this.nextCreature();
 	}
 
@@ -790,7 +777,7 @@ export default class Game {
 					this.nextRound(); // Switch to the next Round
 					return;
 				} else {
-					const next = this.queue.dequeue();
+					const next = this.queue.queue[0];
 					if (this.activeCreature && this.activeCreature) {
 						differentPlayer = this.activeCreature.player != next.player;
 					} else {
@@ -936,12 +923,7 @@ export default class Game {
 			this.turnThrottle = false;
 			this.UI.btnSkipTurn.changeState('normal');
 
-			if (
-				this.activeCreature &&
-				!this.activeCreature.hasWait &&
-				this.activeCreature.delayable &&
-				!this.queue.isCurrentEmpty()
-			) {
+			if (this.activeCreature?.canWait && this.queue.queue.length > 1) {
 				this.UI.btnDelay.changeState('normal');
 			}
 
@@ -955,11 +937,9 @@ export default class Game {
 			const p = this.activeCreature.player;
 			p.totalTimePool = p.totalTimePool - (skipTurn.valueOf() - p.startTime.valueOf());
 			this.pauseTime = 0;
-			this.activeCreature.deactivate(false);
+			this.activeCreature.deactivate('turn-end');
+			this.queue.update();
 			this.nextCreature();
-
-			// Reset temporary Creature
-			this.queue.tempCreature = {};
 		}
 	}
 
@@ -977,11 +957,7 @@ export default class Game {
 			return;
 		}
 
-		if (
-			(this.activeCreature && this.activeCreature.hasWait) ||
-			(this.activeCreature && !this.activeCreature.delayable) ||
-			this.queue.isCurrentEmpty()
-		) {
+		if (!this.activeCreature?.canWait || this.queue.isCurrentEmpty()) {
 			return;
 		}
 
@@ -999,12 +975,7 @@ export default class Game {
 		setTimeout(() => {
 			this.turnThrottle = false;
 			this.UI.btnSkipTurn.changeState('normal');
-			if (
-				this.activeCreature &&
-				!this.activeCreature.hasWait &&
-				this.activeCreature.delayable &&
-				!this.queue.isCurrentEmpty()
-			) {
+			if (this.activeCreature?.canWait && !this.queue.isCurrentEmpty()) {
 				this.UI.btnDelay.changeState('slideIn');
 			}
 
@@ -1618,7 +1589,7 @@ export default class Game {
 		this.playersReady = false;
 		this.preventSetup = false;
 		this.animations = new Animations(this);
-		this.queue = new CreatureQueue(this);
+		this.queue = new CreatureQueue(() => this.creatures);
 		this.creatureData = [];
 		this.pause = false;
 		this.gameState = 'initialized';

--- a/src/player.ts
+++ b/src/player.ts
@@ -300,19 +300,10 @@ export class Player {
 	deactivate(): void {
 		let creature: Creature;
 		const game = this.game;
-		const count = game.creatures.length;
 
 		this.hasLost = true;
 
-		// Remove all player creatures from queues
-		for (let i = 0; i < count; i++) {
-			creature = game.creatures[i];
-
-			if (creature.player.id == this.id) {
-				game.queue.remove(creature);
-			}
-		}
-
+		game.queue.update();
 		game.updateQueueDisplay();
 
 		// Test if allie Dark Priest is dead

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -165,14 +165,7 @@ export class UI {
 				hasShortcut: true,
 				click: () => {
 					if (!this.dashopen) {
-						const creature = game.activeCreature;
-
-						if (
-							game.turnThrottle ||
-							creature.hasWait ||
-							!creature.delayable ||
-							game.queue.isCurrentEmpty()
-						) {
+						if (game.turnThrottle || !game.activeCreature?.canWait || game.queue.isCurrentEmpty()) {
 							return;
 						}
 
@@ -1796,7 +1789,7 @@ export class UI {
 							this.btnAudio.changeState(ButtonStateEnum.slideIn);
 							this.btnSkipTurn.changeState(ButtonStateEnum.slideIn);
 							this.btnFullscreen.changeState(ButtonStateEnum.slideIn);
-							if (!creature.hasWait && creature.delayable && !game.queue.isCurrentEmpty()) {
+							if (creature.canWait && game.queue.getCurrentQueueLength() > 1) {
 								this.btnDelay.changeState(ButtonStateEnum.slideIn);
 							}
 							this.checkAbilities();


### PR DESCRIPTION
bugfix: fix creature delay reset and delays across rounds
    
* Split creature.delay() into creature.hinder() and creature.delay()
* creature.hinder() is called when an attacker delays the creature
* creature.wait() is called when the player delays their own creature
* adds tests for hinder, wait and related getters
* disallows setting of `creature.delayable` and `creature.delayed`
* simplifies `src/creature_queue.ts`
    
See #2158, #2275

----

This is a large PR. Creature `delayed`/`delayable` were set in different parts of the code. And the API treated `delay()`/`delayed` as monolithic – however there were 2 distinct cases in code: 

* delays from the player deciding their own creature should "wait" and delays. These delays **do not** persist across rounds.
* delays resulting from attacks from other players – "hindering" the creature. These delays **do** persist across rounds.

These two methods are now separate: `wait()` and `hinder()`, respectively.

The creature_queue.ts also kept its own state, related to creature delay status, and had a `delay(creature:Creature)` method. Most of its methods have been removed. It now sufficient to change the creatures themselves, then call the `update` method on the CreatureQueue. 

## Future

CreatureQueue could be eliminated entirely and derived when needed.

`game` does a lot of UI calls, e.g., setting button states. Lots of care (or trial and error) is needed to tune `setTimeout`s so that the "winning" UI state ends up on screen. Using the current paradigms in the codebase, it would
simpler if `game` communicated the possible need of a UI update by dispatching a `Signal`. Then the UI could derive its state from the game. 

Likewise, `interface.js` does things like check if a button press should have an action, e.g., if `btnDelay` is pressed, it checks whether the `game.activeCreature` can be delayed. These kinds of business rules shouldn't reside in the UI. It would be simpler if it merely fired off the button press and let `game` or the creature itself decide how to respond – the OOP principle of ["tell, don't ask".](https://www.martinfowler.com/bliki/TellDontAsk.html)