### PR TITLE
refactor: remove deprecated update method from queue

### DIFF
--- a/src/creature.ts
+++ b/src/creature.ts
@@ -386,7 +386,6 @@ export class Creature {
 			this.materializationSickness = false;
 		}
 
-		game.queue.update();
 		game.updateQueueDisplay();
 
 		game.grid.orderCreatureZ();
@@ -1922,7 +1921,6 @@ export class Creature {
 
 		this.cleanHex();
 
-		game.queue.update();
 		game.updateQueueDisplay();
 		game.grid.updateDisplay();
 

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -111,11 +111,6 @@ export class Creature {
 	 *
 	 */
 
-	/* Constructor(obj)
-	 *
-	 * obj :			Object :	Object containing all creature stats
-	 *
-	 */
 	// Engine
 	game: Game;
 	name: string;
@@ -166,6 +161,11 @@ export class Creature {
 
 	creatureSprite: CreatureSprite;
 
+	/**
+	 * @constructor
+	 * @param{Object} obj - Object containing all creature stats
+	 * @param{Game} game - Game instance
+	 */
 	constructor(obj, game: Game) {
 		// Engine
 		this.game = game;
@@ -429,10 +429,8 @@ export class Creature {
 		this.creatureSprite.showHealth(true);
 	}
 
-	/* activate()
-	 *
+	/**
 	 * Activate the creature by showing movement range and binding controls to this creature
-	 *
 	 */
 	activate() {
 		this.travelDist = 0;
@@ -607,8 +605,8 @@ export class Creature {
 		game.updateQueueDisplay();
 	}
 
-	/* queryMove()
-	 * launch move action query
+	/**
+	 * Launch move action query
 	 */
 	// TODO: type `args` in `QueryMoveOptions`
 	queryMove(options?: QueryMoveOptions) {
@@ -740,12 +738,9 @@ export class Creature {
 		}
 	}
 
-	/* previewPosition(hex)
-	 *
-	 * hex :		Hex :		Position
-	 *
+	/**
 	 * Preview the creature position at the given Hex
-	 *
+	 * @param{Hex} hex - Position
 	 */
 	previewPosition(hex: Hex) {
 		const game = this.game;
@@ -791,10 +786,8 @@ export class Creature {
 		}
 	}
 
-	/* cleanHex()
-	 *
+	/**
 	 * Clean current creature hexagons
-	 *
 	 */
 	cleanHex() {
 		this.hexagons.forEach((hex) => {
@@ -803,10 +796,8 @@ export class Creature {
 		this.hexagons = [];
 	}
 
-	/* updateHex()
-	 *
+	/**
 	 * Update the current hexes containing the creature and their display
-	 *
 	 */
 	updateHex() {
 		const count = this.size;
@@ -821,13 +812,10 @@ export class Creature {
 		});
 	}
 
-	/* faceHex(facefrom,faceto)
-	 *
-	 * facefrom :	Hex or Creature :	Hex to face from
-	 * faceto :	Hex or Creature :	Hex to face
-	 *
+	/**
 	 * Face creature at given hex
-	 *
+	 * @param{Hex | Creature} facefrom - Hex to face from
+	 * @param{Hex | Creature} faceto - Hex to face
 	 */
 	faceHex(
 		faceto: Hex | Creature,
@@ -894,10 +882,8 @@ export class Creature {
 			this.sprite.texture.width / 2;
 	}
 
-	/* facePlayerDefault()
-	 *
-	 * Face default direction
-	 *
+	/**
+	 * Make creature face the default direction of its player
 	 */
 	facePlayerDefault() {
 		if (this.player.flipped) {
@@ -912,13 +898,10 @@ export class Creature {
 			this.sprite.texture.width / 2;
 	}
 
-	/* moveTo(hex,opts)
-	 *
-	 * hex :		Hex :		Destination Hex
-	 * opts :		Object :	Optional args object
-	 *
+	/**
 	 * Move the creature along a calculated path to the given coordinates
-	 *
+	 * @param{Hex} hex - Destination Hex
+	 * @param{Object} opts - Optional args object
 	 */
 	moveTo(hex, opts) {
 		const game = this.game,
@@ -977,12 +960,8 @@ export class Creature {
 	}
 
 	/**
-	 * tracePath()
-	 *
-	 * @param{Point} destination: the end of the path.
-	 *
 	 * Trace the path from the current position to the given coordinates
-	 *
+	 * @param{Point} destination: the end of the path.
 	 */
 	tracePath(destination: Point) {
 		const path = this.calculatePath(destination); // Store path in grid to be able to compare it later
@@ -1044,12 +1023,8 @@ export class Creature {
 	}
 
 	/**
-	 * calculatePath(destination:Point)
-	 *
 	 * @param{Point} destination: the end of the path.
-	 *
-	 * return :	Array :	Array containing the path hexes
-	 *
+	 * @returns{Point[]} Array containing the path points.
 	 */
 	calculatePath(destination: Point) {
 		const game = this.game;
@@ -1063,15 +1038,11 @@ export class Creature {
 		); // Calculate path
 	}
 
-	/* calcOffset(x,y)
-	 *
-	 * x :		Integer :	Destination coordinates
-	 * y :		Integer :	Destination coordinates
-	 *
-	 * return :	Object :	New position taking into acount the size, orientation and obstacle {x,y}
-	 *
+	/**
 	 * Return the first possible position for the creature at the given coordinates
-	 *
+	 * @param{number} x - Integer, Destination coordinates
+	 * @param{number} y - Integer, Destination coordinates
+	 * @returns{Object} New position taking into acount the size, orientation and obstacle {x,y}
 	 */
 	calcOffset(x: number, y: number) {
 		const game = this.game,
@@ -1096,22 +1067,17 @@ export class Creature {
 		};
 	}
 
-	/* getInitiative()
-	 *
-	 * return :	Integer :	Initiative value to order the queue
-	 *
+	/**
+	 * @returns{number} Initiative value to order the queue
 	 */
 	getInitiative(): number {
 		// To avoid 2 identical initiative
 		return this.stats.initiative * 500 - this.id;
 	}
 
-	/* adjacentHexes(dist)
-	 *
-	 * dist :		Integer :	Distance in hexagons
-	 *
-	 * return :	Array :		Array of adjacent hexagons
-	 *
+	/**
+	 * @param{number} dist - Integer, Distance in hexagons
+	 * @returns{Hex[]} Array of adjacent hexagons
 	 */
 	adjacentHexes(dist: number, clockwise?: boolean) {
 		const game = this.game;
@@ -1267,7 +1233,7 @@ export class Creature {
 		}
 	}
 
-	/** recharge
+	/**
 	 * @param {number} amount: amount of energy to restore
 	 * @return {void}
 	 * Restore energy up to the max limit
@@ -1283,7 +1249,6 @@ export class Creature {
 	/**
 	 * Restore endurance to a creature. Will be capped against the creature's maximum
 	 * endurance (this.stats.endurance).
-	 *
 	 * @param {*} amount Number of endurance points to restore.
 	 */
 	restoreEndurance(amount: number, log = true) {
@@ -1308,9 +1273,8 @@ export class Creature {
 		}
 	}
 
-	/* heal(amount)
-	 *
-	 * amount :	Damage :	Amount of health point to restore
+	/**
+	 * @param{number} amount - Amount of health point to restore
 	 */
 	heal(amount: number, isRegrowth: boolean, log = true) {
 		const game = this.game;
@@ -1358,11 +1322,9 @@ export class Creature {
 		game.onHeal(this, amount);
 	}
 
-	/* takeDamage(damage)
-	 *
-	 * damage :	Damage : 	Damage object
-	 *
-	 * return :	Object :	Contains damages dealt and if creature is killed or not
+	/**
+	 * @param{Damage} damage - Damage object
+	 * @returns{Object} Contains damages dealt and if creature is killed or not
 	 */
 	takeDamage(damage: Damage, o) {
 		const game = this.game;
@@ -1748,10 +1710,8 @@ export class Creature {
 		);
 	}
 
-	/* updateAlteration()
-	 *
+	/**
 	 * Update the stats taking into account the effects' alteration
-	 *
 	 */
 	updateAlteration() {
 		this.stats = { ...this.baseStats };
@@ -1797,12 +1757,9 @@ export class Creature {
 		this.remainingMove = Math.min(this.remainingMove, this.stats.movement);
 	}
 
-	/* die()
-	 *
-	 * kill animation. remove creature from queue and from hexes
-	 *
-	 * killer :	Creature :	Killer of this creature
-	 *
+	/**
+	 * Play kill animation. Remove creature from queue and from hexes.
+	 * @param{Creature | {player:Player}} killerCreature - Killer of this creature
 	 */
 	die(killerCreature: Creature | { player: Player }) {
 		const game = this.game;
@@ -1941,9 +1898,8 @@ export class Creature {
 		return this.stats.endurance === 1;
 	}
 
-	/* getHexMap()
-	 *
-	 * shortcut convenience function to grid.getHexMap
+	/**
+	 * Shortcut convenience function to grid.getHexMap
 	 */
 	getHexMap(map: AugmentedMatrix, invertFlipped: boolean) {
 		const x = (this.player.flipped ? !invertFlipped : invertFlipped)

--- a/src/creature_queue.ts
+++ b/src/creature_queue.ts
@@ -36,9 +36,4 @@ export class CreatureQueue {
 	getCurrentQueueLength() {
 		return this._getCreatures().filter((c) => c.isInCurrentQueue).length;
 	}
-
-	/**
-	 * @deprecated CreatureQueue is derived on the fly. No need to update.
-	 */
-	update() {}
 }

--- a/src/effect.ts
+++ b/src/effect.ts
@@ -41,13 +41,14 @@ export class Effect {
 	// Refactor to remove.
 	attacker: Creature | undefined = undefined;
 
-	/* Constructor(name, owner, target, trigger, optArgs)
-	 *
-	 * name: name of the effect
-	 * owner :	Creature : Creature that casted the effect
-	 * target :	Object : Creature or Hex : the object that possess the effect
-	 * trigger :	String : Event that trigger the effect
-	 * optArgs: dictionary of optional arguments
+	/**
+	 * @param{string} name - name of the effect
+	 * @param{EffectOwner} owner - Creature that created the effect
+	 * @param{EffectTarget} target - Creature or Hex : the object that possess the effect
+	 * @param{string} trigger - Event that trigger the effect
+	 * @param{EffectOptions} optArgs - dictionary of optional arguments
+	 * @param{Game} game
+	 * @constructor
 	 */
 	constructor(
 		name: string,

--- a/src/ui/chat.js
+++ b/src/ui/chat.js
@@ -2,10 +2,9 @@ import * as $j from 'jquery';
 import * as str from '../utility/string';
 
 export class Chat {
-	/* Constructor
-	 *
+	/**
 	 * Chat/Log Functions
-	 *
+	 * @constructor
 	 */
 	constructor(game) {
 		this.game = game;

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -41,10 +41,9 @@ export class UI {
 	 *
 	 */
 
-	/* Constructor
-	 *
+	/**
 	 * Create attributes and default buttons
-	 *
+	 * @constructor
 	 */
 	constructor(game) {
 		this.game = game;
@@ -1182,11 +1181,9 @@ export class UI {
 		}
 	}
 
-	/* changePlayerTab(id)
-	 *
-	 * id :	Integer :	player id
-	 *
+	/**
 	 * Change to the specified player tab in the dash
+	 * @param{number} id - player id (integer)
 	 */
 	changePlayerTab(id) {
 		const game = this.game;
@@ -1459,12 +1456,10 @@ export class UI {
 		this.$scoreboard.addClass('hide');
 	}
 
-	/* toggleDash()
-	 *
+	/**
 	 * Show the dash and hide some buttons
-	 * Takes optional 'randomize' parameter to select a random creature from the grid.
+	 * @param{boolean} [randomize] - True selects a random creature from the grid.
 	 */
-
 	toggleDash(randomize) {
 		const game = this.game;
 
@@ -1717,8 +1712,7 @@ export class UI {
 
 		this.gridSelectPrevious();
 	}
-	/* changeAbilityButtons()
-	 *
+	/**
 	 * Change ability buttons and bind events
 	 */
 	changeAbilityButtons() {
@@ -1961,8 +1955,6 @@ export class UI {
 		}
 	}
 
-	/* updateTimer()
-	 */
 	updateTimer() {
 		const game = this.game,
 			date = new Date() - game.pauseTime;

--- a/src/ui/progressbar.js
+++ b/src/ui/progressbar.js
@@ -22,10 +22,8 @@ export class ProgressBar {
 		this.setSize(1);
 	}
 
-	/* setSize
-	 *
-	 * percentage :	Float :	Size between 0 and 1
-	 *
+	/**
+	 * @param{number} percentage - Size between 0 and 1
 	 */
 	setSize(percentage) {
 		this.$bar.css({
@@ -43,10 +41,8 @@ export class ProgressBar {
 		});
 	}
 
-	/* animSize
-	 *
-	 * percentage :	Float :	size between 0 and 1
-	 *
+	/**
+	 * @param{number} percentage - size between 0 and 1
 	 */
 	animSize(percentage) {
 		this.$bar.transition(
@@ -72,10 +68,8 @@ export class ProgressBar {
 		);
 	}
 
-	/* previewSize
-	 *
-	 * percentage :	Float :	size between 0 and 1
-	 *
+	/**
+	 * @param{number} percentage - size between 0 and 1
 	 */
 	previewSize(percentage) {
 		this.$preview.css(

--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -264,16 +264,13 @@ export class Hex {
 		// No-op function.
 	}
 
-	/* adjacentHex(distance)
-	 *
-	 * distance : 	integer : 	Distance form the current hex
-	 *
-	 * return : 	Array : 	Array containing hexes
-	 *
+	/**
 	 * This function return an array containing all hexes of the grid
 	 * at the distance given of the current hex.
+	 * @param {number} distance - Integer distance form the current hex
+	 * @returns {Array} Array containing hexes
 	 */
-	adjacentHex(distance: number) {
+	adjacentHex(distance: number): Array<Hex> {
 		const adjHex = [];
 
 		for (let i = -distance; i <= distance; i++) {
@@ -310,9 +307,8 @@ export class Hex {
 		return adjHex;
 	}
 
-	/* ghostOverlap()
-	 *
-	 * add ghosted class to creature on hexes behind this hex
+	/**
+	 * Add ghosted class to creature on hexes behind this hex
 	 */
 	ghostOverlap() {
 		const grid = this.grid || this.game.grid;
@@ -359,14 +355,12 @@ export class Hex {
 		}
 	}
 
-	/* cleanPathAttr(includeG)
-	 *
-	 * includeG : 	Boolean : 	Set includeG to True if you change the start of the calculated path.
-	 *
+	/**
 	 * This function reset all the pathfinding attribute to
 	 * 0 to calculate new path to another hex.
+	 * @param{boolean} includeG - Set includeG to True if you change the start of the calculated path.
 	 */
-	cleanPathAttr(includeG) {
+	cleanPathAttr(includeG: boolean) {
 		this.f = 0;
 		this.g = includeG ? 0 : this.g;
 		this.h = 0;
@@ -374,7 +368,6 @@ export class Hex {
 	}
 
 	/**
-	 *
 	 * @param size Size of the creature.
 	 * @param id ID of the creature.
 	 * @param ignoreReachable Take into account the reachable property.
@@ -418,8 +411,7 @@ export class Hex {
 		return !blocked; // Its walkable if it's NOT blocked
 	}
 
-	/* overlayVisualState
-	 *
+	/**
 	 * Change the appearance of the overlay hex
 	 */
 	overlayVisualState(classes) {
@@ -438,8 +430,7 @@ export class Hex {
 		this.updateStyle();
 	}
 
-	/* cleanOverlayVisualState
-	 *
+	/**
 	 * Clear the appearance of the overlay hex
 	 */
 	cleanOverlayVisualState(classes = '') {
@@ -456,8 +447,7 @@ export class Hex {
 		this.updateStyle();
 	}
 
-	/* cleanDisplayVisualState
-	 *
+	/**
 	 * Clear the appearance of the display hex
 	 */
 	cleanDisplayVisualState(classes = '') {
@@ -475,8 +465,7 @@ export class Hex {
 		this.updateStyle();
 	}
 
-	/* setReachable()
-	 *
+	/**
 	 * Set Hex.reachable to True for this hex and change $display class
 	 */
 	setReachable() {
@@ -485,8 +474,7 @@ export class Hex {
 		this.updateStyle();
 	}
 
-	/* unsetReachable()
-	 *
+	/**
 	 * Set Hex.reachable to False for this hex and change $display class
 	 */
 	unsetReachable() {
@@ -582,14 +570,13 @@ export class Hex {
 		this.overlay.alpha = targetAlpha ? 1 : 0;
 	}
 
-	/** Add a trap to a hex.
+	/**
+	 * Add a trap to a hex.
 	 * @param {string} type - name of sprite to use; see Phaser.load.image usage
 	 * @param {array} effects - effects to activate when trap triggered
 	 * @param {Object} owner - owner of trap
 	 * @param {Object} opt - optional arguments merged into the Trap object
-	 *
 	 * @returns {Trap} trap
-	 *
 	 * Examples:
 	 * - turnLifetime
 	 * - fullTurnLifetime
@@ -606,7 +593,6 @@ export class Hex {
 	/**
 	 * @param trigger
 	 * @param target
-	 *
 	 * @deprecated: use PointFacade - e.g., getPointFacade().getTrapsAt(point).forEach(trap => trap.activate(trigger, target))
 	 */
 	activateTrap(trigger, target) {
@@ -614,9 +600,7 @@ export class Hex {
 	}
 
 	/**
-	 *
 	 * @returns void
-	 *
 	 * @deprecated Traps are no longer held in a Hex. user PointFacade - e.g., getPointFacade().getTrapsAt(point).forEach(trap => trap.destroy());
 	 */
 	destroyTrap() {
@@ -634,11 +618,8 @@ export class Hex {
 
 	/**
 	 * Override toJSON to avoid circular references when outputting to game log
-	 * Used by game log only
-	 *
-	 * @returns {Object} coordinates
-	 * @returns {number} coordinates.x
-	 * @returns {number} coordinates.y
+	 * Used by game log only.
+	 * @returns {{x:number, y:number}} x/y coordinates
 	 */
 	toJSON() {
 		return {


### PR DESCRIPTION
This is a small cleanup PR. It removes calls to the no-op `update` method in `CreatureQueue`. It also removes the method from `CreatureQueue` altogether.

----

Edit: 

This PR now also includes a second commit reformatting some comments as JSDoc. This allows the editor to display pop-ups with function descriptions, etc. E.g.,

[JSDoc comments *must* begin with `/**`, not `/*` or `/***`.](https://jsdoc.app/about-getting-started.html)

This ...

```
/* My awesome function
*/

```

... is not a properly formatted JSDoc comment and does not pop up in VS Code.

But this ...

```
/** My awesome function
*/

```

... is a properly formatted JSDoc comment and will show up in the editor pop-up.

This commit also edits a few comments, where obvious. E.g., function names were removed from JSDocs. The function/method name is not necessary and if present in the JSDoc, it will cause the function name to show up twice in the editor pop-up.
