### PR TITLE
refactor: adjacent hexes, remove clockwise argument, closes  #2470

### DIFF
--- a/src/abilities/Impaler.js
+++ b/src/abilities/Impaler.js
@@ -355,7 +355,7 @@ export default (G) => {
 					nextdmg = nextdmg.damages;
 
 					// Get next available targets
-					let nextTargets = ability.getTargets(trg.adjacentHexes(1, true));
+					let nextTargets = ability.getTargets(trg.adjacentHexes(1));
 
 					nextTargets = nextTargets.filter(function (item) {
 						if (item.hexesHit === undefined) {

--- a/src/utility/const.ts
+++ b/src/utility/const.ts
@@ -17,6 +17,7 @@ function isValid(point: Point) {
 }
 
 export function offsetNeighbors(point: Point): Point[] {
+	// NOTE: returns neighbors in clockwise order starting at 3 o'clock.
 	if (point.y % 2 === 0) {
 		return [
 			{ x: point.x + 1, y: point.y },

--- a/src/utility/const.ts
+++ b/src/utility/const.ts
@@ -2,9 +2,42 @@ import { Point } from './pointfacade';
 
 export const HEX_WIDTH_PX = 90;
 export const HEX_HEIGHT_PX = (HEX_WIDTH_PX / Math.sqrt(3)) * 2 * 0.75;
+
 export function offsetCoordsToPx(point: Point) {
 	return {
 		x: (point.y % 2 === 0 ? point.x + 0.5 : point.x) * HEX_WIDTH_PX,
 		y: point.y * HEX_HEIGHT_PX,
 	};
+}
+
+const n2_16 = Math.pow(2, 16);
+
+function isValid(point: Point) {
+	return 0 <= point.x && point.x < n2_16 && 0 <= point.y && point.y < n2_16;
+}
+
+export function offsetNeighbors(point: Point): Point[] {
+	if (point.y % 2 === 0) {
+		return [
+			{ x: point.x + 1, y: point.y },
+			{ x: point.x + 1, y: point.y + 1 },
+			{ x: point.x, y: point.y + 1 },
+			{ x: point.x - 1, y: point.y },
+			{ x: point.x, y: point.y - 1 },
+			{ x: point.x + 1, y: point.y - 1 },
+		].filter(isValid);
+	} else {
+		return [
+			{ x: point.x + 1, y: point.y },
+			{ x: point.x, y: point.y + 1 },
+			{ x: point.x - 1, y: point.y + 1 },
+			{ x: point.x - 1, y: point.y },
+			{ x: point.x - 1, y: point.y - 1 },
+			{ x: point.x, y: point.y - 1 },
+		].filter(isValid);
+	}
+}
+
+export function hashOffsetCoords(point: Point) {
+	return (point.x << 16) ^ point.y;
 }

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -243,9 +243,7 @@ export class HexGrid {
 	}
 
 	isInBounds({ x, y }: Point) {
-		return (
-			y < this.game.grid.hexes.length && y >= 0 && x < this.game.grid.hexes[y].length && x >= 0
-		);
+		return y < this.hexes.length && y >= 0 && x < this.hexes[y].length && x >= 0;
 	}
 
 	querySelf(o) {

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -8,6 +8,7 @@ import * as arrayUtils from './arrayUtils';
 import Game from '../game';
 import { DEBUG } from '../debug';
 import { HEX_WIDTH_PX } from './const';
+import { Point } from './pointfacade';
 
 interface GridDefinition {
 	numRows: number;
@@ -239,6 +240,12 @@ export class HexGrid {
 				}
 			});
 		}
+	}
+
+	isInBounds({ x, y }: Point) {
+		return (
+			y < this.game.grid.hexes.length && y >= 0 && x < this.game.grid.hexes[y].length && x >= 0
+		);
 	}
 
 	querySelf(o) {

--- a/src/utility/pointfacade.ts
+++ b/src/utility/pointfacade.ts
@@ -1,5 +1,6 @@
 import { Creature } from '../creature';
 import { Drop } from '../drop';
+import { hashOffsetCoords as hash } from './const';
 import { Trap } from './trap';
 
 export type Point = {
@@ -22,10 +23,10 @@ type PointFacadeConfig = {
 };
 
 class PointSet {
-	s: Set<string>;
+	s: Set<number>;
 	config: PointFacadeConfig;
 
-	constructor(s: Set<string>, config: PointFacadeConfig) {
+	constructor(s: Set<number>, config: PointFacadeConfig) {
 		this.s = s;
 		this.config = config;
 	}
@@ -60,7 +61,7 @@ export class PointFacade {
 	}
 
 	getBlockedSet(): PointSet {
-		const blockedSet = new Set<string>();
+		const blockedSet = new Set<number>();
 		for (const c of this.config.getCreatures()) {
 			for (const point of this.config.getCreatureBlockedPoints(c)) {
 				blockedSet.add(hash(point));
@@ -87,9 +88,11 @@ export class PointFacade {
 	getCreaturesAt(point: Point | Creature | Point[] | number, y = 0) {
 		const config = this.config;
 
-		const points: Point[] = normalize(point, y, this.config);
-		const pointsToStr = points.map(hash).join('');
-		const hasPoint = (p: Point) => pointsToStr.indexOf(hash(p)) !== -1;
+		const points: Set<number> = normalize(point, y, this.config).reduce((s, p) => {
+			s.add(hash(p));
+			return s;
+		}, new Set<number>());
+		const hasPoint = (p: Point) => points.has(hash(p));
 
 		return config
 			.getCreatures()
@@ -103,9 +106,11 @@ export class PointFacade {
 	getTrapsAt(point: Point | Creature | Point[] | number, y = 0) {
 		const config = this.config;
 
-		const points: Point[] = normalize(point, y, this.config);
-		const pointsToStr = points.map(hash).join('');
-		const hasPoint = (p: Point) => pointsToStr.indexOf(hash(p)) !== -1;
+		const points: Set<number> = normalize(point, y, this.config).reduce((s, p) => {
+			s.add(hash(p));
+			return s;
+		}, new Set<number>());
+		const hasPoint = (p: Point) => points.has(hash(p));
 
 		return config
 			.getTraps()
@@ -119,9 +124,11 @@ export class PointFacade {
 	getDropsAt(point: Point | Creature | Point[] | number, y = 0) {
 		const config = this.config;
 
-		const points: Point[] = normalize(point, y, this.config);
-		const pointsToStr = points.map(hash).join('');
-		const hasPoint = (p: Point) => pointsToStr.indexOf(hash(p)) !== -1;
+		const points: Set<number> = normalize(point, y, this.config).reduce((s, p) => {
+			s.add(hash(p));
+			return s;
+		}, new Set<number>());
+		const hasPoint = (p: Point) => points.has(hash(p));
 
 		return config
 			.getDrops()
@@ -131,10 +138,6 @@ export class PointFacade {
 					config.getDropPassablePoints(d).some(hasPoint),
 			);
 	}
-}
-
-function hash(point: Point) {
-	return `(${point.x},${point.y})`;
 }
 
 function getMissingConfigRequirements(config: PointFacadeConfig): string[] {


### PR DESCRIPTION
[As discussed here](https://github.com/FreezingMoon/AncientBeast/issues/2470), this closes an 8-year-old TODO. As mentioned, the single caller using the `clockwise` argument doesn't make much sense in the context of a game with players facing opposing direction. So the clockwise argument was removed.

That's my take, admittedly. Feel free to comment/disagree, as always.

Otherwise, the function eliminates reliance on the stateful `Hex` class. It still requires a bit of state to determine what's in- and out-of-bounds. `HexGrid` holds that information, but it previously required a Demeter violation to access – reading into `length` of some arrays. That's been added instead as a method as `HexGrid.isInBounds`.

## Meta

This uses elements included in [this PR](https://github.com/FreezingMoon/AncientBeast/pull/2468). As it's a separate issue, I've open this as a separate PR.