### PR TITLE
fix: stop creature health bounce when dash opened, #2451

### DIFF
--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -1468,6 +1468,7 @@ export class UI {
 			return;
 		}
 
+		game.signals.ui.dispatch('onOpenDash');
 		if (randomize && !this.lastViewedCreature) {
 			// Optional: select a random creature from the grid
 			this.showRandomCreature();

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -185,6 +185,7 @@ export class HexGrid {
 
 		// Events
 		this.game.signals.metaPowers.add(this.handleMetaPowerEvent, this);
+		this.game.signals.ui.add(this.handleUIEvent, this);
 	}
 
 	get traps() {
@@ -201,6 +202,21 @@ export class HexGrid {
 	handleMetaPowerEvent(message, payload) {
 		if (message === 'toggleExecuteMonster') {
 			this._executionMode = payload;
+		}
+	}
+
+	handleUIEvent(message, payload) {
+		if (message === 'onOpenDash') {
+			// NOTE: This is a rather hacky bugfix.
+			// If a "query" is going on, and the dash is opened,
+			// creatures can remain in a "hovered" state.
+			// This hack undoes the "hovered" state.
+			this.forEachHex((hex) => {
+				const creature = hex.creature;
+				if (creature instanceof Creature) {
+					creature.resetBounce();
+				}
+			});
 		}
 	}
 


### PR DESCRIPTION
This fixes the health bounce problem outlined in #2451.

It's a bit of a hack, as discussed.

Fwiw, it doesn't fix the similar `Hex` issue, #2455. For the moment, I don't know what's going on there. There seems to be some stale state in `Hex` that's cleared on mouseout, but none of the `Hex` "cleaning" methods in `HexGrid` seem to fix it.

#2455 is a recent issue for a long-standing bug. Since it's not *painfully* obvious, I think I'll keep pulling the unneeded fields out of `Hex` rather than patching it up in its current form.