### PR TITLE
refactor: hashing, offsetNeighbors

### DIFF
--- a/src/utility/const.ts
+++ b/src/utility/const.ts
@@ -2,9 +2,42 @@ import { Point } from './pointfacade';
 
 export const HEX_WIDTH_PX = 90;
 export const HEX_HEIGHT_PX = (HEX_WIDTH_PX / Math.sqrt(3)) * 2 * 0.75;
+
 export function offsetCoordsToPx(point: Point) {
 	return {
 		x: (point.y % 2 === 0 ? point.x + 0.5 : point.x) * HEX_WIDTH_PX,
 		y: point.y * HEX_HEIGHT_PX,
 	};
+}
+
+const n2_16 = Math.pow(2, 16);
+
+function isValid(point: Point) {
+	return 0 <= point.x && point.x < n2_16 && 0 <= point.y && point.y < n2_16;
+}
+
+export function offsetNeighbors(point: Point): Point[] {
+	if (point.y % 2 === 0) {
+		return [
+			{ x: point.x + 1, y: point.y },
+			{ x: point.x + 1, y: point.y + 1 },
+			{ x: point.x, y: point.y + 1 },
+			{ x: point.x - 1, y: point.y },
+			{ x: point.x, y: point.y - 1 },
+			{ x: point.x + 1, y: point.y - 1 },
+		].filter(isValid);
+	} else {
+		return [
+			{ x: point.x + 1, y: point.y },
+			{ x: point.x, y: point.y + 1 },
+			{ x: point.x - 1, y: point.y + 1 },
+			{ x: point.x - 1, y: point.y },
+			{ x: point.x - 1, y: point.y - 1 },
+			{ x: point.x, y: point.y - 1 },
+		].filter(isValid);
+	}
+}
+
+export function hashOffsetCoords(point: Point) {
+	return (point.x << 16) ^ point.y;
 }

--- a/src/utility/pointfacade.ts
+++ b/src/utility/pointfacade.ts
@@ -1,5 +1,6 @@
 import { Creature } from '../creature';
 import { Drop } from '../drop';
+import { hashOffsetCoords as hash } from './const';
 import { Trap } from './trap';
 
 export type Point = {
@@ -22,10 +23,10 @@ type PointFacadeConfig = {
 };
 
 class PointSet {
-	s: Set<string>;
+	s: Set<number>;
 	config: PointFacadeConfig;
 
-	constructor(s: Set<string>, config: PointFacadeConfig) {
+	constructor(s: Set<number>, config: PointFacadeConfig) {
 		this.s = s;
 		this.config = config;
 	}
@@ -60,7 +61,7 @@ export class PointFacade {
 	}
 
 	getBlockedSet(): PointSet {
-		const blockedSet = new Set<string>();
+		const blockedSet = new Set<number>();
 		for (const c of this.config.getCreatures()) {
 			for (const point of this.config.getCreatureBlockedPoints(c)) {
 				blockedSet.add(hash(point));
@@ -87,9 +88,11 @@ export class PointFacade {
 	getCreaturesAt(point: Point | Creature | Point[] | number, y = 0) {
 		const config = this.config;
 
-		const points: Point[] = normalize(point, y, this.config);
-		const pointsToStr = points.map(hash).join('');
-		const hasPoint = (p: Point) => pointsToStr.indexOf(hash(p)) !== -1;
+		const points: Set<number> = normalize(point, y, this.config).reduce((s, p) => {
+			s.add(hash(p));
+			return s;
+		}, new Set<number>());
+		const hasPoint = (p: Point) => points.has(hash(p));
 
 		return config
 			.getCreatures()
@@ -103,9 +106,11 @@ export class PointFacade {
 	getTrapsAt(point: Point | Creature | Point[] | number, y = 0) {
 		const config = this.config;
 
-		const points: Point[] = normalize(point, y, this.config);
-		const pointsToStr = points.map(hash).join('');
-		const hasPoint = (p: Point) => pointsToStr.indexOf(hash(p)) !== -1;
+		const points: Set<number> = normalize(point, y, this.config).reduce((s, p) => {
+			s.add(hash(p));
+			return s;
+		}, new Set<number>());
+		const hasPoint = (p: Point) => points.has(hash(p));
 
 		return config
 			.getTraps()
@@ -119,9 +124,11 @@ export class PointFacade {
 	getDropsAt(point: Point | Creature | Point[] | number, y = 0) {
 		const config = this.config;
 
-		const points: Point[] = normalize(point, y, this.config);
-		const pointsToStr = points.map(hash).join('');
-		const hasPoint = (p: Point) => pointsToStr.indexOf(hash(p)) !== -1;
+		const points: Set<number> = normalize(point, y, this.config).reduce((s, p) => {
+			s.add(hash(p));
+			return s;
+		}, new Set<number>());
+		const hasPoint = (p: Point) => points.has(hash(p));
 
 		return config
 			.getDrops()
@@ -131,10 +138,6 @@ export class PointFacade {
 					config.getDropPassablePoints(d).some(hasPoint),
 			);
 	}
-}
-
-function hash(point: Point) {
-	return `(${point.x},${point.y})`;
 }
 
 function getMissingConfigRequirements(config: PointFacadeConfig): string[] {


### PR DESCRIPTION
This adds a few useful functions to `const.ts`: `hashOffsetCoords` and `offsetNeighbors`. It also puts the hashing function to use in `pointFacade`.

## Hash details

I had previously implemented a private hashing function in `pointFacade`. But I thought it could be useful elsewhere, so I moved it to `const.ts`. 

An example useful case: sets. Sets are fast and practical. But they don't work with our `Hex` representation out of the box:

```
s.add({x:1, y:1})
s.has({x:1, y:1}) // false 
```

That's because objects in sets are compared by reference. However, if we hash the `Hex` to a value, it can be compared to other hashed values in the set:

```
s.add(hash({x:1, y:1}))
s.has(hash({x:1, y:1})) // true 
```

I also refactored the hash function. Previously, it was `{x:number, y:number} => string`. Now it's `{x:number, y:number} => number`.

## Note

The hashing function uses 16 bits for x, 16 bits for y. (Bitwise operations in JS are limited to 32 bits.) That gives us a max hex x of 65535, and a max hex y of 65535. That should be more than enough – the current maps have a max x of 15 and max y of 8 – but I thought it was worth pointing out, as it's a hard limit.

Fwiw, this happens to be the same hashing scheme that Wesnoth uses for locations.