### PR TITLE
fix: add colored hexagon outlines on unit hover [#2242]

### DIFF
--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -442,7 +442,7 @@ export class Hex {
 	cleanOverlayVisualState(classes = '') {
 		classes =
 			classes ||
-			'creature weakDmg active moveto selected hover h_player0 h_player1 h_player2 h_player3 player0 player1 player2 player3';
+			'creature reachable weakDmg active moveto selected hover h_player0 h_player1 h_player2 h_player3 player0 player1 player2 player3';
 		const a = classes.split(' ');
 
 		for (let i = 0, len = a.length; i < len; i++) {
@@ -562,8 +562,18 @@ export class Hex {
 		if (this.overlayClasses.match(/0|1|2|3/)) {
 			const player = this.overlayClasses.match(/0|1|2|3/);
 
-			if (this.overlayClasses.match(/hover/)) {
+			if (this.overlayClasses.match(/reachable/)) {
+				targetAlpha = true;
 				this.overlay.loadTexture('hex_path');
+			// hover when creature is inactive
+			} else if (this.overlayClasses.match(/hover/) 
+					&& this.displayClasses.indexOf(`creature player${player}`) === -1) {
+				this.display.loadTexture('hex_path');
+				this.display.alpha = 1;
+				this.overlay.loadTexture(`hex_hover_p${player}`);
+			// hover over active player
+			} else if (this.overlayClasses.match(/hover/)) {
+				this.display.loadTexture('hex_path');
 			} else {
 				this.overlay.loadTexture(`hex_p${player}`);
 			}

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -861,7 +861,7 @@ export class HexGrid {
 						hex.overlayVisualState('hover h_player' + hex.creature.team);
 					}
 				} else {
-					hex.overlayVisualState('hover h_player' + this.game.activeCreature.team);
+					hex.overlayVisualState('reachable h_player' + this.game.activeCreature.team);
 				}
 			}
 		});
@@ -1323,7 +1323,7 @@ export class HexGrid {
 	showCurrentCreatureMovementInOverlay(creature) {
 		//lastQueryOpt is same thing as used in redoQuery
 		this.lastQueryOpt?.hexes?.forEach((hex) => {
-			hex.overlayVisualState('hover h_player' + creature.team);
+			hex.overlayVisualState('reachable h_player' + creature.team);
 		});
 	}
 

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -858,7 +858,7 @@ export class HexGrid {
 			if (o.targeting) {
 				if (hex.creature instanceof Creature) {
 					if (hex.creature.id != this.game.activeCreature.id) {
-						hex.overlayVisualState('hover h_player' + hex.creature.team);
+						hex.overlayVisualState('reachable h_player' + hex.creature.team);
 					}
 				} else {
 					hex.overlayVisualState('reachable h_player' + this.game.activeCreature.team);


### PR DESCRIPTION
I added color coded outline hexagons to be displayed on top of the black ones that are filled when hovering an inactive unit, as you can see in the gif below

![ancient_beast5](https://github.com/FreezingMoon/AncientBeast/assets/25573926/1fb47c1c-989d-48c4-8f95-7ed85c57dd60)

Closes #2242

My wallet address is 0xb2717FC8dFcc42A75E06A38aa273C0b9F4Cba848
