### PR TITLE
refactor: streamline grid coords -> pixel coords

### DIFF
--- a/src/abilities/Abolished.js
+++ b/src/abilities/Abolished.js
@@ -3,6 +3,7 @@ import { Team } from '../utility/team';
 import { Creature } from '../creature';
 import { Effect } from '../effect';
 import * as arrayUtils from '../utility/arrayUtils';
+import { getPointFacade } from '../utility/pointfacade';
 
 /** Creates the abilities
  * @param {Object} G the game object
@@ -128,21 +129,25 @@ export default (G) => {
 				});
 			},
 
-			activate(path, args) {
+			activate(path) {
 				const ability = this;
-				const target = arrayUtils.last(path).creature;
-
 				ability.end();
+
+				const targets = getPointFacade().getCreaturesAt(arrayUtils.last(path));
+				// TODO: Path sometimes contains no targets.
+				if (targets.length === 0) {
+					console.error('returning');
+					return;
+				}
+
+				const target = targets[0];
+
 				G.Phaser.camera.shake(0.01, 100, true, G.Phaser.camera.SHAKE_HORIZONTAL, true);
 
-				const startX = ability.creature.sprite.scale.x > 0 ? 232 : 52;
 				const projectileInstance = G.animations.projectile(
 					this,
 					target,
 					'effects_fiery-touch',
-					path,
-					args,
-					startX,
 					-20,
 				);
 				const tween = projectileInstance[0];

--- a/src/abilities/Dark-Priest.js
+++ b/src/abilities/Dark-Priest.js
@@ -275,6 +275,7 @@ export default (G) => {
 					{ materializationSickness: creatureHasMaterializationSickness },
 				);
 				const fullCrea = new Creature(crea, G);
+
 				// Don't allow temporary Creature to take up space
 				fullCrea.cleanHex();
 				// Make temporary Creature invisible

--- a/src/abilities/Snow-Bunny.js
+++ b/src/abilities/Snow-Bunny.js
@@ -3,6 +3,7 @@ import { Damage } from '../damage';
 import { Team, isTeam } from '../utility/team';
 import * as matrices from '../utility/matrices';
 import * as arrayUtils from '../utility/arrayUtils';
+import { getPointFacade } from '../utility/pointfacade';
 
 const HopTriggerDirections = {
 	Above: 0,
@@ -452,19 +453,19 @@ export default (G) => {
 			},
 
 			//	activate() :
-			activate: function (path, args) {
+			activate: function (path) {
 				const ability = this;
 				ability.end();
 				G.Phaser.camera.shake(0.01, 90, true, G.Phaser.camera.SHAKE_HORIZONTAL, true);
-				const target = path.find((hex) => hex.creature).creature;
+
+				const targets = getPointFacade().getCreaturesAt(path);
+				if (targets.length === 0) return;
+				const target = targets[0];
 
 				const projectileInstance = G.animations.projectile(
 					this,
 					target,
 					'effects_freezing-spit',
-					path,
-					args,
-					52,
 					-20,
 				);
 				const tween = projectileInstance[0];

--- a/src/drop.ts
+++ b/src/drop.ts
@@ -1,6 +1,6 @@
 import { Creature } from './creature';
 import Game from './game';
-import { HEX_HEIGHT_PX, HEX_WIDTH_PX, offsetCoordsToPx } from './utility/const';
+import { offsetCoordsToPx } from './utility/const';
 import { Point, getPointFacade } from './utility/pointfacade';
 
 /**
@@ -71,11 +71,8 @@ export class Drop {
 			.forEach((drop) => drop.destroy());
 		this.game.drops.push(this);
 
-		this.display = game.grid.dropGroup.create(
-			this.hex.displayPos.x + 54,
-			this.hex.displayPos.y + 15,
-			'drop_' + this.name,
-		);
+		const px = offsetCoordsToPx(this);
+		this.display = game.grid.dropGroup.create(px.x, px.y, 'drop_' + this.name);
 		this.display.alpha = 0;
 		this.display.anchor.setTo(0.5, 0.5);
 		this.display.scale.setTo(1.5, 1.5);

--- a/src/game.ts
+++ b/src/game.ts
@@ -637,6 +637,13 @@ export default class Game {
 		}
 
 		this.matchInit();
+
+		for (const hexes of this.grid.hexes) {
+			for (const hex of hexes) {
+				//new Trap(hex.x, hex.y, 'firewall', [], this.players[0], {}, this, 'woo');
+				//new Drop('apple', {}, hex.x, hex.y, this);
+			}
+		}
 	}
 
 	async matchInit() {

--- a/src/utility/const.ts
+++ b/src/utility/const.ts
@@ -1,10 +1,20 @@
 import { Point } from './pointfacade';
 
 export const HEX_WIDTH_PX = 90;
-export const HEX_HEIGHT_PX = (HEX_WIDTH_PX / Math.sqrt(3)) * 2 * 0.75;
+export const HEX_HEIGHT_PX = (HEX_WIDTH_PX / Math.sqrt(3)) * 2 * 0.75 * 0.75;
 export function offsetCoordsToPx(point: Point) {
+	// NOTE: Rounding lets callers use this function with non-whole numbers
+	// in order to include offsets. This is offered as a possiblity, but
+	// know that offset hex grid coordinates are a little bonkers. Make
+	// sure to double check your output in the game.
+	// Pass whole numbers and adjust pixel positions after if running into problems.
+	const row = Math.round(point.y);
 	return {
-		x: (point.y % 2 === 0 ? point.x + 0.5 : point.x) * HEX_WIDTH_PX,
+		x: (row % 2 === 0 ? point.x + 0.5 : point.x) * HEX_WIDTH_PX,
 		y: point.y * HEX_HEIGHT_PX,
 	};
 }
+
+// NOTE: Creature textures have space for a "foot" that extends "below" the ground y.
+// This allows for creatures to appear to have some perspective.
+export const CREATURE_TEXTURE_FOOT_HEIGHT_PX = 50;

--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -1,4 +1,3 @@
-import * as $j from 'jquery';
 import { Trap } from './trap';
 import { Drop } from '../drop';
 import { Creature } from '../creature';
@@ -81,11 +80,10 @@ export class Hex {
 	height: number;
 
 	/**
-	 * Pos object to position creature with absolute coordinates {left,top}.
+	 * @deprecated: use Const.offsetCoordsToPx
 	 */
 	displayPos: { x: number; y: number };
 
-	originalDisplayPos: { x: number; y: number };
 	tween: Phaser.Tween;
 	hitBox: Phaser.Sprite;
 	display: Phaser.Sprite;
@@ -125,24 +123,20 @@ export class Hex {
 
 		this.width = Const.HEX_WIDTH_PX;
 		this.height = Const.HEX_HEIGHT_PX;
-		this.displayPos = Const.offsetCoordsToPx({ x, y });
-
-		this.originalDisplayPos = $j.extend({}, this.displayPos);
+		this.displayPos = Const.offsetCoordsToPx({ x: this.x, y: this.y });
 
 		this.tween = null;
 
 		if (grid) {
+			const x_px = this.displayPos.x;
+			const y_px = this.displayPos.y;
 			// NOTE: Set up hex hitBox and display/overlay elements.
-
-			// NOTE: (Hack) 10px is the offset from the old version.
-			const x = this.displayPos.x - 10;
-			const y = this.displayPos.y;
-
-			this.hitBox = grid.hexesGroup.create(x, y, 'hex');
+			this.hitBox = grid.hexesGroup.create(x_px, y_px, 'hex');
 			this.hitBox.alpha = 0;
 			this.hitBox.inputEnabled = true;
 			this.hitBox.ignoreChildInput = true;
 			this.hitBox.input.useHandCursor = false;
+			this.hitBox.anchor.setTo(0.5);
 
 			{
 				// NOTE: Set up hexagonal hitArea for hitBox
@@ -151,19 +145,21 @@ export class Hex {
 				const angles = [0, 1, 2, 3, 4, 5, 6].map((i) => angleStart - i * angleStep);
 				// NOTE: The coefficients below are "magic"; tested in-game.
 				const [radius_w, radius_h] = [0.58 * this.width, 0.69 * this.height];
-				const [offset_x, offset_y] = [radius_w + 2, radius_h + 9];
 				const points = angles.map(
-					(angle) =>
-						new Point(Math.cos(angle) * radius_w + offset_x, Math.sin(angle) * radius_h + offset_y),
+					(angle) => new Point(Math.cos(angle) * radius_w, Math.sin(angle) * radius_h),
 				);
 				this.hitBox.hitArea = new Polygon(points);
 			}
 
-			this.display = grid.displayHexesGroup.create(x, y, 'hex');
+			this.display = grid.displayHexesGroup.create(x_px, y_px, 'hex');
 			this.display.alpha = 0;
+			this.display.anchor.setTo(0.5);
+			this.display.scale.set(1, 0.75);
 
-			this.overlay = grid.overlayHexesGroup.create(x, y, 'hex');
+			this.overlay = grid.overlayHexesGroup.create(x_px, y_px, 'hex');
 			this.overlay.alpha = 0;
+			this.overlay.anchor.setTo(0.5);
+			this.overlay.scale.set(1, 0.75);
 
 			// Binding Events
 			this.hitBox.events.onInputOver.add(() => {
@@ -531,13 +527,13 @@ export class Hex {
 		this.display.alpha = targetAlpha ? 1 : 0;
 
 		if (this.displayClasses.match(/shrunken/)) {
-			this.display.scale.setTo(shrinkScale);
-			this.overlay.scale.setTo(shrinkScale);
+			this.display.scale.setTo(shrinkScale, 0.75 * shrinkScale);
+			this.overlay.scale.setTo(shrinkScale, 0.75 * shrinkScale);
 			this.display.alignIn(this.hitBox, Phaser.CENTER);
 			this.overlay.alignIn(this.hitBox, Phaser.CENTER);
 		} else {
-			this.display.scale.setTo(1);
-			this.overlay.scale.setTo(1);
+			this.display.scale.setTo(1, 0.75);
+			this.overlay.scale.setTo(1, 0.75);
 			this.display.alignIn(this.hitBox, Phaser.CENTER);
 			this.overlay.alignIn(this.hitBox, Phaser.CENTER);
 		}
@@ -545,17 +541,15 @@ export class Hex {
 		// Display Coord
 		if (this.displayClasses.match(/showGrid/g)) {
 			if (!(this.coordText && this.coordText.exists)) {
-				this.coordText = this.game.Phaser.add.text(
-					this.originalDisplayPos.x + 45,
-					this.originalDisplayPos.y + 63,
-					this.coord,
-					{
-						font: '30pt Play',
-						fill: '#000000',
-						align: 'center',
-					},
-				);
+				const px = Const.offsetCoordsToPx(this);
+				this.coordText = this.game.Phaser.add.text(px.x, px.y, this.coord, {
+					font: '30pt Play',
+					fill: '#000000',
+					align: 'center',
+				});
 				this.coordText.anchor.setTo(0.5);
+				// NOTE: Squish the numbers vertically for a "perspective" effect.
+				this.coordText.scale.set(1, 0.75);
 				this.grid.overlayHexesGroup.add(this.coordText);
 			}
 		} else if (this.coordText && this.coordText.exists) {

--- a/src/utility/trap.ts
+++ b/src/utility/trap.ts
@@ -33,7 +33,6 @@ export class Trap {
 	typeOver = false;
 	destroyAnimation: DestroyAnimationType = 'none';
 
-	//
 	display: Phaser.Sprite;
 	displayOver: Phaser.Sprite;
 
@@ -78,15 +77,11 @@ export class Trap {
 
 		const spriteName = 'trap_' + type;
 		const px = offsetCoordsToPx(this);
-		this.display = game.grid.trapGroup.create(px.x + HEX_WIDTH_PX / 2, px.y + 60, spriteName);
+		this.display = game.grid.trapGroup.create(px.x, px.y, spriteName);
 		this.display.anchor.setTo(0.5);
 
 		if (this.typeOver) {
-			this.displayOver = game.grid.trapOverGroup.create(
-				px.x + HEX_WIDTH_PX / 2,
-				px.y + 60,
-				spriteName,
-			);
+			this.displayOver = game.grid.trapOverGroup.create(px.x, px.y, spriteName);
 			this.displayOver.anchor.setTo(0.5);
 			this.displayOver.scale.x *= -1;
 		}


### PR DESCRIPTION
This is a cleanup of #2443, addressing issues raised there, **except for sprite texture "feet", e.g. Uncle Fungus positioning**.

As positioning those elements might require a fair amount of tweaking, I'll submit it as a separate PR.