### PR TITLE
Fix wrong movement range on avatar hover in the first round

### DIFF
--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -2267,9 +2267,10 @@ export class UI {
 			}
 		});
 
-		const onCreatureMouseEnter = ifGameNotFrozen((creature) => {
+		const onCreatureMouseEnter = ifGameNotFrozen((placeholderCreature) => {
 			const creatures = ui.game.creatures.filter((c) => c instanceof Creature);
-			const otherCreatures = creatures.filter((c) => c.id !== creature.id);
+			const creature = creatures.filter(c => c.id === placeholderCreature.id)[0];
+			const otherCreatures = creatures.filter((c) => c.id !== placeholderCreature.id);
 
 			otherCreatures.forEach((c) => {
 				c.xray(true);


### PR DESCRIPTION
Closes #2302

I addressed the issue of incorrect avatar movement display on hover that occurred during the first round. This bug affected not only the players on the right side of the screen but also those on the left. Here some examples:

## Left Player (Before correction)

![Screenshot (746)](https://github.com/FreezingMoon/AncientBeast/assets/25573926/7eb9d4a8-9a3f-4c7c-9564-4db8e470b7ad)

## Left Player (After correction)

![Screenshot (749)](https://github.com/FreezingMoon/AncientBeast/assets/25573926/429ec80e-9561-4f07-836e-b38e4bc24836)

## Right Player (Before correction)

![Screenshot (748)](https://github.com/FreezingMoon/AncientBeast/assets/25573926/fa8f9d5f-26ea-417b-acf8-7b2d1f8000b4)

## Right Player (After correction)

![Screenshot (750)](https://github.com/FreezingMoon/AncientBeast/assets/25573926/33796a81-4bf1-4186-b2c2-b3d4664ef65e)

This fixes issue #2302 

My wallet address is 0xb2717FC8dFcc42A75E06A38aa273C0b9F4Cba848
