### PR TITLE
Creature sprite refactor

### DIFF
--- a/src/__tests__/creature.ts
+++ b/src/__tests__/creature.ts
@@ -1,5 +1,5 @@
 import { Creature } from '../creature';
-import { jest, expect, describe, test, beforeEach } from '@jest/globals';
+import { jest, expect, describe, test, beforeEach, beforeAll } from '@jest/globals';
 
 // NOTE: ts-comments are necessary in this file to avoid mocking the entire game.
 /* eslint-disable @typescript-eslint/ban-ts-comment */
@@ -293,18 +293,23 @@ const getGameMock = () => {
 
 const getPhaserMock = () => {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const self: Record<string, any> = {};
-	self.tween = () => self;
-	self.to = () => self;
+	const self: Record<string, any> = { position: { set: jest.fn() } };
+	self.add = () => self;
+	self.create = () => self;
+	self.forEach = () => self;
+	self.group = () => self;
+	self.removeChild = () => self;
+	self.setTo = () => self;
 	self.start = () => self;
 	self.text = () => self;
+	self.to = () => self;
+	self.tween = () => self;
 	self.anchor = self;
-	self.setTo = () => self;
-	self.group = () => self;
-	self.create = () => self;
+	self.data = {};
+	self.onComplete = self;
+	self.parent = self;
 	self.sprite = self;
 	self.scale = self;
-	self.add = () => self;
 	self.texture = {
 		width: 10,
 		height: 10,
@@ -314,3 +319,11 @@ const getPhaserMock = () => {
 		add: self,
 	};
 };
+
+beforeAll(() => {
+	Object.defineProperty(window, 'Phaser', {
+		get() {
+			return { Easing: { Linear: { None: 1 } } };
+		},
+	});
+});

--- a/src/animations.ts
+++ b/src/animations.ts
@@ -265,7 +265,7 @@ export class Animations {
 		startY: number,
 	) {
 		// Get the target's position on the projectile's path that is closest
-		const emissionPointX = this2.creature.grp.x + startX;
+		const emissionPointX = this2.creature.legacyProjectileEmissionPoint.x + startX;
 		let distance = Number.MAX_SAFE_INTEGER;
 		let targetX = path[0].displayPos.x;
 		for (const hex of path) {
@@ -280,8 +280,8 @@ export class Animations {
 			baseDist = arrayUtils.filterCreature(path.slice(0), false, false).length,
 			dist = baseDist == 0 ? 1 : baseDist,
 			emissionPoint = {
-				x: this2.creature.grp.x + startX,
-				y: this2.creature.grp.y + startY,
+				x: this2.creature.legacyProjectileEmissionPoint.x + startX,
+				y: this2.creature.legacyProjectileEmissionPoint.y + startY,
 			},
 			targetPoint = {
 				x: targetX + 45,

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -371,24 +371,6 @@ export class Creature {
 	get sprite() {
 		return this.creatureSprite.sprite;
 	}
-	get hintGrp() {
-		return this.creatureSprite.hintGrp;
-	}
-	get healthIndicatorGroup() {
-		return this.creatureSprite.healthIndicatorGroup;
-	}
-	get healthIndicatorSprite() {
-		return this.creatureSprite.healthIndicatorSprite;
-	}
-	get healthIndicatorText() {
-		return this.creatureSprite.healthIndicatorText;
-	}
-	get healthIndicatorTween() {
-		return this.creatureSprite.healthIndicatorTween;
-	}
-	set healthIndicatorTween(tw: Phaser.Tween) {
-		this.creatureSprite.healthIndicatorTween = tw;
-	}
 
 	get legacyProjectileEmissionPoint() {
 		return this.creatureSprite.legacyProjectileEmissionPoint;
@@ -1964,24 +1946,6 @@ class CreatureSprite {
 	get sprite() {
 		return this._sprite;
 	}
-	get hintGrp() {
-		return this._hintGrp;
-	}
-	get healthIndicatorGroup() {
-		return this._healthIndicatorGroup;
-	}
-	get healthIndicatorSprite() {
-		return this._healthIndicatorSprite;
-	}
-	get healthIndicatorText() {
-		return this._healthIndicatorText;
-	}
-	get healthIndicatorTween() {
-		return this._healthIndicatorTween;
-	}
-	set healthIndicatorTween(tw: Phaser.Tween) {
-		this._healthIndicatorTween = tw;
-	}
 
 	// TODO: Refactor
 	// This currently has one user.
@@ -2139,7 +2103,7 @@ class CreatureSprite {
 		};
 
 		// Remove constant element
-		this.hintGrp.forEach(
+		this._hintGrp.forEach(
 			(hint: Phaser.Text) => {
 				if (hint.data.hintType === 'confirm') {
 					hint.data.hintType = 'confirm_deleted';
@@ -2177,12 +2141,12 @@ class CreatureSprite {
 			hint.data.tweenAlpha.onComplete.add(() => hint.destroy());
 		}
 
-		this.hintGrp.add(hint);
+		this._hintGrp.add(hint);
 
 		// Stacking
-		this.hintGrp.forEach(
+		this._hintGrp.forEach(
 			(hint: Phaser.Text) => {
-				const index = this.hintGrp.total - this.hintGrp.getIndex(hint) - 1;
+				const index = this._hintGrp.total - this._hintGrp.getIndex(hint) - 1;
 				const offset = -50 * index;
 
 				if (hint.data.tweenPos) {

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -1467,18 +1467,11 @@ export class Creature {
 	}
 
 	displayHealthStats() {
-		if (this.isFrozen()) {
-			this.healthIndicatorSprite.loadTexture('p' + this.team + '_frozen');
-		} else {
-			this.healthIndicatorSprite.loadTexture('p' + this.team + '_health');
-		}
-
-		this.healthIndicatorText.setText(this.health + '');
+		this.creatureSprite.setHealth(this.health, this.isFrozen() ? 'frozen' : 'health');
 	}
 
 	displayPlasmaShield() {
-		this.healthIndicatorSprite.loadTexture('p' + this.team + '_plasma');
-		this.healthIndicatorText.setText(this.player.plasma.toString());
+		this.creatureSprite.setHealth(this.player.plasma, 'plasma');
 	}
 
 	hasCreaturePlayerGotPlasma() {
@@ -1888,6 +1881,7 @@ class CreatureSprite {
 	private _phaser: Phaser.Game;
 	private _frameInfo: { originX: number; originY: number };
 	private _creatureSize: number;
+	private _creatureTeam: PlayerID;
 
 	private _isXray = false;
 
@@ -1898,6 +1892,7 @@ class CreatureSprite {
 
 		this._phaser = phaser;
 		this._creatureSize = size;
+		this._creatureTeam = team;
 		this._frameInfo = { originX: display['offset-x'], originY: display['offset-y'] };
 
 		const group: Phaser.Group = phaser.add.group(game.grid.creatureGroup, 'creatureGrp_' + id);
@@ -2062,6 +2057,11 @@ class CreatureSprite {
 			.start();
 	}
 
+	setHealth(number: number, type: HealthBubbleType) {
+		this._healthIndicatorText.setText(number + '');
+		this._healthIndicatorSprite.loadTexture(`p${this._creatureTeam}_${type}`);
+	}
+
 	showHealth(enable: boolean) {
 		this._healthIndicatorGroup.visible = enable;
 	}
@@ -2211,3 +2211,5 @@ export type CreatureHintType =
 	| 'healing'
 	| 'msg_effects'
 	| 'creature_name';
+
+type HealthBubbleType = 'plasma' | 'frozen' | 'health';

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -838,34 +838,14 @@ export class Creature {
 		}
 
 		const flipped = facefrom.y % 2 === 0 ? faceto.x <= facefrom.x : faceto.x < facefrom.x;
-
-		// TODO: Use CreatureSprite.setDir()
-		if (flipped) {
-			this.sprite.scale.setTo(-1, 1);
-		} else {
-			this.sprite.scale.setTo(1, 1);
-		}
-		this.sprite.x =
-			(!flipped
-				? this.display['offset-x']
-				: HEX_WIDTH_PX * this.size - this.sprite.texture.width - this.display['offset-x']) +
-			this.sprite.texture.width / 2;
+		this.creatureSprite.setDir(flipped ? -1 : 1);
 	}
 
 	/**
 	 * Make creature face the default direction of its player
 	 */
 	facePlayerDefault() {
-		if (this.player.flipped) {
-			this.sprite.scale.setTo(-1, 1);
-		} else {
-			this.sprite.scale.setTo(1, 1);
-		}
-		this.sprite.x =
-			(!this.player.flipped
-				? this.display['offset-x']
-				: HEX_WIDTH_PX * this.size - this.sprite.texture.width - this.display['offset-x']) +
-			this.sprite.texture.width / 2;
+		this.creatureSprite.setDir(this.player.flipped ? -1 : 1);
 	}
 
 	/**

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -407,20 +407,7 @@ export class Creature {
 		game.updateQueueDisplay();
 
 		game.grid.orderCreatureZ();
-
-		if (game.grid.materialize_overlay) {
-			game.grid.materialize_overlay.alpha = 0.5;
-			game.Phaser.add
-				.tween(game.grid.materialize_overlay)
-				.to(
-					{
-						alpha: 0,
-					},
-					500,
-					Phaser.Easing.Linear.None,
-				)
-				.start();
-		}
+		game.grid.fadeOutTempCreature();
 
 		const p: Phaser.Game = game.Phaser;
 		this.creatureSprite.setAlpha(1, 500);

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -390,6 +390,10 @@ export class Creature {
 		this.creatureSprite.healthIndicatorTween = tw;
 	}
 
+	get legacyProjectileEmissionPoint() {
+		return this.creatureSprite.legacyProjectileEmissionPoint;
+	}
+
 	/**
 	 * Summon animation.
 	 */
@@ -1982,6 +1986,13 @@ class CreatureSprite {
 	}
 	set healthIndicatorTween(tw: Phaser.Tween) {
 		this._healthIndicatorTween = tw;
+	}
+
+	// TODO: Refactor
+	// This currently has one user.
+	// Refactoring into some combination of left, right, top, bottom, centerX, centerY would be welcome.
+	get legacyProjectileEmissionPoint() {
+		return { x: this._group.x, y: this._group.y };
 	}
 
 	private _promisifyTween(

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -1699,33 +1699,7 @@ export class Creature {
 		}
 
 		// Kill animation
-		const tweenSprite = game.Phaser.add
-			.tween(this.sprite)
-			.to(
-				{
-					alpha: 0,
-				},
-				500,
-				Phaser.Easing.Linear.None,
-			)
-			.start();
-		const tweenHealth = game.Phaser.add
-			.tween(this.healthIndicatorGroup)
-			.to(
-				{
-					alpha: 0,
-				},
-				500,
-				Phaser.Easing.Linear.None,
-			)
-			.start();
-		tweenSprite.onComplete.add(() => {
-			this.destroy();
-		});
-		tweenHealth.onComplete.add(() => {
-			this.healthIndicatorGroup.destroy();
-		});
-
+		this.creatureSprite.setAlpha(0, 500).then(() => this.destroy());
 		this.cleanHex();
 
 		game.updateQueueDisplay();

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -395,7 +395,6 @@ export class Creature {
 		game.grid.orderCreatureZ();
 		game.grid.fadeOutTempCreature();
 
-		const p: Phaser.Game = game.Phaser;
 		this.creatureSprite.setAlpha(1, 500);
 
 		// Reveal and position health indicator

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -1545,4 +1545,22 @@ export class HexGrid {
 			hexes.forEach((hex) => hex.displayVisualState('creature selected player1'));
 		}
 	}
+
+	fadeOutTempCreature() {
+		// TODO: factor out this function. Use either Creature.creatureSprite
+		// or the existing temp creature created by /src/abilities/Dark-Priest.js
+		if (this.materialize_overlay) {
+			this.materialize_overlay.alpha = 0.5;
+			this.game.Phaser.add
+				.tween(this.materialize_overlay)
+				.to(
+					{
+						alpha: 0,
+					},
+					500,
+					Phaser.Easing.Linear.None,
+				)
+				.start();
+		}
+	}
 }


### PR DESCRIPTION
More refactoring, moving Phaser objects into `CreatureSprite` or out of `Creature` altogether. 

With this PR, there are no more direct references to Phaser in the `Creature` class itself. That's one step closer to having the freedom to do something like #2021, though there's still a long way to go.

There are still some other classes that use the old `Creature` API exposing the Phaser elements, so a few of those getters are still in place to pass calls on to `CreatureSprite`. I'll see about providing a `CreatureSprite` method or two to replace those calls. 

(The calls are Demeter violations and keep `CreatureSprite` tied to its current implementation. For example, even if we switched the game to 3D models, we'd still have to provide the current `sprite.x`, because some abilities dig into `Creature` and grab it.)