### PR TITLE
Lead players to own materializable (#2155)

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -218,6 +218,7 @@ export default class Game {
 				dash: {
 					materializeOverload: 'Overload! Maximum number of units controlled',
 					selectUnit: 'Please select an available unit from the left grid',
+					wrongPlayer: 'Please select an available unit from own unit grid',
 					lowPlasma: 'Low Plasma! Cannot materialize the selected unit',
 					// plasmaCost :    String :    plasma cost of the unit to materialize
 					materializeUnit: (plasmaCost: string) => {

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -949,7 +949,9 @@ export class UI {
 
 			if (activeCreature.player.getNbrOfCreatures() > game.creaLimitNbr) {
 				$j('#materialize_button p').text(game.msg.ui.dash.materializeOverload);
-			} else if (
+			} 
+			// Check if the player is viewing the wrong tab
+			else if (
 				activeCreature.player.id !== player &&
 				activeCreature.isDarkPriest() &&
 				activeCreature.abilities[3].testRequirements() &&
@@ -957,6 +959,7 @@ export class UI {
 			) {
 				$j('#materialize_button p').text(game.msg.ui.dash.wrongPlayer);
 
+				// Switch to turn player's dark priest
 				this.materializeButton.click = () => {
 					this.showCreature("--", activeCreature.player.id);
 				};

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -949,7 +949,12 @@ export class UI {
 
 			if (activeCreature.player.getNbrOfCreatures() > game.creaLimitNbr) {
 				$j('#materialize_button p').text(game.msg.ui.dash.materializeOverload);
-			} else if (activeCreature.player.id !== player) {
+			} else if (
+				activeCreature.player.id !== player &&
+				activeCreature.isDarkPriest() &&
+				activeCreature.abilities[3].testRequirements() &&
+				activeCreature.abilities[3].used === false
+			) {
 				$j('#materialize_button p').text(game.msg.ui.dash.wrongPlayer);
 
 				this.materializeButton.click = () => {

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -949,6 +949,17 @@ export class UI {
 
 			if (activeCreature.player.getNbrOfCreatures() > game.creaLimitNbr) {
 				$j('#materialize_button p').text(game.msg.ui.dash.materializeOverload);
+			} else if (activeCreature.player.id !== player) {
+				$j('#materialize_button p').text(game.msg.ui.dash.wrongPlayer);
+
+				this.materializeButton.click = () => {
+					this.showCreature("--", activeCreature.player.id);
+				};
+
+				$j('#card .sideA').on('click', this.materializeButton.click);
+				$j('#card .sideA').removeClass('disabled');
+				this.materializeButton.changeState(ButtonStateEnum.glowing);
+				$j('#materialize_button').show();
 			} else if (
 				!summonedOrDead &&
 				activeCreature.player.id === player &&


### PR DESCRIPTION
This fixes issue #2155

A new message was added to game.ts, used for indicating when a player is viewing the wrong tab.
Within the interface.js script, a new conditional was added in the showCreature() method to display this message, using the following conditions

- The player is viewing a tab that is not theirs
- The player's Dark Priest is active 
- Godlet Printer has not been cast already
- The requirements are met to cast Godlet Printer


Clicking on the button will swap the tab to the player's Dark Priest.