### PR TITLE
Fixed issue - visibility of the dark priest 

### DIFF
--- a/src/abilities/Dark-Priest.js
+++ b/src/abilities/Dark-Priest.js
@@ -249,7 +249,7 @@ export default (G) => {
 
 				// Ask the creature to summon
 				G.UI.materializeToggled = true;
-				G.UI.toggleDash('randomize');
+				G.UI.toggleDash(true);
 			},
 
 			fnOnSelect: function (hex, args) {

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -1018,8 +1018,7 @@ export class UI {
 						$j('#materialize_button p').text(game.msg.ui.dash.selectUnit);
 						// Bind button for random unit selection
 						this.materializeButton.click = () => {
-							const creatureId = this.showRandomCreature();
-							this.lastViewedCreature = creatureId;
+							this.lastViewedCreature = this.showRandomCreature();
 						};
 						// Apply the changes
 						$j('#card .sideA').on('click', this.materializeButton.click);
@@ -1470,7 +1469,9 @@ export class UI {
 		if (randomize && !this.lastViewedCreature) {
 			// Optional: select a random creature from the grid
 			this.showRandomCreature();
-		} else if (this.lastViewedCreature) {
+		} else if (!randomize) {
+			this.showCreature('--', game.activeCreature.team, '');
+		}  else if (this.lastViewedCreature) {
 			this.showCreature(this.lastViewedCreature, game.activeCreature.team, '');
 		} else {
 			this.showCreature(game.activeCreature.type, game.activeCreature.team, '');

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -1052,17 +1052,8 @@ export class HexGrid {
 				game.UI.showCreature(hex.creature.type, hex.creature.player.id, 'grid');
 			} else {
 				if (game.activeCreature.isDarkPriest()) {
-					// If ability used, default to Dark Priest and say materialize has been used
-					if (game.activeCreature.abilities[3].used) {
-						game.UI.showCreature(
-							game.activeCreature.type,
-							game.activeCreature.player.id,
-							'emptyHex',
-						);
-					} else if (game.UI.lastViewedCreature) {
-						game.UI.showCreature(game.UI.lastViewedCreature, game.UI.selectedPlayer, 'emptyHex');
-					} else if (game.UI.selectedCreatureObj) {
-						game.UI.toggleDash(true);
+					if (game.UI.selectedCreatureObj) {
+						game.UI.toggleDash(false);
 					} else {
 						game.UI.showCreature(
 							game.activeCreature.type,


### PR DESCRIPTION
more right click dash consistency when able to use materialization [bounty: 4 XTR]. Now the dark priest will always be shown as an active unit when you right-click on an empty grid.

TEMPLATE (Please delete this template!)

issue - https://github.com/FreezingMoon/AncientBeast/issues/2156

This fixes issue #issue

My wallet address is 0x0000000000000000000000000000000000000000
