### PR TITLE
fix(ability): Fixed ability enable not working correctly

### DIFF
--- a/src/creature.ts
+++ b/src/creature.ts
@@ -460,6 +460,9 @@ export class Creature {
 
 			this.abilities.forEach((ability) => {
 				ability.reset();
+				if (!ability.upgraded && ability.usesLeftBeforeUpgrade() === 0) {
+					ability.setUpgraded();
+				}
 			});
 		};
 		varReset.bind(this);


### PR DESCRIPTION
Fixes #2478 . Added a ability upgrade check when a creature is activated, this ensures if the ability upgrade is set to 0, all the abilities are upgraded by default.  