### PR TITLE
refactor: strings, supports #923

### DIFF
--- a/src/ability.ts
+++ b/src/ability.ts
@@ -6,6 +6,7 @@ import { isTeam, Team } from './utility/team';
 import * as arrayUtils from './utility/arrayUtils';
 import Game from './game';
 import { ScoreEvent } from './player';
+import { strings } from './data/strings';
 
 /*
  * NOTE
@@ -678,7 +679,7 @@ export class Ability {
 			return true;
 		}
 
-		this.message = this.game.msg.abilities.noTarget;
+		this.message = strings.abilities.noTarget;
 		return false;
 	}
 
@@ -717,7 +718,7 @@ export class Ability {
 				},
 			},
 			req = $j.extend(def, this.requirements),
-			abilityMsgs = game.msg.abilities;
+			abilityMsgs = strings.abilities;
 
 		// Plasma
 		if (req.plasma > 0) {
@@ -909,7 +910,7 @@ export class Ability {
 			}
 		}
 
-		this.message = this.game.msg.abilities.noTarget;
+		this.message = strings.abilities.noTarget;
 		return false;
 	}
 

--- a/src/data/strings.ts
+++ b/src/data/strings.ts
@@ -1,0 +1,29 @@
+// TODO: Support translations
+// https://github.com/FreezingMoon/AncientBeast/issues/923
+
+export const strings = {
+	abilities: {
+		noTarget: 'No targets available.',
+		noPlasma: 'Not enough plasma.',
+		noPsy: 'Psyhelm overload: too many units!',
+		alreadyUsed: 'This ability has already been used.',
+		tooMuch: 'Too much %stat%.',
+		notEnough: 'Not enough %stat%.',
+		notMoveable: 'This creature cannot be moved.',
+		passiveCycle: 'Switches between any usable abilities.',
+		passiveUnavailable: 'No usable abilities to switch to.',
+	},
+	ui: {
+		dash: {
+			materializeOverload: 'Overload! Maximum number of units controlled',
+			selectUnit: 'Please select an available unit from the left grid',
+			lowPlasma: 'Low Plasma! Cannot materialize the selected unit',
+			// plasmaCost :    String :    plasma cost of the unit to materialize
+			materializeUnit: (plasmaCost: string) => {
+				return 'Materialize unit at target location for ' + plasmaCost + ' plasma';
+			},
+			materializeUsed: 'Materialization has already been used this round',
+			heavyDev: 'This unit is currently under heavy development',
+		},
+	},
+} as const;

--- a/src/game.ts
+++ b/src/game.ts
@@ -27,6 +27,7 @@ import { GameConfig } from './script';
 import { Trap } from './utility/trap';
 import { Drop } from './drop';
 import { CreatureType, Realm, UnitData } from './data/types';
+import { strings } from './data/strings';
 
 /* eslint-disable prefer-rest-params */
 
@@ -199,35 +200,7 @@ export default class Game {
 			render: this.phaserRender.bind(this),
 		});
 
-		// Messages
-		// TODO: Move strings to external file in order to be able to support translations
-		// https://github.com/FreezingMoon/AncientBeast/issues/923
-		this.msg = {
-			abilities: {
-				noTarget: 'No targets available.',
-				noPlasma: 'Not enough plasma.',
-				noPsy: 'Psyhelm overload: too many units!',
-				alreadyUsed: 'This ability has already been used.',
-				tooMuch: 'Too much %stat%.',
-				notEnough: 'Not enough %stat%.',
-				notMoveable: 'This creature cannot be moved.',
-				passiveCycle: 'Switches between any usable abilities.',
-				passiveUnavailable: 'No usable abilities to switch to.',
-			},
-			ui: {
-				dash: {
-					materializeOverload: 'Overload! Maximum number of units controlled',
-					selectUnit: 'Please select an available unit from the left grid',
-					lowPlasma: 'Low Plasma! Cannot materialize the selected unit',
-					// plasmaCost :    String :    plasma cost of the unit to materialize
-					materializeUnit: (plasmaCost: string) => {
-						return 'Materialize unit at target location for ' + plasmaCost + ' plasma';
-					},
-					materializeUsed: 'Materialization has already been used this round',
-					heavyDev: 'This unit is currently under heavy development',
-				},
-			},
-		};
+		this.msg = strings;
 
 		/* Regex Test for triggers */
 		this.triggers = {

--- a/src/game.ts
+++ b/src/game.ts
@@ -117,7 +117,6 @@ export default class Game {
 	turnThrottle: boolean;
 	turn: number;
 	Phaser: Phaser;
-	msg: any; // type this properly
 	triggers: Record<string, RegExp>;
 	signals: any;
 
@@ -199,8 +198,6 @@ export default class Game {
 			update: this.phaserUpdate.bind(this),
 			render: this.phaserRender.bind(this),
 		});
-
-		this.msg = strings;
 
 		/* Regex Test for triggers */
 		this.triggers = {
@@ -348,6 +345,14 @@ export default class Game {
 
 	hexAt(x: number, y: number): Hex | undefined {
 		return this.grid.hexAt(x, y);
+	}
+
+	/**
+	 * @returns the "strings" object of (mainly) constant strings
+	 * @deprecated Import and use data/strings.ts
+	 */
+	get msg() {
+		return strings;
 	}
 
 	get activePlayer() {


### PR DESCRIPTION
This moves the strings in `game.msg` to `data/strings.ts`. It also:

* updates `ability.ts` to use `strings`
* converts `game.msg` to a getter and adds a deprecation notice, asking devs to use `data/strings.ts`