### PR TITLE
refactor: interface, pare down arguments, button.js -> button.ts, progressbar.js -> progressbar.ts

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -602,7 +602,14 @@ export default class Game {
 
 		this.activeCreature = this.players[0].creatures[0]; // Prevent errors
 
-		this.UI = new UI(this); // Create UI (not before because some functions require creatures to already exist)
+		this.UI = new UI(
+			{
+				get isAcceptingInput() {
+					return !this.freezedInput;
+				},
+			},
+			this,
+		); // Create UI (not before because some functions require creatures to already exist)
 
 		// DO NOT CALL LOG BEFORE UI CREATION
 		this.gameState = 'playing';

--- a/src/game.ts
+++ b/src/game.ts
@@ -602,14 +602,17 @@ export default class Game {
 
 		this.activeCreature = this.players[0].creatures[0]; // Prevent errors
 
-		this.UI = new UI(
-			{
-				get isAcceptingInput() {
-					return !this.freezedInput;
+		{
+			const self = this;
+			this.UI = new UI(
+				{
+					get isAcceptingInput() {
+						return !self.freezedInput;
+					},
 				},
-			},
-			this,
-		); // Create UI (not before because some functions require creatures to already exist)
+				this,
+			); // Create UI (not before because some functions require creatures to already exist)
+		}
 
 		// DO NOT CALL LOG BEFORE UI CREATION
 		this.gameState = 'playing';

--- a/src/ui/button.ts
+++ b/src/ui/button.ts
@@ -15,8 +15,8 @@ type ValueOf<T> = T[keyof T];
 type ButtonState = ValueOf<typeof ButtonStateEnum>;
 
 export class Button {
+	private isGameAcceptingInput: () => boolean;
 	state: ButtonState;
-	game: any;
 	cssTransitionMeta: { transitionClass: any };
 	resolveCssTransition: null;
 	$button: any;
@@ -36,10 +36,10 @@ export class Button {
 	 * Constructor - Create attributes and default buttons
 	 * @constructor
 	 * @param {Object} opts - Options
-	 * @param {Object} game - Game object
+	 * @param {Object} {isAcceptingInput: () => boolean}
 	 */
-	constructor(opts, game) {
-		this.game = game;
+	constructor(opts, configuration: { isAcceptingInput: () => boolean }) {
+		this.isGameAcceptingInput = configuration.isAcceptingInput;
 
 		const defaultOpts = {
 			click: function () {},
@@ -79,7 +79,6 @@ export class Button {
 	}
 
 	changeState(state) {
-		const game = this.game;
 		const wrapperElement = this.$button.parent();
 
 		state = state || this.state;
@@ -94,7 +93,7 @@ export class Button {
 		if (!['disabled', 'hidden'].includes(this.state)) {
 			this.$button.bind('click', () => {
 				if (!this.overridefreeze) {
-					if (game.freezedInput || !this.clickable) {
+					if (!this.isGameAcceptingInput || !this.clickable) {
 						return;
 					}
 				}
@@ -105,7 +104,7 @@ export class Button {
 
 		this.$button.bind('mouseover', () => {
 			if (!this.overridefreeze) {
-				if (game.freezedInput || !this.clickable) {
+				if (!this.isGameAcceptingInput || !this.clickable) {
 					return;
 				}
 			}
@@ -119,7 +118,7 @@ export class Button {
 
 		this.$button.bind('mouseleave', () => {
 			if (!this.overridefreeze) {
-				if (game.freezedInput || !this.clickable) {
+				if (!this.isGameAcceptingInput || !this.clickable) {
 					return;
 				}
 			}
@@ -134,7 +133,7 @@ export class Button {
 			event.preventDefault();
 			event.stopPropagation();
 			if (!this.overridefreeze) {
-				if (game.freezedInput || !this.clickable) {
+				if (!this.isGameAcceptingInput || !this.clickable) {
 					return;
 				}
 			}
@@ -151,7 +150,7 @@ export class Button {
 			event.preventDefault();
 			event.stopPropagation();
 			if (!this.overridefreeze) {
-				if (game.freezedInput || !this.clickable) {
+				if (!this.isGameAcceptingInput || !this.clickable) {
 					return;
 				}
 			}
@@ -226,7 +225,7 @@ export class Button {
 	triggerClick() {
 		if (!this.overridefreeze) {
 			if (
-				this.game.freezedInput ||
+				!this.isGameAcceptingInput ||
 				!this.clickable ||
 				['disabled', 'hidden'].includes(this.state)
 			) {
@@ -239,7 +238,7 @@ export class Button {
 
 	triggerMouseover() {
 		if (!this.overridefreeze) {
-			if (this.game.freezedInput || !this.clickable) {
+			if (!this.isGameAcceptingInput || !this.clickable) {
 				return;
 			}
 		}
@@ -249,7 +248,7 @@ export class Button {
 
 	triggerMouseleave() {
 		if (!this.overridefreeze) {
-			if (this.game.freezedInput || !this.clickable) {
+			if (!this.isGameAcceptingInput || !this.clickable) {
 				return;
 			}
 		}

--- a/src/ui/button.ts
+++ b/src/ui/button.ts
@@ -9,9 +9,26 @@ export const ButtonStateEnum = {
 	hidden: 'hidden',
 	noClick: 'noclick',
 	slideIn: 'slideIn',
-};
+} as const;
+
+type ValueOf<T> = T[keyof T];
+type ButtonState = ValueOf<typeof ButtonStateEnum>;
 
 export class Button {
+	state: ButtonState;
+	game: any;
+	cssTransitionMeta: { transitionClass: any };
+	resolveCssTransition: null;
+	$button: any;
+	overridefreeze: any;
+	clickable: any;
+	hasShortcut: any;
+	touchX: any;
+	touchY: any;
+	css: any;
+	resolveTransitionTask: null;
+	stateTransitionMeta: { transitionClass: any };
+	resolveCssTransitionTask: any;
 	click() {
 		throw new Error('Method not implemented.');
 	}
@@ -56,7 +73,7 @@ export class Button {
 
 		// Used in applying and removing CSS transitions
 		this.cssTransitionMeta = {
-			transition: null,
+			transitionClass: null,
 		};
 		this.resolveCssTransition = null;
 	}
@@ -74,7 +91,7 @@ export class Button {
 			.unbind('touchend')
 			.unbind('mouseleave');
 
-		if (![ButtonStateEnum.disabled, ButtonStateEnum.hidden].includes(this.state)) {
+		if (!['disabled', 'hidden'].includes(this.state)) {
 			this.$button.bind('click', () => {
 				if (!this.overridefreeze) {
 					if (game.freezedInput || !this.clickable) {
@@ -165,6 +182,12 @@ export class Button {
 			this.$button.css(this.css[state]);
 		}
 	}
+	mouseover() {
+		throw new Error('Method not implemented.');
+	}
+	mouseleave() {
+		throw new Error('Method not implemented.');
+	}
 
 	/**
 	 * Apply a CSS class on a button for a duration
@@ -205,7 +228,7 @@ export class Button {
 			if (
 				this.game.freezedInput ||
 				!this.clickable ||
-				[ButtonStateEnum.disabled, ButtonStateEnum.hidden].includes(this.state)
+				['disabled', 'hidden'].includes(this.state)
 			) {
 				return;
 			}

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -345,37 +345,25 @@ export class UI {
 		}
 
 		// ProgressBar
-		this.healthBar = new ProgressBar(
-			{
-				$bar: $j('#leftpanel .progressbar .bar.healthbar'),
-				color: 'red',
-			},
-			game,
-		);
+		this.healthBar = new ProgressBar({
+			$bar: $j('#leftpanel .progressbar .bar.healthbar'),
+			color: 'red',
+		});
 
-		this.energyBar = new ProgressBar(
-			{
-				$bar: $j('#leftpanel .progressbar .bar.energybar'),
-				color: 'yellow',
-			},
-			game,
-		);
+		this.energyBar = new ProgressBar({
+			$bar: $j('#leftpanel .progressbar .bar.energybar'),
+			color: 'yellow',
+		});
 
-		this.timeBar = new ProgressBar(
-			{
-				$bar: $j('#rightpanel .progressbar .timebar'),
-				color: 'white',
-			},
-			game,
-		);
+		this.timeBar = new ProgressBar({
+			$bar: $j('#rightpanel .progressbar .timebar'),
+			color: 'white',
+		});
 
-		this.poolBar = new ProgressBar(
-			{
-				$bar: $j('#rightpanel .progressbar .poolbar'),
-				color: 'grey',
-			},
-			game,
-		);
+		this.poolBar = new ProgressBar({
+			$bar: $j('#rightpanel .progressbar .poolbar'),
+			color: 'grey',
+		});
 
 		// Sound Effects slider
 		const slider = document.getElementById('sfx');

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -45,7 +45,8 @@ export class UI {
 	 * Create attributes and default buttons
 	 * @constructor
 	 */
-	constructor(game) {
+	constructor(configuration, game) {
+		this.configuration = configuration;
 		this.game = game;
 		this.fullscreen = new Fullscreen($j('#fullscreen.button'), game.fullscreenMode);
 		this.$display = $j('#ui');
@@ -86,7 +87,7 @@ export class UI {
 				},
 				overridefreeze: true,
 			},
-			game,
+			{ isAcceptingInput: () => this.interfaceAPI.isAcceptingInput },
 		);
 		this.buttons.push(this.btnToggleDash);
 
@@ -100,7 +101,7 @@ export class UI {
 				},
 				overridefreeze: true,
 			},
-			game,
+			{ isAcceptingInput: () => this.interfaceAPI.isAcceptingInput },
 		);
 
 		// In-Game Fullscreen Button
@@ -111,7 +112,7 @@ export class UI {
 				click: () => this.fullscreen.toggle(),
 				overridefreeze: true,
 			},
-			game,
+			{ isAcceptingInput: () => this.interfaceAPI.isAcceptingInput },
 		);
 		this.buttons.push(this.btnFullscreen);
 
@@ -125,7 +126,7 @@ export class UI {
 				},
 				overridefreeze: true,
 			},
-			game,
+			{ isAcceptingInput: () => this.interfaceAPI.isAcceptingInput },
 		);
 		this.buttons.push(this.btnAudio);
 
@@ -153,7 +154,7 @@ export class UI {
 					}
 				},
 			},
-			game,
+			{ isAcceptingInput: () => this.interfaceAPI.isAcceptingInput },
 		);
 		this.buttons.push(this.btnSkipTurn);
 
@@ -175,7 +176,7 @@ export class UI {
 					}
 				},
 			},
-			game,
+			{ isAcceptingInput: () => this.interfaceAPI.isAcceptingInput },
 		);
 		this.buttons.push(this.btnDelay);
 
@@ -208,7 +209,7 @@ export class UI {
 				},
 				state: ButtonStateEnum.disabled,
 			},
-			game,
+			{ isAcceptingInput: () => this.interfaceAPI.isAcceptingInput },
 		);
 		this.buttons.push(this.btnFlee);
 
@@ -227,7 +228,7 @@ export class UI {
 				},
 				state: ButtonStateEnum.normal,
 			},
-			game,
+			{ isAcceptingInput: () => this.interfaceAPI.isAcceptingInput },
 		);
 		this.buttons.push(this.btnExit);
 
@@ -250,7 +251,7 @@ export class UI {
 					slideIn: {},
 				},
 			},
-			game,
+			{ isAcceptingInput: () => this.interfaceAPI.isAcceptingInput },
 		);
 
 		// Defines states for ability buttons
@@ -337,7 +338,7 @@ export class UI {
 						},
 					},
 				},
-				game,
+				{ isAcceptingInput: () => this.interfaceAPI.isAcceptingInput },
 			);
 			this.buttons.push(b);
 			this.abilitiesButtons.push(b);

--- a/src/ui/progressbar.js
+++ b/src/ui/progressbar.js
@@ -1,7 +1,7 @@
 import * as $j from 'jquery';
 
 export class ProgressBar {
-	constructor(opts, game) {
+	constructor(opts) {
 		const defaultOpts = {
 			height: 316,
 			width: 7,
@@ -9,7 +9,6 @@ export class ProgressBar {
 			$bar: undefined,
 		};
 
-		this.game = game;
 		opts = $j.extend(defaultOpts, opts);
 		$j.extend(this, opts);
 

--- a/src/ui/progressbar.ts
+++ b/src/ui/progressbar.ts
@@ -1,15 +1,29 @@
 import * as $j from 'jquery';
 
+type ProgressBarOptions = {
+	height: number;
+	width: number;
+	color: string;
+	$bar: any;
+};
+
 export class ProgressBar {
-	constructor(opts) {
-		const defaultOpts = {
+	$bar: any;
+	$preview: any;
+	$current: any;
+	width: number;
+	height: number;
+	color: string;
+
+	constructor(opts: Partial<ProgressBarOptions>) {
+		const defaultOpts: ProgressBarOptions = {
 			height: 316,
 			width: 7,
 			color: 'red',
 			$bar: undefined,
 		};
 
-		opts = $j.extend(defaultOpts, opts);
+		opts = Object.assign({}, defaultOpts, opts);
 		$j.extend(this, opts);
 
 		this.$bar.append('<div class="previewbar"></div>');
@@ -24,7 +38,7 @@ export class ProgressBar {
 	/**
 	 * @param{number} percentage - Size between 0 and 1
 	 */
-	setSize(percentage) {
+	setSize(percentage: number) {
 		this.$bar.css({
 			width: this.width,
 			height: this.height * percentage,
@@ -43,7 +57,7 @@ export class ProgressBar {
 	/**
 	 * @param{number} percentage - size between 0 and 1
 	 */
-	animSize(percentage) {
+	animSize(percentage: number) {
 		this.$bar.transition(
 			{
 				queue: false,
@@ -70,7 +84,7 @@ export class ProgressBar {
 	/**
 	 * @param{number} percentage - size between 0 and 1
 	 */
-	previewSize(percentage) {
+	previewSize(percentage: number) {
 		this.$preview.css(
 			{
 				width: this.width,


### PR DESCRIPTION
This pares down the arguments sent to `Button` and `ProgressBar`:

* `Button`'s constructor was getting the entire instance of `Game`, but only required a single field. Following the "Interface Segregation Principle" of [SOLID](https://www.freecodecamp.org/news/solid-principles-explained-in-plain-english/), the `game` argument was pared down to only pass the field that was actually used.[1]
* `ProgressBar`'s constructor was getting the entire instance of `Game`, but never used it, aside from saving it as a field.. That was removed.

It also converts `button.js` to `button.ts`.

----

## Next steps

I began looking at `src/ui/interface.js` because I'd like to move all abilities out of the interface. It's a Demeter violation to have the buttons mucking around on `game.activeCreature.[whatever]`. If they instead simply fire callbacks, `Game` can process those, *and* have the flexibility to incorporate different kinds of abilities processing – e.g., a new version of abilities, or AI processing of abilities.

In that vein, I'm looking at paring down what's sent to `UI`. It gets the whole version of `Game`, but this makes the code brittle because of all the Demeter violations – it's tempting for an interface element simply to look up a field on `Game` and make the change it needs. But that ties `Game` and `UI` to data storage decisions made 10+ years ago.

It'd be best to pare down what `UI` *actually* needs and then send that interface as an argument.

----

[1]: `Button` shouldn't really require anything from `Game` at all. Following the "Tell, Don't Ask" OOP principle, it should simply fire an event when clicked. Checking first whether or not `Game` wants to hear the event should be left up to `Game`. This was left as-is for now, though.