### PR TITLE
fix(traps): Fixed traps like the Poisonous Vine being triggered more than once #2464

### DIFF
--- a/src/abilities/Impaler.js
+++ b/src/abilities/Impaler.js
@@ -226,14 +226,27 @@ export default (G) => {
 				);
 
 				// NOTE: Add a trap to every hex of the target
+				// Made it so only one hex has the effect & others are placeholders
+				let trapSet = false;
 				target.hexagons.forEach(function (hex) {
-					hex.createTrap('poisonous-vine', [effect], ability.creature.player, {
-						turnLifetime: lifetime,
-						fullTurnLifetime: true,
-						ownerCreature: ability.creature,
-						destroyOnActivate: true,
-						destroyAnimation: 'shrinkDown',
-					});
+					if (!trapSet) {
+						hex.createTrap('poisonous-vine', [effect], ability.creature.player, {
+							turnLifetime: lifetime,
+							fullTurnLifetime: true,
+							ownerCreature: ability.creature,
+							destroyOnActivate: true,
+							destroyAnimation: 'shrinkDown',
+						});
+						trapSet = true;
+					} else {
+						hex.createTrap('poisonous-vine', [], ability.creature.player, {
+							turnLifetime: lifetime,
+							fullTurnLifetime: true,
+							ownerCreature: ability.creature,
+							destroyOnActivate: true,
+							destroyAnimation: 'shrinkDown',
+						});
+					}
 				});
 			},
 


### PR DESCRIPTION
So I got to fixing it but its a bigger issue overall that I noticed with Traps. After debugging for a bit I found the issue to be in the `onStepOut` function of the game.

Currently we're applying traps to all the hexes but we want them to be a single trap & not be called multiple times, so the broader solution to this is to maybe make traps occupy different number of hexes but being one entity. This will make it so that all trap related functions etc. will be executed once as intended but the trap will just take on as much space as the creature it was applied on.

For now I've made changes to the `triggerTrap` function & updated it to the Trap class since it was using a depreciated call as well as made it so the trap activates once but destroys all instances of the trap the creature is currently on. This fix should work temporarily but I feel the above change to traps is something to resolve the issue completely. If that's the case I would be happy to take it on once the issue is created for it. [Fixes #2464]