### PR TITLE
feat: showcase branding in coordinate view [#2248]

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -23,7 +23,7 @@ import { Point, configure as configurePointFacade } from './utility/pointfacade'
 import { pretty as version } from './utility/version';
 import { Ability } from './ability';
 import { Effect } from './effect';
-import { GameConfig } from './script';
+import { GameConfig, adjustBrand } from './script';
 import { Trap } from './utility/trap';
 import { Drop } from './drop';
 import { CreatureType, Realm, UnitData } from './data/types';
@@ -1304,6 +1304,8 @@ export default class Game {
 
 	// Removed individual args from definition because we are using the arguments variable.
 	onStartOfRound(/* creature, callback */) {
+		// position brand when round starts
+		adjustBrand();
 		this.triggerDeleteEffect('onStartOfRound', 'all');
 	}
 

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -669,6 +669,10 @@
 					<div id="queuewrapper"></div>
 				</div>
 
+				<div id="brandlogo" class="hide">
+					<div></div>
+				</div>
+
 				<div id="rightpanel">
 					<div style="position:relative">
 					<div id="playerbutton" class="quickinfowrapper togglescore vignette active frame button">

--- a/src/script.ts
+++ b/src/script.ts
@@ -456,3 +456,22 @@ export function isEmpty(obj) {
 
 	return true;
 }
+
+/**
+ * Method that resizes and positions brand logo
+ * based on the arena
+ */
+export function adjustBrand() {
+	// fix size
+	const arenaWidth = $j('#combatwrapper').innerWidth();
+	let scaledSize = (arenaWidth * 555) / 1070;
+	scaledSize = scaledSize > 555 ? 555 : scaledSize;
+	$j('#brandlogo div').css('background-size', scaledSize);
+	$j('#brandlogo div').css('width', scaledSize);
+
+	// fix position
+	const arenaMarginTopPx = $j('#combatwrapper canvas').css('margin-top');
+	const arenaMarginTop = Number(arenaMarginTopPx.slice(0, -2));
+	const offset = 125 - (19 * arenaMarginTop) / 65;
+	$j('#brandlogo').css('top', arenaMarginTop + offset);
+}

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -2052,7 +2052,7 @@ input {
 	opacity: 1;
 	z-index: 1;
 	position: relative;
-	top: 12em;
+	top: 105px;
 	transition: opacity 300ms cubic-bezier(.39,.58,.57,1);;
 
 	div {
@@ -2070,16 +2070,17 @@ input {
 	}
 }
 
-@media only screen and (max-width: 1095px) {
+@media only screen and (max-width: 744px) {
 	#brandlogo div {
-		width: 300px;
-		background-size: 300px;
+		width: 400px;
+		background-size: 400px;
 	}
 }
 
-@media only screen and (max-width: 759px) {
-	#brandlogo {
-		top: 17em;
+@media only screen and (max-width: 597px) {
+	#brandlogo div {
+		width: 300px;
+		background-size: 300px;
 	}
 }
 

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -2044,3 +2044,47 @@ input {
 	color: #fff;
 	top: 20%;
 }
+
+#brandlogo {
+	display: block;
+	margin: auto;
+	width: 100%;
+	opacity: 1;
+	z-index: 1;
+	position: relative;
+	top: 12em;
+	transition: opacity 300ms cubic-bezier(.39,.58,.57,1);;
+
+	div {
+		height: 125px;
+		background-image: url('~assets/interface/AncientBeast.png');
+		background-repeat: no-repeat;
+		display: block;
+		width: 555px;
+		max-width: 555px;
+		margin: 0 auto;
+	}
+
+	&.hide {
+		opacity: 0;
+	}
+}
+
+@media only screen and (max-width: 1095px) {
+	#brandlogo div {
+		width: 300px;
+		background-size: 300px;
+	}
+}
+
+@media only screen and (max-width: 759px) {
+	#brandlogo {
+		top: 17em;
+	}
+}
+
+@media only screen and (max-width: 500px) {
+	#brandlogo {
+		display: none;
+	}
+}

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -2051,7 +2051,7 @@ input {
 	width: 100%;
 	opacity: 1;
 	z-index: 1;
-	position: relative;
+	position: absolute;
 	top: 105px;
 	transition: opacity 300ms cubic-bezier(.39,.58,.57,1);;
 
@@ -2070,21 +2070,7 @@ input {
 	}
 }
 
-@media only screen and (max-width: 744px) {
-	#brandlogo div {
-		width: 400px;
-		background-size: 400px;
-	}
-}
-
-@media only screen and (max-width: 597px) {
-	#brandlogo div {
-		width: 300px;
-		background-size: 300px;
-	}
-}
-
-@media only screen and (max-width: 500px) {
+@media only screen and (max-width: 410px) {
 	#brandlogo {
 		display: none;
 	}

--- a/src/ui/hotkeys.js
+++ b/src/ui/hotkeys.js
@@ -239,7 +239,7 @@ export function getHotKeys(hk) {
 			},
 			onkeyup() {
 				hk.pressControlKeyUp();
-			}
+			},
 		},
 		ControlRight: {
 			onkeydown() {
@@ -247,7 +247,7 @@ export function getHotKeys(hk) {
 			},
 			onkeyup() {
 				hk.pressControlKeyUp();
-			}
+			},
 		},
 		Space: {
 			onkeydown() {

--- a/src/ui/hotkeys.js
+++ b/src/ui/hotkeys.js
@@ -107,14 +107,23 @@ export class Hotkeys {
 	}
 
 	pressShiftKeyDown() {
+		this.ui.$brandlogo.removeClass('hide');
 		this.ui.game.grid.showGrid(true);
 		this.ui.game.grid.showCurrentCreatureMovementInOverlay(this.ui.game.activeCreature);
 	}
 
 	pressShiftKeyUp() {
+		this.ui.$brandlogo.addClass('hide');
 		this.ui.game.grid.showGrid(false);
 		this.ui.game.grid.cleanOverlay();
 		this.ui.game.grid.redoLastQuery();
+	}
+	pressControlKeyDown() {
+		this.ui.$brandlogo.addClass('hide');
+	}
+
+	pressControlKeyUp() {
+		this.ui.$brandlogo.addClass('hide');
 	}
 
 	pressSpace() {
@@ -223,6 +232,22 @@ export function getHotKeys(hk) {
 			onkeyup() {
 				hk.pressShiftKeyUp();
 			},
+		},
+		ControlLeft: {
+			onkeydown() {
+				hk.pressControlKeyDown();
+			},
+			onkeyup() {
+				hk.pressControlKeyUp();
+			}
+		},
+		ControlRight: {
+			onkeydown() {
+				hk.pressControlKeyDown();
+			},
+			onkeyup() {
+				hk.pressControlKeyUp();
+			}
 		},
 		Space: {
 			onkeydown() {

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -2,6 +2,7 @@ import * as $j from 'jquery';
 import * as time from '../utility/time';
 import * as emoji from 'node-emoji';
 import { Hotkeys, getHotKeys } from './hotkeys';
+import { adjustBrand } from '../script';
 
 import { Button, ButtonStateEnum } from './button';
 import { Chat } from './chat';
@@ -35,7 +36,7 @@ export class UI {
 	 * $activebox :	Current active creature panel (left panel) container
 	 * $dash :			Overview container
 	 * $grid :			Creature grid container
-	 * $brandlogo:  Brand logo container 
+	 * $brandlogo:  Brand logo container
 	 *
 	 * selectedCreature :	String :	ID of the visible creature card
 	 * selectedPlayer :	Integer :	ID of the selected player in the dash
@@ -523,6 +524,9 @@ export class UI {
 
 			e.preventDefault();
 		});
+
+		// adjust brand logo on window resize
+		$j(window).on('resize', (ev) => adjustBrand());
 
 		this.$dash.find('.section.numbers .stat').on('mouseover', (event) => {
 			const $section = $j(event.target).closest('.section');

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -29,12 +29,13 @@ export class UI {
 	 * NOTE : attributes and variables starting with $ are jquery element
 	 * and jquery function can be called directly from them.
 	 *
-	 * $display :		UI container
-	 * $queue :		Queue container
+	 * $display :	 	UI container
+	 * $queue :		  Queue container
 	 * $textbox :		Chat and log container
 	 * $activebox :	Current active creature panel (left panel) container
 	 * $dash :			Overview container
 	 * $grid :			Creature grid container
+	 * $brandlogo:  Brand logo container 
 	 *
 	 * selectedCreature :	String :	ID of the visible creature card
 	 * selectedPlayer :	Integer :	ID of the selected player in the dash
@@ -57,6 +58,7 @@ export class UI {
 		this.$grid = $j(this.#makeCreatureGrid(document.getElementById('creaturerasterwrapper')));
 		this.$activebox = $j('#activebox');
 		this.$scoreboard = $j('#scoreboard');
+		this.$brandlogo = $j('#brandlogo');
 		this.active = false;
 
 		this.queue = UI.#getQueue(this, document.getElementById('queuewrapper'));
@@ -2302,11 +2304,13 @@ export class UI {
 		}, 2000);
 
 		const onTurnEndMouseEnter = ifGameNotFrozen(() => {
+			ui.$brandlogo.removeClass('hide');
 			ui.game.grid.showGrid(true);
 			ui.game.grid.showCurrentCreatureMovementInOverlay(ui.game.activeCreature);
 		});
 
 		const onTurnEndMouseLeave = () => {
+			ui.$brandlogo.addClass('hide');
 			ui.game.grid.showGrid(false);
 			ui.game.grid.cleanOverlay();
 			ui.game.grid.redoLastQuery();

--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -565,13 +565,15 @@ export class Hex {
 			if (this.overlayClasses.match(/reachable/)) {
 				targetAlpha = true;
 				this.overlay.loadTexture('hex_path');
-			// hover when creature is inactive
-			} else if (this.overlayClasses.match(/hover/) 
-					&& this.displayClasses.indexOf(`creature player${player}`) === -1) {
+				// hover when creature is inactive
+			} else if (
+				this.overlayClasses.match(/hover/) &&
+				this.displayClasses.indexOf(`creature player${player}`) === -1
+			) {
 				this.display.loadTexture('hex_path');
 				this.display.alpha = 1;
 				this.overlay.loadTexture(`hex_hover_p${player}`);
-			// hover over active player
+				// hover over active player
 			} else if (this.overlayClasses.match(/hover/)) {
 				this.display.loadTexture('hex_path');
 			} else {


### PR DESCRIPTION
I added the functionality of displaying the project logo in the background when hovering over the round marker or holding shift in order to trigger the hexagon coordinate view as you can see in the gif below. It shows up with a smooth transition as requested in the issue

![ancient_beast](https://github.com/FreezingMoon/AncientBeast/assets/25573926/ab92fb8c-d308-4e33-9646-13dcf4c11bf6)

Closes #2248

My wallet address is 0xb2717FC8dFcc42A75E06A38aa273C0b9F4Cba848
