### PR TITLE
fix: drop display position #2437

### DIFF
--- a/src/drop.ts
+++ b/src/drop.ts
@@ -1,6 +1,6 @@
 import { Creature } from './creature';
 import Game from './game';
-import { offsetCoordsToPx } from './utility/const';
+import { HEX_HEIGHT_PX, HEX_WIDTH_PX, offsetCoordsToPx } from './utility/const';
 import { Point, getPointFacade } from './utility/pointfacade';
 
 /**
@@ -71,11 +71,15 @@ export class Drop {
 			.forEach((drop) => drop.destroy());
 		this.game.drops.push(this);
 
-		const px = offsetCoordsToPx({ x: x + 1, y: y - 0.5 });
-		this.display = game.grid.dropGroup.create(px.x, px.y, 'drop_' + this.name);
+		this.display = game.grid.dropGroup.create(
+			this.hex.displayPos.x + 54,
+			this.hex.displayPos.y + 15,
+			'drop_' + this.name,
+		);
 		this.display.alpha = 0;
 		this.display.anchor.setTo(0.5, 0.5);
 		this.display.scale.setTo(1.5, 1.5);
+
 		game.Phaser.add
 			.tween(this.display)
 			.to(


### PR DESCRIPTION
Closes #2437.
<img width="813" alt="Screenshot 2023-07-19 at 11 25 09" src="https://github.com/FreezingMoon/AncientBeast/assets/20469369/b29d7a19-9a39-4f41-9dde-95dd5bfda88c">

Thanks for the heads up.

I had forgotten that `Hex` and `Drop` were in different "spaces" – Hex space is squished on the screen-y. Drop space isn't. 

That's probably the next thing to smooth out:

https://github.com/FreezingMoon/AncientBeast/blob/3c41d554be92e1d7103b1a8330e9e6d0f4c508c7/src/utility/hexgrid.ts#L151

Squishing the hexes on the y was a quick way to add a feeling of perspective, but the downside is that it puts hexes in a different space.