### PR TITLE
Creature delay bugfix and refactor, closes #2158 #2275

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
 				"@babel/preset-typescript": "^7.21.4",
 				"@types/jest": "^29.5.0",
 				"@types/jquery": "^3.5.9",
+				"@types/underscore": "^1.11.5",
 				"@typescript-eslint/eslint-plugin": "^5.47.1",
 				"@typescript-eslint/parser": "^5.47.1",
 				"babel-jest": "^29.5.0",
@@ -3246,6 +3247,12 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
 			"integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+			"dev": true
+		},
+		"node_modules/@types/underscore": {
+			"version": "1.11.5",
+			"resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.5.tgz",
+			"integrity": "sha512-b8e//LrIlhoXaaBcMC0J/s2/lIF9y5VJYKqbW4nA+tW/nqqDk1Dacd1ULLT7zgGsKs7PGbSnqCPzqEniZ0RxYg==",
 			"dev": true
 		},
 		"node_modules/@types/ws": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 		"@babel/preset-typescript": "^7.21.4",
 		"@types/jest": "^29.5.0",
 		"@types/jquery": "^3.5.9",
+		"@types/underscore": "^1.11.5",
 		"@typescript-eslint/eslint-plugin": "^5.47.1",
 		"@typescript-eslint/parser": "^5.47.1",
 		"babel-jest": "^29.5.0",

--- a/src/__tests__/creature.ts
+++ b/src/__tests__/creature.ts
@@ -170,6 +170,7 @@ describe('Creature', () => {
 			creature.hinder();
 			expect(creature.isHindered).toBe(true);
 			creature.activate();
+			expect(creature.isHindered).toBe(true);
 			creature.deactivate('turn-end');
 			expect(creature.isHindered).toBe(false);
 		});

--- a/src/__tests__/creature.ts
+++ b/src/__tests__/creature.ts
@@ -254,7 +254,7 @@ const getGameMock = () => {
 		turn: 0,
 		creatures: [],
 		players: [],
-		queue: {},
+		queue: { update: jest.fn() },
 		updateQueueDisplay: jest.fn(),
 		grid: {
 			orderCreatureZ: jest.fn(),

--- a/src/__tests__/creature.ts
+++ b/src/__tests__/creature.ts
@@ -162,7 +162,7 @@ describe('Creature', () => {
 			const obj = getCreatureObjMock();
 			// @ts-ignore
 			const creature = new Creature(obj, game);
-			creature.displayHealthStats = () => {};
+			creature.displayHealthStats = () => undefined;
 
 			creature.activate();
 			creature.deactivate('turn-end');

--- a/src/abilities/Dark-Priest.js
+++ b/src/abilities/Dark-Priest.js
@@ -266,10 +266,6 @@ export default (G) => {
 				const creatureHasMaterializationSickness =
 					dpriest.player.summonCreaturesWithMaterializationSickness;
 
-				// Removes temporary Creature from queue when Player chooses a
-				// different Creature to materialize
-				G.queue.removeTempCreature();
-
 				// Create full temporary Creature with placeholder position to show in queue
 				crea = $j.extend(
 					crea,
@@ -284,11 +280,8 @@ export default (G) => {
 				// Make temporary Creature invisible
 				fullCrea.sprite.alpha = 0;
 
-				// Provide full Creature to Queue
-				G.queue.tempCreature = fullCrea;
-
 				// Show temporary Creature in queue
-				G.queue.addByInitiative(fullCrea, !creatureHasMaterializationSickness);
+				G.queue.update();
 				G.updateQueueDisplay();
 
 				G.grid.forEachHex(function (hex) {

--- a/src/abilities/Dark-Priest.js
+++ b/src/abilities/Dark-Priest.js
@@ -281,7 +281,6 @@ export default (G) => {
 				fullCrea.sprite.alpha = 0;
 
 				// Show temporary Creature in queue
-				G.queue.update();
 				G.updateQueueDisplay();
 
 				G.grid.forEachHex(function (hex) {

--- a/src/abilities/Knightmare.js
+++ b/src/abilities/Knightmare.js
@@ -216,7 +216,7 @@ export default (G) => {
 					return;
 				}
 
-				target.delay();
+				target.hinder();
 			},
 		},
 

--- a/src/abilities/Stomper.js
+++ b/src/abilities/Stomper.js
@@ -514,7 +514,7 @@ export default (G) => {
 						target.status.dizzy = true;
 						target.removeEffect('Earth Shaker');
 					} else {
-						target.delay(false);
+						target.hinder();
 						target.addEffect(
 							new Effect(
 								'Earth Shaker', // Name
@@ -524,8 +524,7 @@ export default (G) => {
 								{
 									// disable the ability to delay this unit as it has already been delayed
 									effectFn: () => {
-										target.delayed = true;
-										target.delayable = false;
+										target.hinder();
 									},
 									deleteTrigger: 'onEndPhase',
 									turnLifetime: 1,

--- a/src/ability.ts
+++ b/src/ability.ts
@@ -235,7 +235,6 @@ export class Ability {
 		}
 		game.signals.creature.dispatch('abilityend', { creature: this.creature });
 		game.UI.btnDelay.changeState('disabled');
-		game.activeCreature.delayable = false;
 		game.UI.selectAbility(-1);
 
 		if (this.getTrigger() === 'onQuery' && !deferredEnding) {

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -145,8 +145,9 @@ export class Creature {
 	dropCollection: Drop[];
 	protectedFromFatigue: boolean;
 	turnsActive: number;
-	delayable: boolean;
-	delayed: boolean;
+	private _nextGameTurnActive: number;
+	private _waitedTurn: number;
+	private _hinderedTurn: number;
 	materializationSickness: boolean;
 	noActionPossible: boolean;
 	destroy: any;
@@ -399,15 +400,17 @@ export class Creature {
 		}
 		// Adding Himself to creature arrays and queue
 		game.creatures[this.id] = this;
-
-		this.delayable = true;
-		this.delayed = false;
 		if (typeof obj.materializationSickness !== 'undefined') {
 			this.materializationSickness = obj.materializationSickness;
 		} else {
 			this.materializationSickness = this.isDarkPriest() ? false : true;
 		}
 		this.noActionPossible = false;
+
+		this._nextGameTurnActive =
+			!this.materializationSickness || this.isDarkPriest() ? this.game.turn : this.game.turn + 1;
+		this._waitedTurn = -1;
+		this._hinderedTurn = -1;
 	}
 
 	/**
@@ -420,15 +423,11 @@ export class Creature {
 		priest who must always be in the next queue to properly start the game. */
 		const alsoAddToCurrentQueue = disableMaterializationSickness && !this.isDarkPriest();
 
-		game.queue.addByInitiative(this, alsoAddToCurrentQueue);
-
 		if (disableMaterializationSickness) {
 			this.materializationSickness = false;
 		}
 
-		// Remove temporary Creature to prevent duplicates when the actual
-		// materialized Creature with correct position is added to the queue
-		game.queue.removeTempCreature();
+		game.queue.update();
 		game.updateQueueDisplay();
 
 		game.grid.orderCreatureZ();
@@ -564,61 +563,99 @@ export class Creature {
 		}, 1000);
 	}
 
-	/* deactivate(wait)
+	/**
+	 * Deactivate the creature. Called when the creature is active, then is no longer active.
 	 *
-	 * wait :	Boolean :	Deactivate while waiting or not
-	 *
-	 * Preview the creature position at the given coordinates
-	 *
+	 * @param {'wait' | 'turn-end'} reason: Why is the creature deactivated?
 	 */
-	deactivate(wait: boolean) {
+	deactivate(reason: 'wait' | 'turn-end') {
 		const game = this.game;
-		this.delayed = wait;
-		this.hasWait = this.delayed;
+		this.hasWait = this.isDelayed;
 		this.status.frozen = false;
 		this.status.cryostasis = false;
 		this.status.dizzy = false;
 
 		// Effects triggers
-		if (!wait) {
+		if (reason === 'turn-end') {
 			this.turnsActive += 1;
+			this._nextGameTurnActive = game.turn + 1;
 			// @ts-expect-error 2554
 			game.onEndPhase(this);
 		}
-
-		this.delayable = false;
 	}
 
-	/* wait()
-	 *
-	 * Move the creature to the end of the queue
-	 *
+	get isInCurrentQueue() {
+		return !this.dead && !this.temp && this._nextGameTurnActive <= this.game.turn;
+	}
+
+	get isInNextQueue() {
+		return !this.dead;
+	}
+
+	get isDelayedInNextQueue(): null | boolean {
+		if (!this.isInNextQueue) return null;
+		return !this.isInCurrentQueue && this.isDelayed;
+	}
+
+	/**
+	 * @deprecated Use isDelayed
 	 */
-	wait() {
-		let abilityAvailable = false;
+	get delayed() {
+		return this.isDelayed;
+	}
 
-		if (this.delayed) {
-			return;
-		}
+	get isDelayed() {
+		return this.isWaiting || this.isHindered;
+	}
 
-		// If at least one ability has not been used
-		this.abilities.forEach((ability) => {
-			abilityAvailable = abilityAvailable || !ability.used;
-		});
+	get isWaiting() {
+		return this._waitedTurn >= this.turnsActive;
+	}
 
-		if (this.remainingMove > 0 && abilityAvailable) {
-			this.delay();
-			this.deactivate(true);
+	get isHindered() {
+		return this._hinderedTurn >= this.turnsActive;
+	}
+
+	/**
+	 * @deprecated Use canWait
+	 */
+	get delayable() {
+		return this.canWait;
+	}
+
+	/**
+	 * Is waiting possible?
+	 */
+	get canWait() {
+		const hasUnusedAbilities = this.abilities.some((a) => !a.used);
+		return !this.isDelayed && this.remainingMove > 0 && hasUnusedAbilities;
+	}
+
+	/**
+	 * The creature waits. It will have its turn at the end of the round.
+	 * The player has decided to delay the creature until the end of the turn.
+	 */
+	wait(): void {
+		if (this.canWait) {
+			const game = this.game;
+
+			this._waitedTurn = this.turnsActive;
+			this.hint('Delayed', 'msg_effects');
+			game.queue.update();
+			game.updateQueueDisplay();
+			this.deactivate('wait');
 		}
 	}
 
-	delay() {
+	/**
+	 * A creature's turn is delayed as part of an attack from another creature.
+	 */
+	hinder(): void {
 		const game = this.game;
 
-		game.queue.delay(this);
-		this.delayable = false;
-		this.delayed = true;
+		this._hinderedTurn = this.turnsActive;
 		this.hint('Delayed', 'msg_effects');
+		game.queue.update();
 		game.updateQueueDisplay();
 	}
 
@@ -686,7 +723,6 @@ export class Creature {
 							},
 						});
 					}
-					args.creature.delayable = false;
 					game.UI.btnDelay.changeState('disabled');
 					args.creature.moveTo(hex, {
 						animation: args.creature.movementType() === 'flying' ? 'fly' : 'walk',
@@ -702,11 +738,7 @@ export class Creature {
 		if (!o.isAbility) {
 			if (game.UI.selectedAbility != -1) {
 				this.hint('Canceled', 'gamehintblack');
-
-				// If this Creature is Dark Priest, remove temporary Creature in queue
-				if (this.isDarkPriest()) {
-					game.queue.removeTempCreature();
-				}
+				game.queue.update();
 			}
 
 			$j('#abilities .ability').removeClass('active');
@@ -1632,6 +1664,7 @@ export class Creature {
 	}
 
 	hint(text: string, cssClass: string) {
+		if (typeof Phaser === 'undefined') return;
 		const game = this.game,
 			tooltipSpeed = 250,
 			tooltipDisplaySpeed = 500,
@@ -1941,7 +1974,7 @@ export class Creature {
 
 		this.cleanHex();
 
-		game.queue.remove(this);
+		game.queue.update();
 		game.updateQueueDisplay();
 		game.grid.updateDisplay();
 

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -641,7 +641,6 @@ export class Creature {
 
 			this._waitedTurn = this.turnsActive;
 			this.hint('Delayed', 'msg_effects');
-			game.queue.update();
 			game.updateQueueDisplay();
 			this.deactivate('wait');
 		}
@@ -655,7 +654,6 @@ export class Creature {
 
 		this._hinderedTurn = this.turnsActive;
 		this.hint('Delayed', 'msg_effects');
-		game.queue.update();
 		game.updateQueueDisplay();
 	}
 
@@ -738,7 +736,6 @@ export class Creature {
 		if (!o.isAbility) {
 			if (game.UI.selectedAbility != -1) {
 				this.hint('Canceled', 'gamehintblack');
-				game.queue.update();
 			}
 
 			$j('#abilities .ability').removeClass('active');

--- a/src/creature_queue.ts
+++ b/src/creature_queue.ts
@@ -2,13 +2,31 @@ import { Creature } from './creature';
 
 export class CreatureQueue {
 	private _getCreatures: () => Creature[];
-	queue: Creature[];
-	nextQueue: Creature[];
 
 	constructor(getCreatures: () => Creature[]) {
 		this._getCreatures = getCreatures;
-		this.queue = [];
-		this.nextQueue = [];
+	}
+
+	get queue() {
+		const creatures = this._getCreatures().filter((c) => c.isInCurrentQueue);
+		const undelayed = creatures
+			.filter((c) => !c.isDelayed)
+			.sort((a, b) => b.getInitiative() - a.getInitiative());
+		const delayed = creatures
+			.filter((c) => c.isDelayed)
+			.sort((a, b) => b.getInitiative() - a.getInitiative());
+		return [].concat(undelayed, delayed);
+	}
+
+	get nextQueue() {
+		const creatures = this._getCreatures().filter((c) => c.isInNextQueue);
+		const undelayed = creatures
+			.filter((c) => !c.isDelayedInNextQueue)
+			.sort((a, b) => b.getInitiative() - a.getInitiative());
+		const delayed = creatures
+			.filter((c) => c.isDelayedInNextQueue)
+			.sort((a, b) => b.getInitiative() - a.getInitiative());
+		return [].concat(undelayed, delayed);
 	}
 
 	isCurrentEmpty() {
@@ -19,34 +37,8 @@ export class CreatureQueue {
 		return this._getCreatures().filter((c) => c.isInCurrentQueue).length;
 	}
 
-	update() {
-		this._updateQueues();
-	}
-
-	private _updateQueues() {
-		this._updateCurrentQueue();
-		this._updateNextQueue();
-	}
-
-	private _updateCurrentQueue() {
-		const creatures = this._getCreatures().filter((c) => c.isInCurrentQueue);
-		const undelayed = creatures
-			.filter((c) => !c.isDelayed)
-			.sort((a, b) => b.getInitiative() - a.getInitiative());
-		const delayed = creatures
-			.filter((c) => c.isDelayed)
-			.sort((a, b) => b.getInitiative() - a.getInitiative());
-		this.queue = [].concat(undelayed, delayed);
-	}
-
-	private _updateNextQueue() {
-		const creatures = this._getCreatures().filter((c) => c.isInNextQueue);
-		const undelayed = creatures
-			.filter((c) => !c.isDelayedInNextQueue)
-			.sort((a, b) => b.getInitiative() - a.getInitiative());
-		const delayed = creatures
-			.filter((c) => c.isDelayedInNextQueue)
-			.sort((a, b) => b.getInitiative() - a.getInitiative());
-		this.nextQueue = [].concat(undelayed, delayed);
-	}
+	/**
+	 * @deprecated CreatureQueue is derived on the fly. No need to update.
+	 */
+	update() {}
 }

--- a/src/creature_queue.ts
+++ b/src/creature_queue.ts
@@ -1,103 +1,52 @@
-import Game from './game';
 import { Creature } from './creature';
-import * as arrayUtils from './utility/arrayUtils';
 
 export class CreatureQueue {
-	game: Game;
+	private _getCreatures: () => Creature[];
 	queue: Creature[];
 	nextQueue: Creature[];
-	tempCreature: Creature | Record<string, never>;
 
-	constructor(game: Game) {
-		this.game = game;
+	constructor(getCreatures: () => Creature[]) {
+		this._getCreatures = getCreatures;
 		this.queue = [];
 		this.nextQueue = [];
-		this.tempCreature = {};
-	}
-
-	/**
-	 * Add a creature to the next turn's queue by initiative, and optionally the current
-	 * turn's queue.
-	 *
-	 * @param {Creature} creature The creature to add.
-	 * @param {boolean} alsoAddToCurrentQueue Also add the creature to the current
-	 * turn's queue. Doing so lets a creature act in the same turn it was summoned.
-	 */
-	addByInitiative(creature: Creature, alsoAddToCurrentQueue = true) {
-		const queues = [this.nextQueue];
-
-		if (alsoAddToCurrentQueue) {
-			queues.push(this.queue);
-		}
-
-		queues.forEach((queue) => {
-			for (let i = 0; i < queue.length; i++) {
-				const queueItem = queue[i];
-
-				if (queueItem.delayed || queueItem.getInitiative() < creature.getInitiative()) {
-					queue.splice(i, 0, creature);
-					return;
-				}
-			}
-
-			queue.push(creature);
-		});
-	}
-
-	dequeue() {
-		return this.queue.splice(0, 1)[0];
-	}
-
-	remove(creature: Creature) {
-		arrayUtils.removePos(this.queue, creature);
-		arrayUtils.removePos(this.nextQueue, creature);
-	}
-
-	// Removes temporary Creature from queue
-	removeTempCreature() {
-		if (this.tempCreature instanceof Creature) {
-			this.remove(this.tempCreature);
-		}
-	}
-
-	nextRound() {
-		// Copy next queue into current queue
-		this.queue = this.nextQueue.slice(0);
-		// Sort next queue by initiative (current queue may be reordered) descending
-		this.nextQueue = this.nextQueue.sort((a, b) => b.getInitiative() - a.getInitiative());
 	}
 
 	isCurrentEmpty() {
-		return this.queue.length === 0;
+		return this.getCurrentQueueLength() === 0;
 	}
 
-	isNextEmpty() {
-		return this.nextQueue.length === 0;
+	getCurrentQueueLength() {
+		return this._getCreatures().filter((c) => c.isInCurrentQueue).length;
 	}
 
-	delay(creature: Creature) {
-		// Find out if the creature is in the current queue or next queue; remove
-		// it from the queue and replace it at the end
-		const game = this.game,
-			inQueue = arrayUtils.removePos(this.queue, creature) || creature === game.activeCreature;
-		let queue = this.queue;
+	update() {
+		this._updateQueues();
+	}
 
-		if (!inQueue) {
-			queue = this.nextQueue;
-			arrayUtils.removePos(this.nextQueue, creature);
-		}
-		// Move creature to end of queue but in order w.r.t. other delayed creatures
-		for (let i = 0, len = queue.length; i < len; i++) {
-			if (!queue[i].delayed) {
-				continue;
-			}
+	private _updateQueues() {
+		this._updateCurrentQueue();
+		this._updateNextQueue();
+	}
 
-			if (queue[i].getInitiative() < creature.getInitiative()) {
-				queue.splice(i, 0, creature);
-				return;
-			}
-		}
+	private _updateCurrentQueue() {
+		const creatures = this._getCreatures().filter((c) => c.isInCurrentQueue);
+		const undelayed = creatures
+			.filter((c) => !c.isDelayed)
+			.sort((a, b) => b.getInitiative() - a.getInitiative());
+		const delayed = creatures
+			.filter((c) => c.isDelayed)
+			.sort((a, b) => b.getInitiative() - a.getInitiative());
+		this.queue = [].concat(undelayed, delayed);
+	}
 
-		queue.push(creature);
+	private _updateNextQueue() {
+		const creatures = this._getCreatures().filter((c) => c.isInNextQueue);
+		const undelayed = creatures
+			.filter((c) => !c.isDelayedInNextQueue)
+			.sort((a, b) => b.getInitiative() - a.getInitiative());
+		const delayed = creatures
+			.filter((c) => c.isDelayedInNextQueue)
+			.sort((a, b) => b.getInitiative() - a.getInitiative());
+		this.nextQueue = [].concat(undelayed, delayed);
 	}
 }

--- a/src/game.ts
+++ b/src/game.ts
@@ -746,7 +746,7 @@ export default class Game {
 	 */
 	nextRound() {
 		this.turn++;
-		this.log('Round ' + this.turn, 'roundmarker', true);
+		this.log(`Round ${this.turn + 1}`, 'roundmarker', true);
 		this.onStartOfRound();
 		this.nextCreature();
 	}

--- a/src/game.ts
+++ b/src/game.ts
@@ -746,7 +746,7 @@ export default class Game {
 	 */
 	nextRound() {
 		this.turn++;
-		this.log(`Round ${this.turn + 1}`, 'roundmarker', true);
+		this.log(`Round ${this.turn}`, 'roundmarker', true);
 		this.onStartOfRound();
 		this.nextCreature();
 	}
@@ -772,7 +772,7 @@ export default class Game {
 
 				let differentPlayer = false;
 
-				if (this.queue.isCurrentEmpty()) {
+				if (this.queue.isCurrentEmpty() || this.turn === 0) {
 					this.nextRound(); // Switch to the next Round
 					return;
 				} else {
@@ -806,7 +806,7 @@ export default class Game {
 				// console.log(this.activeCreature);
 
 				// Show mini tutorial in the first round for each player
-				if (this.turn == 0) {
+				if (this.turn == 1) {
 					this.log('The active unit has a flashing hexagon');
 					this.log('It uses a plasma field to protect itself');
 					this.log('Its portrait is displayed in the upper left');

--- a/src/game.ts
+++ b/src/game.ts
@@ -153,7 +153,7 @@ export default class Game {
 		this.playersReady = false;
 		this.preventSetup = false;
 		this.animations = new Animations(this);
-		this.queue = new CreatureQueue(this);
+		this.queue = new CreatureQueue(() => this.creatures);
 		this.creatureData = [];
 		this.pause = false;
 		this.gameState = 'initialized';
@@ -745,23 +745,10 @@ export default class Game {
 	 * Replace the current queue with the next queue
 	 */
 	nextRound() {
-		let totalCreatures = this.creatures.length,
-			i;
-
 		this.turn++;
 		this.log('Round ' + this.turn, 'roundmarker', true);
-		this.queue.nextRound();
-
-		// Resets values
-		for (i = 0; i < totalCreatures; i++) {
-			if (this.creatures[i]) {
-				this.creatures[i].delayable = true;
-				this.creatures[i].delayed = false;
-			}
-		}
-
+		this.queue.update();
 		this.onStartOfRound();
-
 		this.nextCreature();
 	}
 
@@ -790,7 +777,7 @@ export default class Game {
 					this.nextRound(); // Switch to the next Round
 					return;
 				} else {
-					const next = this.queue.dequeue();
+					const next = this.queue.queue[0];
 					if (this.activeCreature && this.activeCreature) {
 						differentPlayer = this.activeCreature.player != next.player;
 					} else {
@@ -906,9 +893,9 @@ export default class Game {
 	 */
 	skipTurn(o?) {
 		// NOTE: If skipping a turn and there is a temp creature, remove it.
-		this.queue.removeTempCreature();
+		this.creatures = this.creatures.filter((c) => !c.temp);
 
-		// NOTE: Send skip turn to server
+		// Send skip turn to server
 
 		if (this.turnThrottle) {
 			return;
@@ -936,12 +923,7 @@ export default class Game {
 			this.turnThrottle = false;
 			this.UI.btnSkipTurn.changeState('normal');
 
-			if (
-				this.activeCreature &&
-				!this.activeCreature.hasWait &&
-				this.activeCreature.delayable &&
-				!this.queue.isCurrentEmpty()
-			) {
+			if (this.activeCreature?.canWait && this.queue.queue.length > 1) {
 				this.UI.btnDelay.changeState('normal');
 			}
 
@@ -955,11 +937,9 @@ export default class Game {
 			const p = this.activeCreature.player;
 			p.totalTimePool = p.totalTimePool - (skipTurn.valueOf() - p.startTime.valueOf());
 			this.pauseTime = 0;
-			this.activeCreature.deactivate(false);
+			this.activeCreature.deactivate('turn-end');
+			this.queue.update();
 			this.nextCreature();
-
-			// Reset temporary Creature
-			this.queue.tempCreature = {};
 		}
 	}
 
@@ -977,11 +957,7 @@ export default class Game {
 			return;
 		}
 
-		if (
-			(this.activeCreature && this.activeCreature.hasWait) ||
-			(this.activeCreature && !this.activeCreature.delayable) ||
-			this.queue.isCurrentEmpty()
-		) {
+		if (!this.activeCreature?.canWait || this.queue.isCurrentEmpty()) {
 			return;
 		}
 
@@ -999,12 +975,7 @@ export default class Game {
 		setTimeout(() => {
 			this.turnThrottle = false;
 			this.UI.btnSkipTurn.changeState('normal');
-			if (
-				this.activeCreature &&
-				!this.activeCreature.hasWait &&
-				this.activeCreature.delayable &&
-				!this.queue.isCurrentEmpty()
-			) {
+			if (this.activeCreature?.canWait && !this.queue.isCurrentEmpty()) {
 				this.UI.btnDelay.changeState('slideIn');
 			}
 
@@ -1618,7 +1589,7 @@ export default class Game {
 		this.playersReady = false;
 		this.preventSetup = false;
 		this.animations = new Animations(this);
-		this.queue = new CreatureQueue(this);
+		this.queue = new CreatureQueue(() => this.creatures);
 		this.creatureData = [];
 		this.pause = false;
 		this.gameState = 'initialized';

--- a/src/game.ts
+++ b/src/game.ts
@@ -747,7 +747,6 @@ export default class Game {
 	nextRound() {
 		this.turn++;
 		this.log('Round ' + this.turn, 'roundmarker', true);
-		this.queue.update();
 		this.onStartOfRound();
 		this.nextCreature();
 	}
@@ -938,7 +937,6 @@ export default class Game {
 			p.totalTimePool = p.totalTimePool - (skipTurn.valueOf() - p.startTime.valueOf());
 			this.pauseTime = 0;
 			this.activeCreature.deactivate('turn-end');
-			this.queue.update();
 			this.nextCreature();
 		}
 	}

--- a/src/game.ts
+++ b/src/game.ts
@@ -806,7 +806,7 @@ export default class Game {
 				// console.log(this.activeCreature);
 
 				// Show mini tutorial in the first round for each player
-				if (this.turn == 1) {
+				if (this.turn == 0) {
 					this.log('The active unit has a flashing hexagon');
 					this.log('It uses a plasma field to protect itself');
 					this.log('Its portrait is displayed in the upper left');

--- a/src/player.ts
+++ b/src/player.ts
@@ -300,19 +300,10 @@ export class Player {
 	deactivate(): void {
 		let creature: Creature;
 		const game = this.game;
-		const count = game.creatures.length;
 
 		this.hasLost = true;
 
-		// Remove all player creatures from queues
-		for (let i = 0; i < count; i++) {
-			creature = game.creatures[i];
-
-			if (creature.player.id == this.id) {
-				game.queue.remove(creature);
-			}
-		}
-
+		game.queue.update();
 		game.updateQueueDisplay();
 
 		// Test if allie Dark Priest is dead

--- a/src/player.ts
+++ b/src/player.ts
@@ -303,7 +303,6 @@ export class Player {
 
 		this.hasLost = true;
 
-		game.queue.update();
 		game.updateQueueDisplay();
 
 		// Test if allie Dark Priest is dead

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -165,14 +165,7 @@ export class UI {
 				hasShortcut: true,
 				click: () => {
 					if (!this.dashopen) {
-						const creature = game.activeCreature;
-
-						if (
-							game.turnThrottle ||
-							creature.hasWait ||
-							!creature.delayable ||
-							game.queue.isCurrentEmpty()
-						) {
+						if (game.turnThrottle || !game.activeCreature?.canWait || game.queue.isCurrentEmpty()) {
 							return;
 						}
 
@@ -1796,7 +1789,7 @@ export class UI {
 							this.btnAudio.changeState(ButtonStateEnum.slideIn);
 							this.btnSkipTurn.changeState(ButtonStateEnum.slideIn);
 							this.btnFullscreen.changeState(ButtonStateEnum.slideIn);
-							if (!creature.hasWait && creature.delayable && !game.queue.isCurrentEmpty()) {
+							if (creature.canWait && game.queue.getCurrentQueueLength() > 1) {
 								this.btnDelay.changeState(ButtonStateEnum.slideIn);
 							}
 							this.checkAbilities();

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -2026,7 +2026,7 @@ export class UI {
 	 */
 	updateQueueDisplay() {
 		const game = this.game;
-		this.queue.setQueue(game.queue, game.activeCreature, game.turn);
+		this.queue.setQueue(game.queue, game.turn);
 	}
 
 	xrayQueue(creaID) {

--- a/src/ui/queue.ts
+++ b/src/ui/queue.ts
@@ -556,7 +556,7 @@ class TurnEndMarkerVignette extends Vignette {
 	getHTML() {
 		return `<div turn="${this.turnNumber}" roundmarker="1" class="vignette roundmarker">
 			<div class="frame"></div>
-            <div class="stats">Round ${this.turnNumber + 1}</div>
+            <div class="stats">Round ${this.turnNumber}</div>
 		</div>`;
 	}
 

--- a/src/ui/queue.ts
+++ b/src/ui/queue.ts
@@ -1,6 +1,6 @@
-/* eslint-env dom, mocha */
 import { throttle } from 'underscore';
 import { Creature } from '../creature';
+import { CreatureQueue } from '../creature_queue';
 
 const CONST = {
 	animDurationMS: 500,
@@ -18,27 +18,12 @@ export class Queue {
 		this.element.innerHTML = '';
 		this.vignettes = [];
 		this.eventHandlers = eventHandlers;
-
-		refactor.stopGap.init();
 	}
 
-	setQueue(creatureQueue, activeCreature, turnNumber: number) {
-		refactor.stopGap.setTurnNumber(turnNumber);
-		refactor.stopGap.setCreatureQueue(creatureQueue);
-
-		const creatures = refactor.creatureQueue.getCurrentQueue(creatureQueue, activeCreature);
-		const nextCreatures = refactor.creatureQueue.getNextQueue(creatureQueue);
-
-		creatures.forEach((c) =>
-			refactor.stopGap.updateCreatureDelayStatus(c, creatures, nextCreatures, turnNumber),
-		);
-		nextCreatures.forEach((c) =>
-			refactor.stopGap.updateCreatureDelayStatus(c, creatures, nextCreatures, turnNumber + 1),
-		);
-
+	setQueue(creatureQueue: CreatureQueue, turnNumber: number) {
 		const nextVignettes = Queue.getNextVignettes(
-			creatures,
-			nextCreatures,
+			creatureQueue.queue,
+			creatureQueue.nextQueue,
 			turnNumber,
 			this.eventHandlers,
 		);
@@ -49,8 +34,7 @@ export class Queue {
 		this.vignettes.forEach((v) => v.refresh());
 	}
 
-	empty(immediately) {
-		refactor.stopGap.init();
+	empty(immediately: number) {
 		if (immediately === Queue.IMMEDIATE) {
 			this.vignettes = [];
 			this.element.innerHTML = '';
@@ -63,37 +47,45 @@ export class Queue {
 		this.vignettes.forEach((v) => v.xray(creatureId));
 	}
 
-	bounce(creatureId, bounceHeight = 40) {
+	bounce(creatureId: number, bounceHeight = 40) {
 		Queue.throttledBounce(this.vignettes, creatureId, bounceHeight);
 	}
 
-	private setVignettes(nextVignettes) {
+	private setVignettes(nextVignettes: Vignette[]) {
 		const prevVs = this.vignettes;
 		this.vignettes = Queue.reuseOldDomElements(prevVs, nextVignettes);
 		Queue.deleteRemovedVignettes(this.vignettes, prevVs);
 		Queue.insertUpdateNextVignettes(this.vignettes, prevVs, this.element);
 	}
 
-	private static throttledBounce = throttle((vignettes, creatureId, bounceHeight) => {
-		let x = 0;
-		vignettes.forEach((v, i) => {
-			v.bounce(creatureId, i, x, bounceHeight);
-			x += v.getWidth();
-		});
-	}, 500);
+	private static throttledBounce = throttle(
+		(vignettes: Vignette[], creatureId: number, bounceHeight: number) => {
+			let x = 0;
+			vignettes.forEach((v, i) => {
+				v.bounce(creatureId, i, x, bounceHeight);
+				x += v.getWidth();
+			});
+		},
+		500,
+	);
 
-	private static getNextVignettes(creatures, creaturesNext, turnNum, eventHandlers) {
-		const isDelayedCurr = (c) => refactor.creature.getIsDelayed(c, turnNum);
-		const [undelayedCsCurr, delayedCsCurr] = utils.partitionAt(creatures, isDelayedCurr);
+	private static getNextVignettes(
+		creatures: Creature[],
+		creaturesNext: Creature[],
+		turnNum: number,
+		eventHandlers: QueueEventHandlers,
+	) {
+		const undelayedCsCurr = creatures.filter((c) => !c.isDelayed);
+		const delayedCsCurr = creatures.filter((c) => c.isDelayed);
 		const hasDelayedCurr = delayedCsCurr.length > 0;
 
-		const isDelayedNext = (c) => refactor.creature.getIsDelayed(c, turnNum + 1);
-		const [undelayedCsNext, delayedCsNext] = utils.partitionAt(creaturesNext, isDelayedNext);
+		const undelayedCsNext = creaturesNext.filter((c) => !c.isDelayedInNextQueue);
+		const delayedCsNext = creaturesNext.filter((c) => c.isDelayedInNextQueue);
 		const hasDelayedNext = delayedCsNext.length > 0;
 
 		const is1stCreature = utils.trueIfFirstElseFalse();
 
-		const newCreatureVCurr = (c) =>
+		const newCreatureVCurr = (c: Creature) =>
 			new CreatureVignette(c, turnNum, eventHandlers, is1stCreature());
 		const undelayedVsCurr = undelayedCsCurr.map(newCreatureVCurr);
 		const delayMarkerVCurr = hasDelayedCurr
@@ -103,7 +95,7 @@ export class Queue {
 
 		const turnEndMarkerV = [new TurnEndMarkerVignette(turnNum, eventHandlers)];
 
-		const newCreatureVNext = (c) =>
+		const newCreatureVNext = (c: Creature) =>
 			new CreatureVignette(c, turnNum + 1, eventHandlers, is1stCreature());
 		const undelayedVsNext = undelayedCsNext.map(newCreatureVNext);
 		const delayMarkerVNext = hasDelayedNext
@@ -146,13 +138,13 @@ export class Queue {
 		return [].concat(undelayedVsCurr, delayMarkerVCurr, delayedVsCurr, vsNext);
 	}
 
-	private static reuseOldDomElements(oldVignettes, newVignettes) {
+	private static reuseOldDomElements(oldVignettes: Vignette[], newVignettes: Vignette[]) {
 		/**
 		 * NOTE: For every vignette in newVignettes, if there's
 		 * an equivalent in oldVignettes, use its DOM element.
 		 * This keeps animations, transitions, and styles from breaking.
 		 */
-		const oldVDict = utils.arrToDict(oldVignettes, (v) => v.getHash());
+		const oldVDict = utils.arrToDict(oldVignettes, (v: Vignette) => v.getHash());
 		for (const newV of newVignettes) {
 			const hash = newV.getHash();
 			if (oldVDict.hasOwnProperty(hash)) {
@@ -163,11 +155,11 @@ export class Queue {
 		return newVignettes;
 	}
 
-	private static deleteRemovedVignettes(nextVignettes, prevVignettes) {
+	private static deleteRemovedVignettes(nextVignettes: Vignette[], prevVignettes: Vignette[]) {
 		const nextHashes = new Set(nextVignettes.map((v) => v.getHash()));
 		const vignettesDeletedAtFront = utils.takeWhile(
 			prevVignettes,
-			(v) => !nextHashes.has(v.getHash()),
+			(v: Vignette) => !nextHashes.has(v.getHash()),
 		);
 		const spaceDeletedAtFrontOfQueue = vignettesDeletedAtFront.reduce(
 			(acc, v) => acc + v.getWidth(),
@@ -190,10 +182,16 @@ export class Queue {
 		});
 	}
 
-	private static insertUpdateNextVignettes(nextVignettes, prevVignettes, containerElement) {
+	private static insertUpdateNextVignettes(
+		nextVignettes: Vignette[],
+		prevVignettes: Vignette[],
+		containerElement: HTMLElement,
+	) {
 		const prevHashes = new Set(prevVignettes.map((v) => v.getHash()));
 		const nextHashes = new Set(nextVignettes.map((v) => v.getHash()));
-		const [updateHashes, insertHashes] = utils.splitSetBy(nextHashes, (h) => prevHashes.has(h));
+		const [updateHashes, insertHashes] = utils.splitSetBy(nextHashes, (h: string) =>
+			prevHashes.has(h),
+		);
 
 		let x = 0;
 		nextVignettes.forEach((v, i) => {
@@ -223,7 +221,7 @@ class Vignette {
 		return `<div></div>`;
 	}
 
-	insert(containerElement, queuePosition, x) {
+	insert(containerElement: HTMLElement, queuePosition: number, x: number) {
 		this.queuePosition = queuePosition;
 		if (this.el) {
 			this.el.remove();
@@ -239,13 +237,13 @@ class Vignette {
 		return this;
 	}
 
-	update(queuePosition, x) {
+	update(queuePosition: number, x: number) {
 		this.queuePosition = queuePosition;
 		this.animateUpdate(queuePosition, x);
 		return this;
 	}
 
-	delete(queuePosition, x) {
+	delete(queuePosition: number, x: number) {
 		this.queuePosition = queuePosition;
 		this.animateDelete(queuePosition, x).onfinish = () => {
 			this.el.remove();
@@ -253,7 +251,7 @@ class Vignette {
 		return this;
 	}
 
-	deleteFromFront(queuePosition, x, spaceDeletedAtFrontOfQueue) {
+	deleteFromFront(queuePosition: number, x: number, spaceDeletedAtFrontOfQueue: number) {
 		this.queuePosition = queuePosition;
 		this.animateDeleteFromFront(queuePosition, x, spaceDeletedAtFrontOfQueue).onfinish = () => {
 			this.el.remove();
@@ -261,7 +259,7 @@ class Vignette {
 		return this;
 	}
 
-	animateInsert(queuePosition, x) {
+	animateInsert(queuePosition: number, x: number) {
 		const keyframes = [
 			{
 				transform: `translateX(${x + 500}px) translateY(-100px) scale(1)`,
@@ -282,7 +280,7 @@ class Vignette {
 		return animation;
 	}
 
-	animateUpdate(queuePosition, x) {
+	animateUpdate(queuePosition: number, x: number) {
 		const keyframes = [{ transform: `translateX(${x}px) translateY(0px) scale(1)` }];
 		const animation = this.el.animate(keyframes, {
 			duration: CONST.animDurationMS,
@@ -292,7 +290,7 @@ class Vignette {
 		return animation;
 	}
 
-	animateDelete(queuePosition, x) {
+	animateDelete(queuePosition: number, x: number) {
 		const keyframes = [{ transform: `translateX(${x}px) translateY(-100px) scale(1)` }];
 		const animation = this.el.animate(keyframes, {
 			duration: CONST.animDurationMS,
@@ -302,7 +300,7 @@ class Vignette {
 		return animation;
 	}
 
-	animateDeleteFromFront(queuePosition, x, emptySpaceAtFrontOfQueue) {
+	animateDeleteFromFront(queuePosition: number, x: number, emptySpaceAtFrontOfQueue: number) {
 		const keyframes = [
 			{ transform: `translateX(${x - emptySpaceAtFrontOfQueue}px) translateY(0px) scale(1)` },
 		];
@@ -314,7 +312,7 @@ class Vignette {
 		return animation;
 	}
 
-	animateBounce(queuePosition, x, bounceH) {
+	animateBounce(queuePosition: number, x: number, bounceH: number) {
 		const NUM_BOUNCES = 3;
 		const BOUNCE_MS = 280 * NUM_BOUNCES;
 
@@ -358,14 +356,14 @@ class Vignette {
 }
 
 class CreatureVignette extends Vignette {
-	creature;
+	creature: Creature;
 	isActiveCreature: boolean;
 	turnNumberIsCurrentTurn: boolean;
 
 	constructor(
-		creature,
-		turnNumber,
-		eventHandlers,
+		creature: Creature,
+		turnNumber: number,
+		eventHandlers: QueueEventHandlers,
 		isActiveCreature = false,
 		turnNumberIsCurrentTurn = true,
 	) {
@@ -393,7 +391,7 @@ class CreatureVignette extends Vignette {
 			</div>`;
 	}
 
-	setCreature(creature) {
+	setCreature(creature: Creature) {
 		this.creature = creature;
 	}
 
@@ -427,7 +425,7 @@ class CreatureVignette extends Vignette {
 			cl.add('materialized');
 		}
 
-		if (refactor.creature.getIsDelayed(this.creature) && this.turnNumberIsCurrentTurn) {
+		if (this.creature.isDelayed && this.turnNumberIsCurrentTurn) {
 			cl.add('delayed');
 		}
 
@@ -440,7 +438,7 @@ class CreatureVignette extends Vignette {
 		statsEl.textContent = stats;
 	}
 
-	animateInsert(queuePosition, x) {
+	animateInsert(queuePosition: number, x: number) {
 		const scale = this.isActiveCreature ? 1.25 : 1.0;
 		const keyframes = [
 			{
@@ -462,7 +460,7 @@ class CreatureVignette extends Vignette {
 		return animation;
 	}
 
-	animateUpdate(queuePosition, x) {
+	animateUpdate(queuePosition: number, x: number) {
 		const scale = this.isActiveCreature ? 1.25 : 1.0;
 		const keyframes = [{ transform: `translateX(${x}px) translateY(0px) scale(${scale})` }];
 		const animation = this.el.animate(keyframes, {
@@ -473,7 +471,7 @@ class CreatureVignette extends Vignette {
 		return animation;
 	}
 
-	animateDelete(queuePosition, x) {
+	animateDelete(queuePosition: number, x: number) {
 		this.el.style.zIndex = '-1';
 		const [x_, y, scale] = this.isActiveCreature ? [-this.getWidth(), 0, 1.25] : [x, -100, 1];
 		const keyframes = [{ transform: `translateX(${x_}px) translateY(${y}px) scale(${scale})` }];
@@ -485,7 +483,7 @@ class CreatureVignette extends Vignette {
 		return animation;
 	}
 
-	animateDeleteFromFront(queuePosition, x, emptySpaceAtFrontOfQueue) {
+	animateDeleteFromFront(queuePosition: number, x: number, emptySpaceAtFrontOfQueue: number) {
 		const scale = this.isActiveCreature ? 1.25 : 1;
 		const keyframes = [
 			{
@@ -518,7 +516,7 @@ class CreatureVignette extends Vignette {
 		const el = this.el;
 		const h = this.eventHandlers;
 
-		el.addEventListener('click', (e) => {
+		el.addEventListener('click', () => {
 			if (h.onCreatureClick) h.onCreatureClick(this.creature);
 		});
 
@@ -539,13 +537,13 @@ class CreatureVignette extends Vignette {
 		return this.isActiveCreature ? 100 : 80;
 	}
 
-	static is(obj) {
+	static is(obj: object) {
 		return typeof obj !== 'undefined' && CreatureVignette.prototype.isPrototypeOf(obj);
 	}
 }
 
 class TurnEndMarkerVignette extends Vignette {
-	constructor(turnNumber, eventHandlers) {
+	constructor(turnNumber: number, eventHandlers: QueueEventHandlers) {
 		super();
 		this.turnNumber = turnNumber;
 		this.eventHandlers = eventHandlers;
@@ -581,7 +579,7 @@ class TurnEndMarkerVignette extends Vignette {
 }
 
 class DelayMarkerVignette extends Vignette {
-	constructor(turnNumber, eventHandlers) {
+	constructor(turnNumber: number, eventHandlers: QueueEventHandlers) {
 		super();
 		this.turnNumber = turnNumber;
 		this.eventHandlers = eventHandlers;
@@ -615,7 +613,7 @@ class DelayMarkerVignette extends Vignette {
 		});
 	}
 
-	animateInsert(queuePosition, x) {
+	animateInsert(queuePosition: number, x: number) {
 		const keyframes = [
 			{
 				transform: `translateX(${x}px) translateY(-100px) scale(1)`,
@@ -647,7 +645,7 @@ const utils = {
 		};
 	},
 
-	arrToDict: (arr, keyFn) => {
+	arrToDict: (arr: Vignette[], keyFn: (arg0: Vignette) => string) => {
 		// NOTE: Turns an array to an object using the key function.
 		// If the keyFn produces two or more identical keys, only the
 		// last instance at that key will be kept.
@@ -658,19 +656,7 @@ const utils = {
 		return result;
 	},
 
-	partitionAt: (arr, splitFn) => {
-		let hasSplit = false;
-		return arr.reduce(
-			(acc, el, i, arr) => {
-				hasSplit = hasSplit || splitFn(el, i, arr);
-				acc[hasSplit ? 1 : 0].push(el);
-				return acc;
-			},
-			[[], []],
-		);
-	},
-
-	takeWhile: (arr, takeFn) => {
+	takeWhile: (arr: Vignette[], takeFn: (arg0: Vignette) => boolean) => {
 		const result = [];
 		for (const element of arr) {
 			if (!takeFn(element)) {
@@ -681,7 +667,10 @@ const utils = {
 		return result;
 	},
 
-	splitSetBy: (s, splitFn) => {
+	splitSetBy: (
+		s: Set<string>,
+		splitFn: (value: string, key: string, set: Set<string>) => boolean,
+	) => {
 		const a = new Set();
 		const b = new Set();
 		s.forEach((value, key, set) => {
@@ -706,137 +695,6 @@ const utils = {
 		}
 		return s;
 	},
-};
-
-/* eslint-disable @typescript-eslint/no-unused-vars */
-const refactor = {
-	/** NOTE:
-	 * Other modules that the present module relies on sometimes go
-	 * into inconsistent states. In order to facilitate future
-	 * improvements, workarounds/fixes are factored out of the present
-	 * module's code and placed here.
-	 * .
-	 * Interface is here for easy browsing.
-	 * Implementations are below.
-	 */
-	creatureQueue: {
-		// NOTE: Suggestions for fixed/improved CreatureQueue interface.
-		getCurrentQueue: (queue, activeCreature) => {
-			return [];
-		},
-		getNextQueue: (queue) => {
-			return [];
-		},
-	},
-	creature: {
-		// NOTE: Suggestions for fixed/improved Creature interface.
-		getIsDelayed: (creature, turnNumber = -1) => {
-			return false;
-		},
-	},
-	stopGap: {
-		init: () => {
-			// pass
-		},
-		// NOTE: Extra data/functions needed only while refactor is pending.
-		setTurnNumber: (turnNumber) => {
-			// pass
-		},
-		setCreatureQueue: (queue) => {
-			// pass
-		},
-		updateCreatureDelayStatus: (c, creatures, nextCreatures, turnNumber) => {
-			// pass
-		},
-		turnNumber: -1,
-		creatureIdsDelayedNextTurn: new Set(),
-		creatureIdsDelayedCurrTurn: new Set(),
-	},
-};
-
-refactor.creatureQueue = {
-	getCurrentQueue: (creatureQueue, activeCreature) => {
-		// NOTE: creatureQueue and game.activeCreature get into inconsistent states.
-		// Mostly creatureQueue does *not* hold activeCreature ...
-		// - But sometimes it does.
-		// - And sometimes activeCreature isn't meant to be active.
-		//
-		// What we really need is *every* creature that still needs a turn.
-		//
-		// We'll check if activeCreature is in the queue.
-		// - If not, we'll add it to the front.
-		// - If so, we'll leave it where it is.
-		if (!activeCreature) {
-			return creatureQueue.queue;
-		}
-		const arr = Array.from(creatureQueue.queue);
-		const containsActive = arr.some((c) => c.hasOwnProperty('id') && c['id'] === activeCreature.id);
-		if (containsActive) {
-			return arr;
-		}
-		return [activeCreature].concat(arr);
-	},
-	getNextQueue: (creatureQueue) => {
-		// NOTE: if `getCurrentQueue` is added to creatureQueue
-		// add this as well.
-		return creatureQueue.nextQueue;
-	},
-};
-
-refactor.stopGap.init = () => {
-	refactor.stopGap.setTurnNumber(-1);
-	refactor.stopGap.creatureIdsDelayedNextTurn = new Set();
-	refactor.stopGap.creatureIdsDelayedCurrTurn = new Set();
-};
-
-refactor.stopGap.setTurnNumber = (turnNumber) => {
-	if (turnNumber !== refactor.stopGap.turnNumber) {
-		refactor.stopGap.turnNumber = turnNumber;
-
-		refactor.stopGap.creatureIdsDelayedCurrTurn = refactor.stopGap.creatureIdsDelayedNextTurn;
-		refactor.stopGap.creatureIdsDelayedNextTurn = new Set();
-
-		refactor.stopGap.updateCreatureDelayStatus = (
-			creature,
-			creatures,
-			nextCreatures,
-			currTurnNumber,
-		) => {
-			/**
-			 * NOTE: If creature.delayed == true:
-			 * This might happen because the creature is/was just active and the user delayed the creature.
-			 * Or it might happen because the creature received an attack that delayed it.
-			 * Or it might be a holdover from a previous interaction.
-			 * -
-			 * This code should eventually not be necessary. Creature should ideally update/report its own status.
-			 * This code assumes that a creature can never be undelayed for a given round.
-			 */
-			const creatureIsInCurrTurn = creatures.filter((c) => c.id === creature.id).length > 0;
-			const creatureIsInNextTurn = nextCreatures.filter((c) => c.id === creature.id).length > 0;
-			if (creatureIsInCurrTurn) {
-				if (creature.delayed) {
-					refactor.stopGap.creatureIdsDelayedCurrTurn.add(creature.id);
-				}
-			} else if (creatureIsInNextTurn) {
-				if (creature.delayed) {
-					refactor.stopGap.creatureIdsDelayedNextTurn.add(creature.id);
-				}
-			}
-		};
-
-		refactor.creature.getIsDelayed = (creature, turnNumber = -1) => {
-			// NOTE: Creatures get into inconsistent states vis-a-vis the
-			// queue. Sometimes a creature's state will go from delayed
-			// to !delayed, while being active and having previously been delayed.
-			// This is problematic.
-			const currTurn = refactor.stopGap.turnNumber;
-			if (currTurn === turnNumber) {
-				return refactor.stopGap.creatureIdsDelayedCurrTurn.has(creature.id);
-			} else if (currTurn + 1 === turnNumber) {
-				return refactor.stopGap.creatureIdsDelayedNextTurn.has(creature.id);
-			}
-		};
-	}
 };
 
 type QueueEventHandlers = {


### PR DESCRIPTION
bugfix: fix creature delay reset and delays across rounds
    
* splits `creature.delay()` into `creature.hinder()` and `creature.wait()`
* `creature.hinder()` is called when an attacker delays the creature
* `creature.wait()` is called when the player delays their own creature
* adds tests for `hinder`, `wait` and related getters
* disallows setting of `creature.delayable` and `creature.delayed`
* simplifies `src/creature_queue.ts`; its values are now derived on the fly – no need to call `update()`
* adds types and cleans up `ui/queue.ts`, removing `stopGap` functions needed to derive correct data from buggy delays
    
See #2158, #2275

----

## Creature.delay()

Creature `delayed`/`delayable` were set in different parts of the code. And the `Creature` class treated `delay()`/`delayed` as monolithic – however there were 2 distinct cases in code: 

* delays from the player deciding their own creature should "wait". These delays **do not** persist across rounds.
* delays resulting from attacks from other players – "hindering" the creature. These delays **do** persist across rounds.

These two cases are now separate methods: `wait()` and `hinder()`, respectively.

`delayable` was converted to `canWait` and is no longer settable – it's derived.

## CreatureQueue

`CreatureQueue (creature_queue.ts)` kept its own state related to creature delay status and turn position. That had to be kept updated and in sync with the world. Most of its methods have been removed. It now sufficient to change the creatures themselves. `CreatureQueue` no longer holds any data. It merely derives it, so it's always up to date.

## Future

`game` does a lot of UI calls, e.g., setting button states. Lots of care (or trial and error) is needed to tune `setTimeout`s so that the correct UI state ends up on screen. Using the current paradigms in the codebase, it would be
simpler if `game` communicated the possible need for a UI update by dispatching an event. Then the UI could derive its state from the game. 

Likewise, `interface.js` does things like check if a button press should have an action, e.g., if `btnDelay` is pressed, it checks whether the `game.activeCreature` can be delayed. These kinds of business rules shouldn't reside in the UI. It would be simpler if it merely fired off the button press and let `game` or the creature itself decide how to respond – the OOP principle of ["tell, don't ask".](https://www.martinfowler.com/bliki/TellDontAsk.html)