### PR TITLE
refactor: fullscreen.js -> fullscreen.ts

### DIFF
--- a/src/script.ts
+++ b/src/script.ts
@@ -89,7 +89,7 @@ $j(() => {
 	disableScrollAndArrowKeys(document.getElementById('loader')); // Disable scroll and arrow keys for loader element
 
 	// Add listener for Fullscreen API
-	const fullscreen = new Fullscreen($j('#fullscreen'));
+	const fullscreen = new Fullscreen(document.getElementById('fullscreen'));
 	$j('#fullscreen').on('click', () => fullscreen.toggle());
 
 	const startScreenHotkeys = {

--- a/src/ui/fullscreen.ts
+++ b/src/ui/fullscreen.ts
@@ -1,12 +1,10 @@
-import * as $j from 'jquery';
-
 export class Fullscreen {
-	fullscreenElement: any;
+	private fullscreenElement: HTMLElement;
 
-	constructor(fullscreenElement, fullscreenMode = false) {
+	constructor(fullscreenElement: HTMLElement, fullscreenMode = false) {
 		this.fullscreenElement = fullscreenElement;
 		if (fullscreenMode) {
-			fullscreenElement.addClass('fullscreenMode');
+			fullscreenElement.classList.add('fullscreenMode');
 		}
 	}
 
@@ -18,7 +16,7 @@ export class Fullscreen {
 			alert('Use F11 to exit fullscreen');
 		} else {
 			enableFullscreenLayout(this.fullscreenElement);
-			$j('#AncientBeast')[0].requestFullscreen();
+			document.getElementById('AncientBeast').requestFullscreen();
 		}
 	}
 }
@@ -32,12 +30,18 @@ const isNativeFullscreenAPIUse = () => {
 	);
 };
 
-const disableFullscreenLayout = (fullscreenElement) => {
-	fullscreenElement.removeClass('fullscreenMode');
-	fullscreenElement.find('.fullscreen__title').text('Fullscreen');
+const disableFullscreenLayout = (fullscreenElement: HTMLElement) => {
+	fullscreenElement.classList.remove('fullscreenMode');
+	const labelNode = fullscreenElement.querySelector('.fullscreen__title');
+	if (labelNode) {
+		labelNode.textContent = 'Fullscreen';
+	}
 };
 
-const enableFullscreenLayout = (fullscreenElement) => {
-	fullscreenElement.addClass('fullscreenMode');
-	fullscreenElement.find('.fullscreen__title').text('Contract');
+const enableFullscreenLayout = (fullscreenElement: HTMLElement) => {
+	fullscreenElement.classList.add('fullscreenMode');
+	const labelNode = fullscreenElement.querySelector('.fullscreen__title');
+	if (labelNode) {
+		labelNode.textContent = 'Contract';
+	}
 };

--- a/src/ui/fullscreen.ts
+++ b/src/ui/fullscreen.ts
@@ -1,47 +1,40 @@
 export class Fullscreen {
-	private fullscreenElement: HTMLElement;
+	private button: HTMLElement;
 
-	constructor(fullscreenElement: HTMLElement, fullscreenMode = false) {
-		this.fullscreenElement = fullscreenElement;
-		if (fullscreenMode) {
-			fullscreenElement.classList.add('fullscreenMode');
+	constructor(button: HTMLElement, isFullscreen = false) {
+		this.button = button;
+		if (isFullscreen) {
+			button.classList.add('fullscreenMode');
 		}
 	}
 
 	toggle() {
-		if (isNativeFullscreenAPIUse()) {
-			disableFullscreenLayout(this.fullscreenElement);
+		if (isAppInNativeFullscreenMode()) {
+			this.button.classList.remove('fullscreenMode');
+			this.button
+				.querySelectorAll('.fullscreen__title')
+				.forEach((el) => (el.textContent = 'FullScreen'));
 			document.exitFullscreen();
-		} else if (!isNativeFullscreenAPIUse() && window.innerHeight === screen.height) {
+		} else if (!isAppInNativeFullscreenMode() && window.innerHeight === screen.height) {
 			alert('Use F11 to exit fullscreen');
 		} else {
-			enableFullscreenLayout(this.fullscreenElement);
+			this.button.classList.add('fullscreenMode');
+			this.button
+				.querySelectorAll('.fullscreen__title')
+				.forEach((el) => (el.textContent = 'Contract'));
 			document.getElementById('AncientBeast').requestFullscreen();
 		}
 	}
 }
 
-const isNativeFullscreenAPIUse = () => {
+/**
+ * @returns {boolean} true if app is currently in [fullscreen mode using the native API](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API), else false.
+ */
+function isAppInNativeFullscreenMode(): boolean {
 	// NOTE: These properties were vendor-prefixed until very recently.
 	// Keeping vendor prefixes, though they make TS report an error.
 	return (
 		// @ts-expect-error 2551
 		document.fullscreenElement || document.webkitFullscreenElement || document.mozFullScreenElement
 	);
-};
-
-const disableFullscreenLayout = (fullscreenElement: HTMLElement) => {
-	fullscreenElement.classList.remove('fullscreenMode');
-	const labelNode = fullscreenElement.querySelector('.fullscreen__title');
-	if (labelNode) {
-		labelNode.textContent = 'Fullscreen';
-	}
-};
-
-const enableFullscreenLayout = (fullscreenElement: HTMLElement) => {
-	fullscreenElement.classList.add('fullscreenMode');
-	const labelNode = fullscreenElement.querySelector('.fullscreen__title');
-	if (labelNode) {
-		labelNode.textContent = 'Contract';
-	}
-};
+}

--- a/src/ui/fullscreen.ts
+++ b/src/ui/fullscreen.ts
@@ -1,7 +1,9 @@
 import * as $j from 'jquery';
 
 export class Fullscreen {
-	constructor(fullscreenElement, fullscreenMode) {
+	fullscreenElement: any;
+
+	constructor(fullscreenElement, fullscreenMode = false) {
 		this.fullscreenElement = fullscreenElement;
 		if (fullscreenMode) {
 			fullscreenElement.addClass('fullscreenMode');
@@ -21,8 +23,14 @@ export class Fullscreen {
 	}
 }
 
-const isNativeFullscreenAPIUse = () =>
-	document.fullscreenElement || document.webkitFullscreenElement || document.mozFullScreenElement;
+const isNativeFullscreenAPIUse = () => {
+	// NOTE: These properties were vendor-prefixed until very recently.
+	// Keeping vendor prefixes, though they make TS report an error.
+	return (
+		// @ts-expect-error 2551
+		document.fullscreenElement || document.webkitFullscreenElement || document.mozFullScreenElement
+	);
+};
 
 const disableFullscreenLayout = (fullscreenElement) => {
 	fullscreenElement.removeClass('fullscreenMode');

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -47,7 +47,10 @@ export class UI {
 	 */
 	constructor(game) {
 		this.game = game;
-		this.fullscreen = new Fullscreen($j('#fullscreen.button'), game.fullscreenMode);
+		this.fullscreen = new Fullscreen(
+			document.querySelector('#fullscreen.button'),
+			game.fullscreenMode,
+		);
 		this.$display = $j('#ui');
 		this.$dash = $j('#dash');
 		this.$grid = $j(this.#makeCreatureGrid(document.getElementById('creaturerasterwrapper')));


### PR DESCRIPTION
This converts fullscreen.js to fullscreen.ts. It also:

* removes jQuery
* (hopefully) clarifies some member, argument, function names
* inlines some short functions
* adds a JSDoc for the remaining private function