### PR TITLE
Decouple Hex

### DIFF
--- a/src/__tests__/utility/pointfacade.ts
+++ b/src/__tests__/utility/pointfacade.ts
@@ -17,11 +17,11 @@ describe('class PointFacade', () => {
 		 *     getCreatures:() => this.creatures,
 		 *     getCreaturePassablePoints:(creature) => [],
 		 *     getCreatureBlockedPoints:(creature) => (creature.dead || creature.temp) ? [] : creature.hexagons,
-		 *     getTraps: () => this.grid.traps,
-		 *     getTrapPassablePoints:(trap) => [trap.hex],
+		 *     getTraps: () => this.traps,
+		 *     getTrapPassablePoints:(trap) => [trap],
 		 *     getTrapBlockedPoints:(trap) => [],
 		 *     getDrops: () => this.grid.forEachHex(hex => hex.drop).filter(d => d),
-		 *     getDropPassablePoints: (drop) => drop.hex ? [drop.hex] : [],
+		 *     getDropPassablePoints: (drop) => [drop],
 		 *     getDropBlockedPoitns: (drop) => [],
 		 * });
 		 */
@@ -49,14 +49,14 @@ describe('class PointFacade', () => {
 			},
 		];
 		const trapMocks = [
-			{ hex: { x: 13, y: 20 } },
-			{ hex: { x: 1, y: 1 } },
-			{ hex: { x: 10, y: 10 } },
+			{ x: 13, y: 20 },
+			{ x: 1, y: 1 },
+			{ x: 10, y: 10 },
 		];
 		const dropMocks = [
-			{ hex: { x: 2, y: 10 } },
-			{ hex: { x: 0, y: 0 } },
-			{ hex: { x: 10, y: 10 } },
+			{ x: 2, y: 10 },
+			{ x: 0, y: 0 },
+			{ x: 10, y: 10 },
 		];
 
 		/**
@@ -70,11 +70,11 @@ describe('class PointFacade', () => {
 				creature.dead || creature.temp ? [] : creature.hexagons,
 			// @ts-ignore
 			getTraps: () => trapMocks, // NOTE: Locate actual in-game data
-			getTrapPassablePoints: (trap) => [trap.hex],
+			getTrapPassablePoints: (trap) => [trap],
 			getTrapBlockedPoints: (trap) => [],
 			// @ts-ignore
 			getDrops: () => dropMocks, // NOTE: Locate actual in-game data
-			getDropPassablePoints: (drop) => (drop.hex ? [drop.hex] : []),
+			getDropPassablePoints: (drop) => [drop],
 			getDropBlockedPoints: (drop) => [],
 		});
 
@@ -107,7 +107,7 @@ describe('class PointFacade', () => {
 		// NOTE: The methods can be called with anything having {x:number, y:number}.
 		// However, it's awkward using game data. This is why we're using a facade in the first place!
 		expect(blockedSet.has(10, 10)).toBe(true);
-		expect(pointFacade.getCreaturesAt(trapMocks[2].hex)).toEqual([creatureMocks[2]]);
+		expect(pointFacade.getCreaturesAt(trapMocks[2])).toEqual([creatureMocks[2]]);
 		expect(pointFacade.getTrapsAt(creatureMocks[2].hexagons[0])).toEqual([trapMocks[2]]);
 		expect(pointFacade.getDropsAt({ x: 10, y: 10 })).toEqual([dropMocks[2]]);
 

--- a/src/abilities/Impaler.js
+++ b/src/abilities/Impaler.js
@@ -6,6 +6,7 @@ import * as arrayUtils from '../utility/arrayUtils';
 import { Creature } from '../creature';
 import { Effect } from '../effect';
 import { once } from 'underscore';
+import { getPointFacade } from '../utility/pointfacade';
 
 /** Creates the abilities
  * @param {Object} G the game object
@@ -216,7 +217,9 @@ export default (G) => {
 							// be poisonous vine. This is not strictly necessary but it
 							// keeps multiple instances of "Poisonous Vine" text
 							// from appearing on screen.
-							target.hexagons.forEach((hex) => hex.destroyTrap());
+							getPointFacade()
+								.getTrapsAt(target)
+								.forEach((trap) => trap.destroy);
 						}),
 					},
 					G,

--- a/src/abilities/Infernal.js
+++ b/src/abilities/Infernal.js
@@ -3,6 +3,7 @@ import { Team, isTeam } from '../utility/team';
 import * as matrices from '../utility/matrices';
 import * as arrayUtils from '../utility/arrayUtils';
 import { Effect } from '../effect';
+import { getPointFacade } from '../utility/pointfacade';
 
 /** Creates the abilities
  * @param {Object} G the game object
@@ -308,12 +309,10 @@ export default (G) => {
 					G,
 				);
 
-				// Destroy traps currently under self
-				for (let i = 0; i < this.creature.hexagons.length; i++) {
-					if (this.creature.hexagons[i].trap) {
-						this.creature.hexagons[i].destroyTrap();
-					}
-				}
+				// NOTE: Destroy traps currently under self
+				getPointFacade()
+					.getTrapsAt(magmaSpawn)
+					.forEach((trap) => trap.destroy());
 
 				// Movement
 				const hurl = (_path) => {

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -5,7 +5,7 @@ import { Hex } from './utility/hex';
 import Game from './game';
 import * as arrayUtils from './utility/arrayUtils';
 import { Drop, DropDefinition } from './drop';
-import { getPointFacade } from './utility/pointfacade';
+import { Point, getPointFacade } from './utility/pointfacade';
 import { Effect } from './effect';
 import { Player, PlayerID } from './player';
 import { Damage } from './damage';
@@ -997,7 +997,7 @@ export class Creature {
 			if (opts.ignorePath || opts.animation == 'fly') {
 				path = [hex];
 			} else {
-				path = this.calculatePath(x, y);
+				path = this.calculatePath({ x, y });
 			}
 
 			if (path.length === 0) {
@@ -1025,23 +1025,22 @@ export class Creature {
 		}, 100);
 	}
 
-	/* tracePath(hex)
+	/**
+	 * tracePath()
 	 *
-	 * hex :	Hex :	Destination Hex
+	 * @param{Point} destination: the end of the path.
 	 *
 	 * Trace the path from the current position to the given coordinates
 	 *
 	 */
-	tracePath(hex) {
-		const x = hex.x,
-			y = hex.y,
-			path = this.calculatePath(x, y); // Store path in grid to be able to compare it later
+	tracePath(destination: Point) {
+		const path = this.calculatePath(destination); // Store path in grid to be able to compare it later
 
 		if (path.length === 0) {
 			return; // Break if empty path
 		}
 
-		path.forEach((item) => {
+		path.forEach((item: { x: any; y: any }) => {
 			this.tracePosition({
 				x: item.x,
 				y: item.y,
@@ -1093,20 +1092,20 @@ export class Creature {
 		}
 	}
 
-	/* calculatePath(x,y)
+	/**
+	 * calculatePath(destination:Point)
 	 *
-	 * x :		Integer :	Destination coordinates
-	 * y :		Integer :	Destination coordinates
+	 * @param{Point} destination: the end of the path.
 	 *
 	 * return :	Array :	Array containing the path hexes
 	 *
 	 */
-	calculatePath(x: number, y: number) {
+	calculatePath(destination: Point) {
 		const game = this.game;
 
 		return search(
 			game.grid.hexes[this.y][this.x],
-			game.grid.hexes[y][x],
+			game.grid.hexes[destination.y][destination.x],
 			this.size,
 			this.id,
 			this.game.grid,

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -10,6 +10,7 @@ import { Effect } from './effect';
 import { Player, PlayerID } from './player';
 import { Damage } from './damage';
 import { AugmentedMatrix } from './utility/matrices';
+import { HEX_WIDTH_PX } from './utility/const';
 
 // to fix @ts-expect-error 2554: properly type the arguments for the trigger functions in `game.ts`
 
@@ -341,7 +342,7 @@ export class Creature {
 		this.sprite.x =
 			(!this.player.flipped
 				? this.display['offset-x']
-				: 90 * this.size - this.sprite.texture.width - this.display['offset-x']) +
+				: HEX_WIDTH_PX * this.size - this.sprite.texture.width - this.display['offset-x']) +
 			this.sprite.texture.width / 2;
 		this.sprite.y = this.display['offset-y'] + this.sprite.texture.height;
 		// Placing Group
@@ -352,20 +353,20 @@ export class Creature {
 
 		// Hint Group
 		this.hintGrp = game.Phaser.add.group(this.grp, 'creatureHintGrp_' + this.id);
-		this.hintGrp.x = 45 * this.size;
+		this.hintGrp.x = 0.5 * HEX_WIDTH_PX * this.size;
 		this.hintGrp.y = -this.sprite.texture.height + 5;
 
 		// Health indicator
 		this.healthIndicatorGroup = game.Phaser.add.group(this.grp, 'creatureHealthGrp_' + this.id);
 		// Adding background sprite
 		this.healthIndicatorSprite = this.healthIndicatorGroup.create(
-			this.player.flipped ? 19 : 19 + 90 * (this.size - 1),
+			this.player.flipped ? 19 : 19 + HEX_WIDTH_PX * (this.size - 1),
 			49,
 			'p' + this.team + '_health',
 		);
 		// Add text
 		this.healthIndicatorText = game.Phaser.add.text(
-			this.player.flipped ? 45 : 45 + 90 * (this.size - 1),
+			this.player.flipped ? HEX_WIDTH_PX * 0.5 : HEX_WIDTH_PX * (this.size - 0.5),
 			63,
 			this.health,
 			{
@@ -939,7 +940,7 @@ export class Creature {
 		this.sprite.x =
 			(!flipped
 				? this.display['offset-x']
-				: 90 * this.size - this.sprite.texture.width - this.display['offset-x']) +
+				: HEX_WIDTH_PX * this.size - this.sprite.texture.width - this.display['offset-x']) +
 			this.sprite.texture.width / 2;
 	}
 
@@ -957,7 +958,7 @@ export class Creature {
 		this.sprite.x =
 			(!this.player.flipped
 				? this.display['offset-x']
-				: 90 * this.size - this.sprite.texture.width - this.display['offset-x']) +
+				: HEX_WIDTH_PX * this.size - this.sprite.texture.width - this.display['offset-x']) +
 			this.sprite.texture.width / 2;
 	}
 

--- a/src/game.ts
+++ b/src/game.ts
@@ -25,6 +25,7 @@ import { Ability } from './ability';
 import { Effect } from './effect';
 import { GameConfig } from './script';
 import { Trap } from './utility/trap';
+import { Drop } from './drop';
 
 /* eslint-disable prefer-rest-params */
 
@@ -80,6 +81,7 @@ export default class Game {
 	players: Player[];
 	creatures: Creature[];
 	traps: Trap[];
+	drops: Drop[];
 	effects: Effect[];
 	activeCreature: Creature | undefined;
 	matchid: number;
@@ -151,6 +153,7 @@ export default class Game {
 		this.players = [];
 		this.creatures = [];
 		this.traps = [];
+		this.drops = [];
 		this.effects = [];
 		this.activeCreature = undefined;
 		this.matchid = null;
@@ -526,16 +529,8 @@ export default class Game {
 			getTraps: () => this.traps,
 			getTrapPassablePoints: (trap: Trap) => [trap],
 			getTrapBlockedPoints: (trap) => [],
-			getDrops: () => {
-				const result = [];
-				this.grid.forEachHex((hex) => {
-					if (hex.drop) {
-						result.push(hex.drop);
-					}
-				});
-				return result;
-			},
-			getDropPassablePoints: (drop) => (drop.hex ? [drop.hex] : []),
+			getDrops: () => this.drops,
+			getDropPassablePoints: (drop) => [drop],
 			getDropBlockedPoints: (drop) => [],
 		});
 

--- a/src/game.ts
+++ b/src/game.ts
@@ -24,6 +24,7 @@ import { pretty as version } from './utility/version';
 import { Ability } from './ability';
 import { Effect } from './effect';
 import { GameConfig } from './script';
+import { Trap } from './utility/trap';
 
 /* eslint-disable prefer-rest-params */
 
@@ -60,6 +61,7 @@ export default class Game {
 	 * // Game elements
 	 * players :			Array :	Contains Player objects ordered by player ID (0 to 3)
 	 * creatures :			Array :	Contains Creature objects (creatures[creature.id]) start at index 1
+	 * traps :				Array : Contains Trap objects
 	 *
 	 * grid :				Grid :	Grid object
 	 * UI :				UI :	UI object
@@ -77,6 +79,7 @@ export default class Game {
 	abilities: Ability[];
 	players: Player[];
 	creatures: Creature[];
+	traps: Trap[];
 	effects: Effect[];
 	activeCreature: Creature | undefined;
 	matchid: number;
@@ -147,6 +150,7 @@ export default class Game {
 		this.abilities = [];
 		this.players = [];
 		this.creatures = [];
+		this.traps = [];
 		this.effects = [];
 		this.activeCreature = undefined;
 		this.matchid = null;
@@ -367,6 +371,10 @@ export default class Game {
 		this.dataLoaded(dataJson);
 	}
 
+	hexAt(x: number, y: number): Hex | undefined {
+		return this.grid.hexAt(x, y);
+	}
+
 	get activePlayer() {
 		if (this.multiplayer) {
 			if (this.players && this.match instanceof MatchI && this.match.userTurn) {
@@ -515,8 +523,8 @@ export default class Game {
 					return ps;
 				}
 			},
-			getTraps: () => this.grid.traps,
-			getTrapPassablePoints: (trap) => [trap.hex],
+			getTraps: () => this.traps,
+			getTrapPassablePoints: (trap: Trap) => [trap],
 			getTrapBlockedPoints: (trap) => [],
 			getDrops: () => {
 				const result = [];
@@ -1259,12 +1267,12 @@ export default class Game {
 	// Removed individual args from definition because we are using the arguments variable.
 	onStartPhase(/* creature, callback */) {
 		let creature = arguments[0],
-			totalTraps = this.grid.traps.length,
+			totalTraps = this.traps.length,
 			trap,
 			i;
 
 		for (i = 0; i < totalTraps; i++) {
-			trap = this.grid.traps[i];
+			trap = this.traps[i];
 
 			if (trap === undefined) {
 				continue;
@@ -1317,7 +1325,7 @@ export default class Game {
 		this.triggerEffect('onCreatureDeath', [creature, creature]);
 
 		// Looks for traps owned by this creature and destroy them
-		this.grid.traps
+		this.traps
 			.filter(
 				(trap) => trap.turnLifetime > 0 && trap.fullTurnLifetime && trap.ownerCreature == creature,
 			)

--- a/src/utility/const.ts
+++ b/src/utility/const.ts
@@ -1,0 +1,10 @@
+import { Point } from './pointfacade';
+
+export const HEX_WIDTH_PX = 90;
+export const HEX_HEIGHT_PX = (HEX_WIDTH_PX / Math.sqrt(3)) * 2 * 0.75;
+export function offsetCoordsToPx(point: Point) {
+	return {
+		x: (point.y % 2 === 0 ? point.x + 0.5 : point.x) * HEX_WIDTH_PX,
+		y: point.y * HEX_HEIGHT_PX,
+	};
+}

--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -7,6 +7,7 @@ import Phaser, { Point, Polygon } from 'phaser-ce';
 import { Drop } from '../drop';
 import { DEBUG } from '../debug';
 import { getPointFacade } from './pointfacade';
+import * as Const from './const';
 
 export enum Direction {
 	None = -1,
@@ -125,13 +126,9 @@ export class Hex {
 		this.displayClasses = '';
 		this.overlayClasses = '';
 
-		// Horizontal hex grid, width is distance between opposite sides
-		this.width = 90;
-		this.height = (this.width / Math.sqrt(3)) * 2 * 0.75;
-		this.displayPos = {
-			x: (y % 2 === 0 ? x + 0.5 : x) * this.width,
-			y: y * this.height,
-		};
+		this.width = Const.HEX_WIDTH_PX;
+		this.height = Const.HEX_HEIGHT_PX;
+		this.displayPos = Const.offsetCoordsToPx({ x, y });
 
 		this.originalDisplayPos = $j.extend({}, this.displayPos);
 

--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -1,10 +1,10 @@
 import * as $j from 'jquery';
 import { Trap } from './trap';
+import { Drop } from '../drop';
 import { Creature } from '../creature';
 import { HexGrid } from './hexgrid';
 import Game from '../game';
 import Phaser, { Point, Polygon } from 'phaser-ce';
-import { Drop } from '../drop';
 import { DEBUG } from '../debug';
 import { getPointFacade } from './pointfacade';
 import * as Const from './const';
@@ -75,7 +75,6 @@ export class Hex {
 	 */
 	reachable: boolean;
 	direction: Direction;
-	#drop: Drop;
 	displayClasses: string;
 	overlayClasses: string;
 	width: number;
@@ -121,7 +120,6 @@ export class Hex {
 		this.blocked = false;
 		this.reachable = true;
 		this.direction = Direction.None; // Used for queryDirection
-		this.drop = undefined; // Drop items
 		this.displayClasses = '';
 		this.overlayClasses = '';
 
@@ -220,29 +218,19 @@ export class Hex {
 		return traps.length > 0 ? traps[0] : undefined;
 	}
 
+	/**
+	 * @deprecated Use new Drop();
+	 */
 	set drop(d) {
-		if (this.#drop && d !== this.#drop) {
-			/**
-			 * NOTE: Currently, the #drop reference here in Hex
-			 * is the only place that a Drop "lives". If it's
-			 * removed here, there are no other references and it
-			 * becomes inaccessible. Therefore, we'll destroy this.#drop
-			 * if it exists, before setting a new this.#drop.
-			 *
-			 * NOTE: Currently, calling d.destroy() on a Drop
-			 * will make it try to unset the drop value. This
-			 * could lead to infinite recursion. So, unset
-			 * this.#drop before calling destroy().
-			 */
-			const dOld = this.#drop;
-			this.#drop = undefined;
-			dOld.destroy();
-		}
-		this.#drop = d;
+		new Drop(d.name, d.alterations, d.x, d.y, d.game);
 	}
 
-	get drop() {
-		return this.#drop;
+	/**
+	 * @deprecated Use getPointFacade().getDropsAt({x, y});
+	 */
+	get drop(): Drop | undefined {
+		const drops = getPointFacade().getDropsAt(this);
+		return drops.length > 0 ? drops[0] : undefined;
 	}
 
 	get creature(): Creature | undefined {

--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -233,14 +233,19 @@ export class Hex {
 		return drops.length > 0 ? drops[0] : undefined;
 	}
 
+	/**
+	 * @deprecated Use getPointFacade().getCreaturesAt({x, y});
+	 */
 	get creature(): Creature | undefined {
 		const creatures = getPointFacade().getCreaturesAt(this.x, this.y);
 		return creatures.length ? creatures[0] : undefined;
 	}
 
+	/**
+	 * @deprecated There's no longer a need to set hex.creature. Simply update the creature.
+	 */
 	set creature(creature: Creature) {
 		// NOTE: solely for compatability.
-		// this.creature used to be settable, but now it's derived.
 	}
 
 	onSelectFn(arg0: this) {

--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -91,7 +91,6 @@ export class Hex {
 	hitBox: Phaser.Sprite;
 	display: Phaser.Sprite;
 	overlay: Phaser.Sprite;
-	trap: Trap;
 	coordText: Phaser.Text;
 
 	/**
@@ -211,8 +210,14 @@ export class Hex {
 		}
 
 		this.displayPos.y = this.displayPos.y * 0.75 + 30;
+	}
 
-		this.trap = undefined;
+	/**
+	 * @deprecated Use getPointFacade().getTrapsAt({x, y});
+	 */
+	get trap() {
+		const traps = getPointFacade().getTrapsAt(this);
+		return traps.length > 0 ? traps[0] : undefined;
 	}
 
 	set drop(d) {
@@ -598,41 +603,31 @@ export class Hex {
 	 * - ownerCreature
 	 * - destroyOnActivate
 	 * - typeOver
+	 *
+	 * @deprecated Use new Trap(x, y, type, effects, own, opt, game)
 	 */
-	createTrap(type, effects, owner, opt) {
-		if (this.trap) {
-			this.destroyTrap();
-		}
-
-		this.trap = new Trap(this.x, this.y, type, effects, owner, opt, this.game);
-		return this.trap;
+	createTrap(type, effects, owner, opt): Trap {
+		return new Trap(this.x, this.y, type, effects, owner, opt, this.game);
 	}
 
+	/**
+	 * @param trigger
+	 * @param target
+	 *
+	 * @deprecated: use PointFacade - e.g., getPointFacade().getTrapsAt(point).forEach(trap => trap.activate(trigger, target))
+	 */
 	activateTrap(trigger, target) {
-		if (!this.trap) {
-			return;
-		}
-
-		this.trap.effects.forEach((effect) => {
-			if (trigger.test(effect.trigger) && effect.requireFn()) {
-				this.game.log('Trap triggered');
-				effect.activate(target);
-			}
-		});
-
-		if (this.trap && this.trap.destroyOnActivate) {
-			this.destroyTrap();
-		}
+		this.trap?.activate(trigger, target);
 	}
 
+	/**
+	 *
+	 * @returns void
+	 *
+	 * @deprecated Traps are no longer held in a Hex. user PointFacade - e.g., getPointFacade().getTrapsAt(point).forEach(trap => trap.destroy());
+	 */
 	destroyTrap() {
-		if (!this.trap) {
-			return;
-		}
-
-		delete this.grid.traps[this.trap.id];
-		this.trap.destroy();
-		delete this.trap;
+		this.trap?.destroy();
 	}
 
 	//---------DROP FUNCTION---------//

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -8,6 +8,7 @@ import * as arrayUtils from './arrayUtils';
 import Game from '../game';
 import { Trap } from './trap';
 import { DEBUG } from '../debug';
+import { HEX_WIDTH_PX } from './const';
 
 interface QueryOptions {
 	/**
@@ -722,7 +723,7 @@ export class HexGrid {
 				game.activeCreature.queryMove();
 			},
 			fnOnSelect: (hex: Hex) => {
-				game.activeCreature.faceHex(hex, undefined, true);
+				game.activeCreature.faceHex(hex);
 				hex.overlayVisualState('creature selected player' + game.activeCreature.team);
 			},
 			fnOnCancel: () => {
@@ -917,7 +918,7 @@ export class HexGrid {
 				}
 
 				hex = this.hexes[y][x]; // New coords
-				game.activeCreature.faceHex(hex, undefined, true, true);
+				game.activeCreature.faceHex(hex);
 
 				if (hex !== this.lastClickedHex) {
 					this.lastClickedHex = hex;
@@ -1503,7 +1504,7 @@ export class HexGrid {
 			hex.displayPos.x +
 			(!player.flipped
 				? creatureData.display['offset-x']
-				: 90 * creatureData.size -
+				: HEX_WIDTH_PX * creatureData.size -
 				  this.materialize_overlay.texture.width -
 				  creatureData.display['offset-x']) +
 			this.materialize_overlay.texture.width / 2;

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -6,7 +6,6 @@ import * as matrices from './matrices';
 import { Team, isTeam } from './team';
 import * as arrayUtils from './arrayUtils';
 import Game from '../game';
-import { Trap } from './trap';
 import { DEBUG } from '../debug';
 import { HEX_WIDTH_PX } from './const';
 
@@ -99,7 +98,6 @@ export class HexGrid {
 	 */
 	hexes: Hex[][];
 
-	traps: Trap[];
 	allhexes: Hex[];
 
 	/**
@@ -142,7 +140,6 @@ export class HexGrid {
 
 		this.game = game;
 		this.hexes = []; // Hex Array
-		this.traps = []; // Traps Array
 		this.allhexes = []; // All hexes
 		this.lastClickedHex = undefined;
 
@@ -188,6 +185,17 @@ export class HexGrid {
 
 		// Events
 		this.game.signals.metaPowers.add(this.handleMetaPowerEvent, this);
+	}
+
+	get traps() {
+		return this.game.traps;
+	}
+
+	hexAt(x: number, y: number): Hex | undefined {
+		if (y < 0 || y >= this.hexes.length) return;
+		const row = this.hexes[y];
+		if (x < 0 || x >= row.length) return;
+		return row[x];
 	}
 
 	handleMetaPowerEvent(message, payload) {


### PR DESCRIPTION
This continues the refactoring effort to slim down `Hex`. It largely makes `Drop` and `Trap` independent from `Hex` and `HexGrid`.

* moves `Drop`s and `Trap`s to their own arrays in `Game`. 
* largely removes `Hex` from `Trap`
* removes `HexGrid` from `Trap`
* removes `Hex` from `Drop`
* allows `Drop` and `Trap` to created directly, rather than passing through `Hex`
* writes down a few `const` variables for hex pixel height/width: `Const.HEX_WIDTH_PX` and `Const.HEX_HEIGHT_PX`
* adds a function to convert from hex space to (Phaser) pixel space: `Const.offsetCoordsToPx` (The hex coordinate system the game uses is known as "offset coordinates", hence the function name")
* deprecates several now-unneeded methods, particularly in `Hex`

`Drop`, `Trap`, and `Creature` remain accessible via `Hex`. Those properties have been refactored to getters and forward the request to `PointFacade`. The `Hex` methods are marked as deprecated. PointFacade should be used directly, instead.

## Future

Pathfinding still relies on `Hex`. I'll remove that dependency if this PR goes through.