### PR TITLE
issue resolved: basic attack icon not clickable

### DIFF
--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -2056,8 +2056,8 @@ input {
 
 #brandlogo {
 	display: block;
-	margin: auto;
-	width: 100%;
+	margin: auto 25%;
+	width: 50%;
 	opacity: 1;
 	z-index: 1;
 	position: absolute;


### PR DESCRIPTION
> Issue Description:
- Unit basic attacks (second ability icon) are no longer usable from left side icon, since the icon is not clickable even if the ability is usable. Workarounds like using hotkeys (W) or mouse wheel work just fine. Hovering the icon itself is also quite
problematic, not showing a tooltip as well, which would have been helpful as it indicates the corresponding ability hotkey.

> Findings
- Initially, The Problem seems to be with Buttons logic... So I tried to find it in the code base. But, didn't get much to consider.
- So After thoroughly analyzing UI on multiple screen sizes, found that the affected area is also changing with the screen and it is not related to any specific button.
- Found that the Brandlogo is always been render above the leftpanel

> Conclusion
- The brand logo is always been rendered above the affected area. As this logo is hidden been rendered above the button, we can't click on the buttons that are covered by it.

<br>
<br>

> Visual description

<br>

- brand logo which has a div wrapper and hidden property attached to it 
![pr 02](https://github.com/FreezingMoon/AncientBeast/assets/82114930/19f9ac88-683f-4a48-a393-02a05e7479ba)

<br>

- this div is been rendered above the Leftpanel and covers the entire width of the screen which doesn't seem to have any use-case... and also creates this issue
<img width="669" alt="pr 00" src="https://github.com/FreezingMoon/AncientBeast/assets/82114930/20e6f140-3f36-4a3b-b2d8-523081c5f7bb"> 

<br>
<br>

- To resolve this I adjusted the div size in a way that it still holds its initial position
- I have tested this modification with multiple screen sizes and it's working properly.
<img width="960" alt="css change 01" src="https://github.com/FreezingMoon/AncientBeast/assets/82114930/eca10a0a-76f6-447b-8c49-9e0519cef518">

<br>
<br>
<br>

This fixes issue #2506 

My wallet address is 0x44f6226bc89c4cb9D00F7c8E06c9d31Fa7D8B634
