### PR TITLE
Fix for Upgraded Seismic Stomp Visual Behavior, issue 2125/2126

### DIFF
--- a/src/abilities/Stomper.js
+++ b/src/abilities/Stomper.js
@@ -146,7 +146,7 @@ export default (G) => {
 						sourceCreature: stomper,
 						stopOnCreature: false,
 						dashedHexesUnderCreature: true,
-						fillOnlyHovered: true,
+						fillOnlyHoveredCreature: true,
 					});
 					G.h
 			

--- a/src/abilities/Stomper.js
+++ b/src/abilities/Stomper.js
@@ -115,6 +115,7 @@ export default (G) => {
 						y: stomper.y,
 						distance: 3,
 						sourceCreature: stomper,
+						stopOnCreature: true,
 						dashedHexesUnderCreature: true,
 					});
 				} // Once upgraded, can hit any ennemy within 3hex in any direction

--- a/src/abilities/Stomper.js
+++ b/src/abilities/Stomper.js
@@ -146,6 +146,7 @@ export default (G) => {
 						sourceCreature: stomper,
 						stopOnCreature: false,
 						dashedHexesUnderCreature: true,
+						fillOnlyHovered: true,
 					});
 					G.h
 			

--- a/src/abilities/Stomper.js
+++ b/src/abilities/Stomper.js
@@ -102,7 +102,7 @@ export default (G) => {
 				const stomper = this.creature;
 				const ability = this;
 
-				// Take the closest ennemy in each direction within 3hex
+				// Take the closest enemy in each direction within 3hex
 				if (!this.isUpgraded()) {
 					G.grid.queryDirection({
 						fnOnConfirm: function () {
@@ -118,7 +118,7 @@ export default (G) => {
 						sourceCreature: stomper,
 						dashedHexesUnderCreature: true,
 					});
-				} // Once upgraded, can hit any ennemy within 3hex in any direction
+				} // Once upgraded, can hit any enemy within 3hex in any direction
 				else {
 					G.grid.queryDirection({
 						fnOnConfirm: function () {
@@ -147,8 +147,6 @@ export default (G) => {
 						dashedHexesUnderCreature: true,
 						fillOnlyHoveredCreature: true,
 					});
-					G.h
-			
 				}
 			},
 

--- a/src/abilities/Stomper.js
+++ b/src/abilities/Stomper.js
@@ -5,6 +5,7 @@ import * as matrices from '../utility/matrices';
 import * as arrayUtils from '../utility/arrayUtils';
 import { Effect } from '../effect';
 import { getDirectionFromDelta } from '../utility/position';
+import { forEach } from 'underscore';
 
 /** Creates the abilities
  * @param {Object} G the game object
@@ -146,6 +147,8 @@ export default (G) => {
 						stopOnCreature: false,
 						dashedHexesUnderCreature: true,
 					});
+					G.h
+			
 				}
 			},
 

--- a/src/abilities/Stomper.js
+++ b/src/abilities/Stomper.js
@@ -116,7 +116,6 @@ export default (G) => {
 						y: stomper.y,
 						distance: 3,
 						sourceCreature: stomper,
-						stopOnCreature: true,
 						dashedHexesUnderCreature: true,
 					});
 				} // Once upgraded, can hit any ennemy within 3hex in any direction

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -1058,9 +1058,12 @@ export class HexGrid {
 
 			if (hex.reachable) {
 
-				if (o.fillOnlyHoveredCreature && !(hex instanceof Creature)) {
+				if (o.fillOnlyHoveredCreature && !(hex.creature instanceof Creature)) {
 					$j('canvas').css('cursor', 'not-allowed');
 				}
+				//else if (o.fillOnlyHoveredCreature && (hex.creature instanceof Creature)) {
+			//		$j('canvas').css('cursor', 'pointer');
+			//	}
 				
 				if (o.fillHexOnHover) {
 					this.cleanHex(hex);

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -550,7 +550,7 @@ export class HexGrid {
 				}
 				else {
 					choice.forEach((item) => {
-					if (item.creature instanceof Creature && item.creature === this.hoveredCreature) {
+					if (item.creature instanceof Creature) {
 						item.displayVisualState('creature selected player' + item.creature.team);
 					} else {
 						item.displayVisualState('adj');
@@ -1033,8 +1033,6 @@ export class HexGrid {
 
 			$j('canvas').css('cursor', 'default');
 		};
-
-		let currentlyHoveredCreature: Creature | null = null;
 
 		// ONMOUSEOVER
 		const onSelectFn = (hex: Hex) => {

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -883,11 +883,29 @@ export class HexGrid {
 			}
 		}
 
+		
+		// Function to find the path of a given hex
+		const findDirectionalPathOfHex = (hex) => {
+			let startIndex = o.hexes.indexOf(hex);
+			let endIndex = startIndex;
+			// Find the start of the path
+			while (startIndex > 0 && o.hexes[startIndex - 1].direction === hex.direction) {
+				startIndex--;
+			}
+			// Find the end of the path
+			while (endIndex < o.hexes.length - 1 && o.hexes[endIndex + 1].direction === hex.direction) {
+				endIndex++;
+			}
+			// Extract the path
+			return o.hexes.slice(startIndex, endIndex + 1);
+		};
+
 		// Function to determine if an empty hex is before or after the first creature in path
 		const emptyHexBeforeCreature = (hex) => {
-			const index = o.hexes.indexOf(hex);
-			const beforeEmpty = o.hexes.slice(0, index);
-			const afterEmpty = o.hexes.slice(index + 1);
+			const path = findDirectionalPathOfHex(hex);
+			const index = path.findIndex(h => h === hex);
+    		const beforeEmpty = path.slice(0, index);
+    		const afterEmpty = path.slice(index + 1);
 			// Check conditions
 			if (beforeEmpty.some(hex => hex.creature instanceof Creature)) {
 				return false;

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -10,6 +10,7 @@ import { DEBUG } from '../debug';
 import { HEX_WIDTH_PX } from './const';
 import { Point } from './pointfacade';
 import { AugmentedMatrix } from './matrices';
+import { Ability } from '../ability';
 
 interface GridDefinition {
 	numRows: number;
@@ -859,6 +860,9 @@ export class HexGrid {
 				if (hex.creature instanceof Creature) {
 					if (hex.creature.id != this.game.activeCreature.id) {
 						hex.overlayVisualState('reachable h_player' + hex.creature.team);
+						if (!hex.hovered) {
+							hex.cleanOverlayVisualState('hover h_player' + hex.creature.team);
+						}
 					}
 				} else {
 					hex.overlayVisualState('reachable h_player' + this.game.activeCreature.team);
@@ -1012,7 +1016,7 @@ export class HexGrid {
 					this.cleanHex(hex);
 					hex.displayVisualState('creature player' + this.game.activeCreature.team);
 				}
-
+				
 				// Offset Pos
 				const offset = o.flipped ? o.size - 1 : 0;
 				const mult = o.flipped ? 1 : -1; // For flipped player

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -1057,6 +1057,10 @@ export class HexGrid {
 		
 
 			if (hex.reachable) {
+
+				if (o.fillOnlyHoveredCreature && !(hex instanceof Creature)) {
+					$j('canvas').css('cursor', 'not-allowed');
+				}
 				
 				if (o.fillHexOnHover) {
 					this.cleanHex(hex);

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -1057,13 +1057,10 @@ export class HexGrid {
 		
 
 			if (hex.reachable) {
-
 				if (o.fillOnlyHoveredCreature && !(hex.creature instanceof Creature)) {
 					$j('canvas').css('cursor', 'not-allowed');
 				}
-				//else if (o.fillOnlyHoveredCreature && (hex.creature instanceof Creature)) {
-			//		$j('canvas').css('cursor', 'pointer');
-			//	}
+				
 				
 				if (o.fillHexOnHover) {
 					this.cleanHex(hex);

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -859,10 +859,7 @@ export class HexGrid {
 			if (o.targeting) {
 				if (hex.creature instanceof Creature) {
 					if (hex.creature.id != this.game.activeCreature.id) {
-						hex.overlayVisualState('reachable h_player' + hex.creature.team);
-						if (!hex.hovered) {
-							hex.cleanOverlayVisualState('hover h_player' + hex.creature.team);
-						}
+						hex.overlayVisualState('reachable h_player' + hex.creature.team);	
 					}
 				} else {
 					hex.overlayVisualState('reachable h_player' + this.game.activeCreature.team);
@@ -1006,12 +1003,16 @@ export class HexGrid {
 
 			if (hex.creature instanceof Creature) {
 				// If creature
+
 				onCreatureHover(hex.creature, game.UI.xrayQueue.bind(game.UI), hex);
 
 				hex.creature.startBounce();
 			}
+		
 
 			if (hex.reachable) {
+				console.log("Reachable");
+				console.log(o.size);
 				if (o.fillHexOnHover) {
 					this.cleanHex(hex);
 					hex.displayVisualState('creature player' + this.game.activeCreature.team);
@@ -1031,10 +1032,17 @@ export class HexGrid {
 						x += offset - i * mult;
 						break;
 					}
+					
+					if (hex.creature && hex.creature.id !== o.id) {
+						// This hex is occupied by a different creature, so skip the mouse-over logic.
+						return;
+					}
+			
 				}
 
 				hex = this.hexes[y][x]; // New coords
 				o.fnOnSelect(hex, o.args);
+
 			} else if (!hex.reachable) {
 				if (this.materialize_overlay) {
 					this.materialize_overlay.alpha = 0;

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -302,7 +302,6 @@ export class HexGrid {
 	queryDirection(o: Partial<QueryOptions>) {
 		o.isDirectionsQuery = true;
 		o = this.getDirectionChoices(o);
-		if ('fillOnlyHovered' in o) console.log('In queryDirection:', o.fillOnlyHovered);
 		this.queryChoice(o);
 	}
 
@@ -333,7 +332,7 @@ export class HexGrid {
 			sourceCreature: undefined,
 			choices: [],
 			optTest: () => true,
-			fillOnlyHovered: false,
+			fillOnlyHoveredCreature: false,
 		};
 
 		const options = { ...defaultOpt, ...o };
@@ -531,14 +530,13 @@ export class HexGrid {
 				game.activeCreature.queryMove();
 			},
 			fnOnSelect: (choice) => {
-				if (o.fillOnlyHovered) {
+				if (o.fillOnlyHoveredCreature) {
 					choice.forEach((item) => {
 						if (item.creature instanceof Creature && item.creature === this.hoveredCreature) {
 							item.displayVisualState('creature selected player' + item.creature.team);
 						} else if (item.creature instanceof Creature) {
 							item.displayVisualState('adj');
 						} else if (this.hoveredCreature == null) {
-							console.log('hovering empty hex')
 							this.cleanHex(item);
 							item.displayVisualState('dashed');
 							item.overlayVisualState('hover');
@@ -575,7 +573,7 @@ export class HexGrid {
 			isDirectionsQuery: false,
 			hideNonTarget: true,
 			dashedHexesUnderCreature: false,
-			fillOnlyHovered: false,
+			fillOnlyHoveredCreature: false,
 		};
 
 		o = { ...defaultOpt, ...o };
@@ -656,7 +654,7 @@ export class HexGrid {
 			hideNonTarget: o.hideNonTarget,
 			id: o.id,
 			fillHexOnHover: false,
-			fillOnlyHovered: o.fillOnlyHovered,
+			fillOnlyHoveredCreature: o.fillOnlyHoveredCreature,
 		});
 	}
 
@@ -820,12 +818,11 @@ export class HexGrid {
 			ownCreatureHexShade: false,
 			targeting: true,
 			fillHexOnHover: true,
-			fillOnlyHovered: false,
+			fillOnlyHoveredCreature: false,
 		};
 
 		o = { ...defaultOpt, ...o };
 
-		console.log('In queryHexes:', o.fillOnlyHovered);
 
 		this.lastClickedHex = undefined;
 
@@ -895,7 +892,7 @@ export class HexGrid {
 						hex.overlayVisualState('reachable h_player' + hex.creature.team);	
 					}
 				} else {
-					if (o.fillOnlyHovered) {	
+					if (o.fillOnlyHoveredCreature) {	
 						hex.displayVisualState('dashed');
 					}
 					else {
@@ -985,8 +982,8 @@ export class HexGrid {
 				const offset = o.flipped ? o.size - 1 : 0;
 				const mult = o.flipped ? 1 : -1; // For flipped player
 				
-				// If only fill hovered hexes, cancel if player clicks on empty hex
-				if (o.fillOnlyHovered) {
+				// If only filling hovered creatures hexes, cancel if player clicks on empty hex
+				if (o.fillOnlyHoveredCreature) {
 					if (!(hex.creature instanceof Creature)) {
 						o.fnOnCancel(hex, o.args); // ON CANCEL
 						return;
@@ -1062,14 +1059,7 @@ export class HexGrid {
 		
 
 			if (hex.reachable) {
-				console.log(o.fillOnlyHovered);
-				if (o.fillOnlyHovered) {
-					if (!(hex.creature instanceof Creature)) {
-						this.cleanHex(hex);
-						hex.overlayVisualState('hover');
-						$j('canvas').css('cursor', 'not-allowed');
-					}
-				}
+				
 				if (o.fillHexOnHover) {
 					this.cleanHex(hex);
 					hex.displayVisualState('creature player' + this.game.activeCreature.team);

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -536,13 +536,12 @@ export class HexGrid {
 							item.displayVisualState('creature selected player' + item.creature.team);
 						} else if (item.creature instanceof Creature) {
 							item.displayVisualState('adj');
-						} else if (this.hoveredCreature == null) {
-							this.cleanHex(item);
-							item.displayVisualState('dashed');
-							item.overlayVisualState('hover');
-						}
+						} //else if (this.hoveredCreature == null) {
+							//this.cleanHex(item);
+							//item.displayVisualState('dashed');
+							//item.overlayVisualState('hover');
+						//}
 						else {
-							this.cleanHex(item);
 							item.displayVisualState('dashed');
 						}
 
@@ -1059,6 +1058,7 @@ export class HexGrid {
 			if (hex.reachable) {
 				if (o.fillOnlyHoveredCreature && !(hex.creature instanceof Creature)) {
 					$j('canvas').css('cursor', 'not-allowed');
+					hex.overlayVisualState('hover');
 				}
 				
 				


### PR DESCRIPTION
Fix for Upgraded Seismic Stomp Visual Behavior
===

This fixes issue #2125 and potentially #2126. The new visual behaviour for Seismic Stomp upgraded ability: 


https://github.com/FreezingMoon/AncientBeast/assets/71015951/4d667d76-73da-4cdf-acbe-f05fa034d4d6

The changes include:

> Only filling in the hexes of the creature that is hovered 

> Showing dashed hex for empty hexes 

> Cancelling the ability upon clicking the empty hex. 
