### PR TITLE
feat(banner): Added the Open Collective banner in the dash that switches randomly [#2438]

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -598,6 +598,11 @@
 							<div id="materialize_button">
 								<p></p>
 							</div>
+							<div id="opencollective_banner">
+								<object type="image/svg+xml"
+								data="https://opencollective.com/ancientbeast/tiers/sponsor.svg?avatarHeight=61&width=800&limit=10"> 
+								</object>
+							</div>
 						</div>
 					</div>
 					<div id="creaturerasterwrapper">

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -845,6 +845,13 @@ div.section.info {
 	animation: glowingtext 750ms infinite alternate;
 }
 
+#opencollective_banner > object {
+	background-color: white;
+	border-radius: 25px;
+	width: 800px;
+	height: 70px;
+}
+
 .buff {
 	color: green;
 }

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -846,8 +846,10 @@ div.section.info {
 }
 
 #opencollective_banner > object {
-	background-color: white;
-	border-radius: 25px;
+	background-color: rgba(0, 0, 0, 0.7);
+	border: 4px ridge;
+	border-color: grey;
+	border-radius: 35px;
 	width: 800px;
 	height: 70px;
 }

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -1116,6 +1116,15 @@ export class UI {
 			$j('#materialize_button p').text(game.msg.ui.dash.heavyDev);
 			$j('#materialize_button').show();
 			$j('#card .sideA').addClass('disabled').off('click');
+
+			// OpenCollective Banner
+			let bannerTitles = ['sponsor', 'backer', 'helper'];
+			$j('#opencollective_banner > object').attr(
+				'data',
+				`https://opencollective.com/ancientbeast/tiers/${
+					bannerTitles[Math.floor(Math.random() * bannerTitles.length)]
+				}.svg?avatarHeight=61&width=800&limit=10`,
+			);
 		}
 	}
 


### PR DESCRIPTION
Also added a white background for better visibility; The banners change randomly when a locked creature is selected. [#2438]

<img width="762" alt="Screenshot 2023-08-06 at 1 07 56 PM" src="https://github.com/FreezingMoon/AncientBeast/assets/77203287/074a7dd0-6d10-4257-8f6e-02477f43cbc8">
<img width="770" alt="Screenshot 2023-08-06 at 1 09 57 PM" src="https://github.com/FreezingMoon/AncientBeast/assets/77203287/a8c23333-7c98-4434-9ba7-d8320955670d">
<img width="761" alt="Screenshot 2023-08-06 at 1 10 10 PM" src="https://github.com/FreezingMoon/AncientBeast/assets/77203287/5eeeca61-77f2-471a-98db-25c2d27f224d">
