### PR TITLE
Implement types from `units.ts` & `types.ts`

### DIFF
--- a/src/__tests__/creature.ts
+++ b/src/__tests__/creature.ts
@@ -11,7 +11,9 @@ describe('Creature', () => {
 		beforeEach(() => (game = getGameMock()));
 
 		test('"materialized" creatures are automatically assigned separate ids', () => {
+			// @ts-ignore
 			const creature0 = new Creature(getCreatureObjMock(), game);
+			// @ts-ignore
 			const creature1 = new Creature(getCreatureObjMock(), game);
 			expect(creature0).toBeDefined();
 			expect(creature1).toBeDefined();
@@ -22,8 +24,10 @@ describe('Creature', () => {
 		test('a "materialized" (not temp) creature will reuse an existing, matching "unmaterialized" creature id', () => {
 			const obj = getCreatureObjMock();
 			obj.temp = true;
+			// @ts-ignore
 			const creatureTemp = new Creature(obj, game);
 			obj.temp = false;
+			// @ts-ignore
 			const creatureNotTemp = new Creature(obj, game);
 			expect(creatureTemp.id).toBe(creatureNotTemp.id);
 		});

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -11,6 +11,8 @@ import { Player, PlayerID } from './player';
 import { Damage } from './damage';
 import { AugmentedMatrix } from './utility/matrices';
 import { HEX_WIDTH_PX, offsetCoordsToPx } from './utility/const';
+import { CreatureType, Level, Realm, Unit, UnitName } from './data/types';
+import { UnitDisplayInfo, UnitSize } from './data/units';
 
 // to fix @ts-expect-error 2554: properly type the arguments for the trigger functions in `game.ts`
 
@@ -37,6 +39,8 @@ export type CreatureMasteries = {
 	sonic: number;
 	mental: number;
 };
+
+export type Movement = 'normal' | 'flying' | 'hover';
 
 type CreatureStats = CreatureVitals &
 	CreatureMasteries & {
@@ -68,8 +72,6 @@ type Status = {
 	cryostasis: boolean;
 	dizzy: boolean;
 };
-
-type Movement = 'normal' | 'flying';
 
 /**
  * Creature Class
@@ -113,17 +115,17 @@ export class Creature {
 
 	// Engine
 	game: Game;
-	name: string;
+	name: UnitName;
 	id: number;
 	x: number;
 	y: number;
-	pos: { x: number; y: number };
-	size: number;
-	type: string;
-	level: number;
-	realm: string;
+	pos: Point;
+	size: UnitSize;
+	type: CreatureType;
+	level: Level;
+	realm: Realm;
 	animation: { walk_speed: number };
-	display: object;
+	display: UnitDisplayInfo;
 	drop: DropDefinition;
 	_movementType: Movement;
 	temp: boolean;
@@ -166,7 +168,23 @@ export class Creature {
 	 * @param{Object} obj - Object containing all creature stats
 	 * @param{Game} game - Game instance
 	 */
-	constructor(obj, game: Game) {
+	constructor(
+		obj: Unit & {
+			// These properties are created by the `summon` method in `player.ts`
+			x: number;
+			y: number;
+			team: PlayerID;
+			temp: boolean;
+			// These are properties that might not exists on all creatures
+			type?: CreatureType;
+			drop?: DropDefinition;
+			display?: UnitDisplayInfo;
+			movementType?: Movement;
+			// This depends on player._summonCreaturesWithMaterializationSickness
+			materializationSickness?: boolean;
+		},
+		game: Game,
+	) {
 		// Engine
 		this.game = game;
 		this.name = obj.name;
@@ -177,9 +195,9 @@ export class Creature {
 			x: this.x,
 			y: this.y,
 		};
-		this.size = obj.size - 0;
+		this.size = obj.size;
 		this.type = obj.type;
-		this.level = obj.level - 0;
+		this.level = obj.level;
 		this.realm = obj.realm;
 		this.animation = obj.animation;
 		this.display = obj.display;

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -30,3 +30,6 @@ export type Level = (typeof unitLevels)[number];
 
 // Create a union of valid creature `type`s
 export type CreatureType = ExtractValidCreatureTypes<UnitData>;
+
+// Extract each literal unit from `units.ts`
+export type Unit = UnitData[number];

--- a/src/data/units.ts
+++ b/src/data/units.ts
@@ -1,3 +1,13 @@
+import { Movement } from '../creature';
+
+export type UnitSize = 1 | 2 | 3;
+export type UnitDisplayInfo = {
+	width: number;
+	height: number;
+	'offset-x': number;
+	'offset-y': number;
+};
+
 type Stats = {
 	health: number;
 	regrowth: number;
@@ -25,13 +35,13 @@ type UnitDataStructure = readonly {
 	playable: boolean;
 	level: number | string;
 	realm: string;
-	size: number;
+	size: UnitSize;
 	stats: Stats;
 	animation: { walk_speed: number };
 	type?: string;
 	drop?: { name: string } & Partial<Stats>;
-	movementType?: 'hover';
-	display?: { width: number; height: number; 'offset-x': number; 'offset-y': number };
+	movementType?: Movement;
+	display?: UnitDisplayInfo;
 	set?: 'α' | 'β';
 
 	ability_info: readonly {


### PR DESCRIPTION
Some additional changes related to implementing the mentioned types:

## `player.ts`
- Adjusted variable names in the `summon` method for clarity. Also typed the arguments.
- Addressed type errors in `getScore`.

## `creature.ts`
- Typed the `obj` argument of the constructor.
- Also added some comments on where the properties of `obj` are defined.

## Tests for `creature.ts`
- Added `@ts-ignore` comments to prevent mocking the entire `obj` now that it is typed.

## Types
- Created `UnitSize` & `UnitDisplayInfo`.
- Adjusted `Movement` definition.
