### PR TITLE
refactor: format JSDoc

### DIFF
--- a/src/ability.ts
+++ b/src/ability.ts
@@ -209,9 +209,8 @@ export class Ability {
 		this.timesUsedThisTurn = 0;
 	}
 
-	/*
+	/**
 	 * Test and use the ability
-	 *
 	 */
 	use() {
 		const game = this.game;
@@ -231,11 +230,10 @@ export class Ability {
 		return this.query();
 	}
 
-	/*
+	/**
 	 * End the ability. Must be called at the end of each ability function;
-	 *
-	 * TODO: Once all files in `abilities` are converted to TS, consider defaulting both of these arguments to `false`.
 	 */
+	//TODO: Once all files in `abilities` are converted to TS, consider defaulting both of these arguments to `false`.
 	end(disableLogMsg?: boolean, deferredEnding?: boolean) {
 		const game = this.game;
 
@@ -413,7 +411,7 @@ export class Ability {
 
 	/**
 	 * Helper to animation method.
-	 * @param  o Animation object to extend.
+	 * @param {object} o - Animation object to extend.
 	 */
 	animation2(o: object): void {
 		const game = this.game;
@@ -626,7 +624,7 @@ export class Ability {
 		return string;
 	}
 
-	/*
+	/**
 	 * targets : Array : Example : target = [ { target: crea1, hexesHit: 2 }, { target: crea2, hexesHit: 1 } ]
 	 */
 	areaDamage(attacker: Creature, damages, effects, targets: Target[], ignoreRetaliation: boolean) {
@@ -898,7 +896,7 @@ export class Ability {
 	/**
 	 * Test whether there are valid targets in directions, using direction queries.
 	 *
-	 * @param {Object} o Dict of arguments for direction query.
+	 * @param {Object} o - Dict of arguments for direction query.
 	 * @return true if valid targets in at least one direction, else false
 	 */
 	testDirection(o: object): boolean {

--- a/src/game.ts
+++ b/src/game.ts
@@ -313,13 +313,10 @@ export default class Game {
 		this.Phaser.load.start();
 	}
 
-	/* loadGame(setupOpt) preload
-	 *
-	 * setupOpt :	Object :	Setup options from matchmaking menu
-	 *
+	/**
+	 * @param {Partial<GameConfig>} setupOpt - Setup options from matchmaking menu
 	 * Load all required game files
 	 */
-
 	loadGame(
 		setupOpt: Partial<GameConfig>,
 		matchInitialized?: boolean,
@@ -462,12 +459,9 @@ export default class Game {
 		this.setup(this.playerMode);
 	}
 
-	/* Setup(playerMode)
-	 *
-	 * playerMode :		Integer :	Ideally 2 or 4, number of players to configure
-	 *
+	/**
+	 * @param {number} playerMode - Ideally 2 or 4, number of players to configure
 	 * Launch the game with the given number of player.
-	 *
 	 */
 	setup(playerMode: number) {
 		let bg, i;
@@ -735,8 +729,7 @@ export default class Game {
 			$j('.lobby-match-list').append(_matchBtn);
 		});
 	}
-	/* resizeCombatFrame()
-	 *
+	/**
 	 * Resize the combat frame
 	 */
 	resizeCombatFrame() {
@@ -745,8 +738,7 @@ export default class Game {
 		}
 	}
 
-	/* nextRound()
-	 *
+	/**
 	 * Replace the current queue with the next queue
 	 */
 	nextRound() {
@@ -756,8 +748,7 @@ export default class Game {
 		this.nextCreature();
 	}
 
-	/* nextCreature()
-	 *
+	/**
 	 * Activate the next creature in queue
 	 */
 	nextCreature() {
@@ -841,10 +832,8 @@ export default class Game {
 		}
 	}
 
-	/* log(obj)
-	 *
-	 * obj :	Any :	Any variable to display in console and game log
-	 *
+	/**
+	 * @param {any} obj - Any variable to display in console and game log
 	 * Display obj in the console log and in the game log
 	 */
 	log(obj, htmlclass?, ifNoTimestamp = false) {
@@ -946,8 +935,7 @@ export default class Game {
 		}
 	}
 
-	/* delayCreature()
-	 *
+	/**
 	 * Delay the action turn of the current creature
 	 */
 	delayCreature(o) {
@@ -1009,8 +997,6 @@ export default class Game {
 		clearInterval(this.timeInterval);
 	}
 
-	/* checkTime()
-	 */
 	checkTime() {
 		let date = new Date().valueOf() - this.pauseTime,
 			p = this.activeCreature.player,
@@ -1104,10 +1090,8 @@ export default class Game {
 		}
 	}
 
-	/* retrieveCreatureStats(type)
-	 *
-	 * type :	String :	Creature's type (ex: "--" for Dark Priest)
-	 *
+	/**
+	 * @param {CreatureType} type -	Creature's type (ex: "--" for Dark Priest)
 	 * Query the database for creature stats.
 	 * Additonaly, ensure that a `type` property exists on each creature.
 	 */

--- a/src/player.ts
+++ b/src/player.ts
@@ -139,11 +139,9 @@ export class Player {
 		return nbr;
 	}
 
-	/* summon(type, pos)
-	 *
-	 * type :	String :	Creature type (ex: "--" for Dark Priest and "G2" for Swampler)
-	 * pos :	Object :	Position {x,y}
-	 *
+	/**
+	 * @param {string} type - Creature type (ex: "--" for Dark Priest and "G2" for Swampler)
+	 * @param {Point} pos - Position {x,y}
 	 */
 	summon(type: CreatureType, pos: Point) {
 		const game = this.game;
@@ -167,10 +165,8 @@ export class Player {
 		game.onCreatureSummon(creature);
 	}
 
-	/* flee()
-	 *
+	/**
 	 * Ask if the player wants to flee the match
-	 *
 	 */
 	flee(o) {
 		this.hasFled = true;
@@ -178,10 +174,8 @@ export class Player {
 		this.game.skipTurn(o);
 	}
 
-	/* getScore()
-	 *
+	/**
 	 * Create and return a totalScore object that includes the point value for each score event as well as the cumulative score
-	 *
 	 */
 	getScore(): TotalScore {
 		let points = 0;
@@ -261,11 +255,9 @@ export class Player {
 		return totalScore;
 	}
 
-	/* isLeader()
-	 *
+	/**
 	 * Test if the player has the greater score.
 	 * Return true if in lead. False if not.
-	 *
 	 * TODO: This is also wrong, because it allows for ties to result in a "leader".
 	 */
 	isLeader(): boolean {
@@ -282,8 +274,7 @@ export class Player {
 		return true; // If nobody has a better score he's in lead
 	}
 
-	/* isAnnihilated()
-	 *
+	/**
 	 * A player is considered annihilated if all his creatures are dead DP included
 	 */
 	isAnnihilated(): boolean {
@@ -298,8 +289,7 @@ export class Player {
 		return annihilated;
 	}
 
-	/* deactivate()
-	 *
+	/**
 	 * Remove all player's creature from the queue
 	 */
 	deactivate(): void {

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -2014,7 +2014,7 @@ export class UI {
 		}
 	}
 
-	/* updateQueueDisplay()
+	/**
 	 * Delete and add element to the Queue container based on the game's queues
 	 */
 	updateQueueDisplay() {


### PR DESCRIPTION
This is a cleanup PR. I believe this fixes the last of a particular kind of malformed JSDoc comment from the codebase:

## Bad

```
/*
 * This isn't a JSDoc and won't show up in as an info box in the editor.
 */
function myFunction() {
```

## Good

```
/**
 * This is a JSDoc.
 */
function myFunction() {
```