### PR TITLE
Drop Dead (#720)

### DIFF
--- a/src/abilities/Nutcase.js
+++ b/src/abilities/Nutcase.js
@@ -587,7 +587,6 @@ export default (G) => {
 						return ability.isUpgraded() ? true : creature.size <= 2;
 					},
 				});
-				
 			},
 
 			//	activate() :

--- a/src/animations.ts
+++ b/src/animations.ts
@@ -313,13 +313,16 @@ export class Animations {
 
 	death(creature: Creature, opts: AnimationOptions) {
 		const game = this.game;
-		
-		const length = 100;
-		const numSegments = 10;
+
+		// Animation Properties
+		const length = 100; // Distance travelled in x
+		const numSegments = 10; // "Resolution" of the curve
 		const speed = !opts.overrideSpeed ? 500 : opts.overrideSpeed;
 
+		// Curve should pass (0, 0)
 		const curve = opts.flipped ? new QuadraticCurve(0.1, 5, 0) : new QuadraticCurve(0.1, -5, 0);
 
+		// Tween properties
 		const segmentLength = (opts.flipped ? -1 : 1) * Math.round(length / numSegments);
 		const segmentTime = Math.round(speed / numSegments);
 
@@ -335,15 +338,18 @@ export class Animations {
 				return;
 			}
 
+			// Calculate the point in the curve
 			let next = {
 				x: startPos.x + segmentLength * currSegment,
 				y: startPos.y + curve.calc_y(segmentLength * currSegment)
 			};
 
+			// Tween to point
 			creature.creatureSprite.setPx(next, segmentTime).then(() => {
+				// Next tween
 				anim();
 			});
-
+			
 			currSegment++;
 		}
 

--- a/src/animations.ts
+++ b/src/animations.ts
@@ -349,10 +349,15 @@ export class Animations {
 				// Next tween
 				anim();
 			});
-			
+
 			currSegment++;
 		}
 
+		// Rotate and Fade the sprite
+		creature.creatureSprite.setAngle(opts.flipped ? -90 : 90, 500);
+		creature.creatureSprite.setAlpha(0, 500);
+
+		// Launch the sprite
 		anim();
 	}
 }

--- a/src/animations.ts
+++ b/src/animations.ts
@@ -312,8 +312,6 @@ export class Animations {
 	}
 
 	death(creature: Creature, opts: AnimationOptions) {
-		const game = this.game;
-
 		// Animation Properties
 		const length = 100; // Distance travelled in x
 		const numSegments = 10; // "Resolution" of the curve
@@ -339,9 +337,9 @@ export class Animations {
 			}
 
 			// Calculate the point in the curve
-			let next = {
+			const next = {
 				x: startPos.x + segmentLength * currSegment,
-				y: startPos.y + curve.calc_y(segmentLength * currSegment)
+				y: startPos.y + curve.calc_y(segmentLength * currSegment),
 			};
 
 			// Tween to point
@@ -351,7 +349,7 @@ export class Animations {
 			});
 
 			currSegment++;
-		}
+		};
 
 		// Rotate and Fade the sprite
 		creature.creatureSprite.setAngle(opts.flipped ? -90 : 90, 500);

--- a/src/animations.ts
+++ b/src/animations.ts
@@ -336,7 +336,7 @@ export class Animations {
 			let next = {
 				x: startPos.x + segmentLength * currSegment,
 				y: startPos.y + curve.calc_y(segmentLength * currSegment)
-			}
+			};
 
 			creature.creatureSprite.setPx(next, segmentTime).then(() => {
 				anim();

--- a/src/animations.ts
+++ b/src/animations.ts
@@ -17,6 +17,7 @@ type AnimationOptions = {
 	callbackStepIn?: (hex?: Hex) => void;
 	pushed?: boolean;
 	turnAroundOnComplete?: boolean;
+	flipped?: boolean;
 };
 
 export class Animations {
@@ -312,13 +313,14 @@ export class Animations {
 
 	death(creature: Creature, opts: AnimationOptions) {
 		const game = this.game;
+		
 		const length = 100;
 		const numSegments = 10;
 		const speed = !opts.overrideSpeed ? 500 : opts.overrideSpeed;
 
-		const curve = new QuadraticCurve(0.1, -5, 0);
+		const curve = opts.flipped ? new QuadraticCurve(0.1, 5, 0) : new QuadraticCurve(0.1, -5, 0);
 
-		const segmentLength = Math.round(length / numSegments);
+		const segmentLength = (opts.flipped ? -1 : 1) * Math.round(length / numSegments);
 		const segmentTime = Math.round(speed / numSegments);
 
 		const startPos = creature.creatureSprite.getPos();

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -1552,11 +1552,6 @@ export class Creature {
 			}
 		}
 
-		// Fade and rotate the sprite
-		this.creatureSprite.setAngle(opts.flipped ? -90 : 90, 500);
-		this.creatureSprite.setAlpha(0, 500);
-
-		// Trigger the "launching off board"
 		game.animations.death(this, opts);
 		this.cleanHex();
 

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -1543,9 +1543,10 @@ export class Creature {
 		//this.creatureSprite.setAlpha(0, 500).then(() => this.destroy());
 		const opts = {
 			callback: () => {this.destroy();}
-		}
+		};
 
-		this.creatureSprite.setAlpha(0, 500)
+		this.creatureSprite.setAngle(90, 500);
+		this.creatureSprite.setAlpha(0, 500);
 		game.animations.death(this, opts);
 		this.cleanHex();
 
@@ -1844,6 +1845,17 @@ class CreatureSprite {
 			});
 		}
 		return this._promisifyTween(this._group, { alpha: a }, durationMS);
+	}
+
+	setAngle(a: number, durationMS = 0): Promise<CreatureSprite> {
+		if (durationMS === 0 || this._group.angle === a) {
+			this._group.angle = a;
+			return new Promise((resolve) => {
+				resolve(this);
+			});
+		} else {
+			return this._promisifyTween(this._group, { angle: a }, durationMS);
+		}
 	}
 
 	setHex(h: Hex, durationMS = 0): Promise<CreatureSprite> {

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -1540,7 +1540,13 @@ export class Creature {
 		}
 
 		// Kill animation
-		this.creatureSprite.setAlpha(0, 500).then(() => this.destroy());
+		//this.creatureSprite.setAlpha(0, 500).then(() => this.destroy());
+		const opts = {
+			callback: () => {this.destroy();}
+		}
+
+		this.creatureSprite.setAlpha(0, 500)
+		game.animations.death(this, opts);
 		this.cleanHex();
 
 		game.updateQueueDisplay();
@@ -1919,6 +1925,10 @@ class CreatureSprite {
 				this._healthIndicatorGroup.y = 0;
 			}
 		}
+	}
+
+	getPos() {
+		return this._group.position;
 	}
 
 	hint(text: string, hintType: CreatureHintType) {

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -1539,22 +1539,24 @@ export class Creature {
 			this.player.deactivate(); // Here because of score calculation
 		}
 
-		// Kill animation
-		//this.creatureSprite.setAlpha(0, 500).then(() => this.destroy());
-		
+		// Kill animation		
 		const opts = {
 			callback: () => {this.destroy();},
 			flipped: false
 		};
 
+		// Check whether or not to flip the animation
 		if (killerCreature instanceof Creature) {
 			if (this.pos.x - killerCreature.pos.x < 0) {
 				opts.flipped = true;
 			}
 		}
 
+		// Fade and rotate the sprite
 		this.creatureSprite.setAngle(opts.flipped ? -90 : 90, 500);
 		this.creatureSprite.setAlpha(0, 500);
+
+		// Trigger the "launching off board"
 		game.animations.death(this, opts);
 		this.cleanHex();
 

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -1541,11 +1541,19 @@ export class Creature {
 
 		// Kill animation
 		//this.creatureSprite.setAlpha(0, 500).then(() => this.destroy());
+		
 		const opts = {
-			callback: () => {this.destroy();}
+			callback: () => {this.destroy();},
+			flipped: false
 		};
 
-		this.creatureSprite.setAngle(90, 500);
+		if (killerCreature instanceof Creature) {
+			if (this.pos.x - killerCreature.pos.x < 0) {
+				opts.flipped = true;
+			}
+		}
+
+		this.creatureSprite.setAngle(opts.flipped ? -90 : 90, 500);
 		this.creatureSprite.setAlpha(0, 500);
 		game.animations.death(this, opts);
 		this.cleanHex();

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -1539,10 +1539,12 @@ export class Creature {
 			this.player.deactivate(); // Here because of score calculation
 		}
 
-		// Kill animation		
+		// Kill animation
 		const opts = {
-			callback: () => {this.destroy();},
-			flipped: false
+			callback: () => {
+				this.destroy();
+			},
+			flipped: false,
 		};
 
 		// Check whether or not to flip the animation

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -24,9 +24,9 @@ type ExtractValidCreatureTypes<T extends UnitData> = {
 }[number];
 
 // Create unions from the various arrays
-export type UnitName = typeof unitNames[number];
-export type Realm = typeof realms[number];
-export type Level = typeof unitLevels[number];
+export type UnitName = (typeof unitNames)[number];
+export type Realm = (typeof realms)[number];
+export type Level = (typeof unitLevels)[number];
 
 // Create a union of valid creature `type`s
 export type CreatureType = ExtractValidCreatureTypes<UnitData>;

--- a/src/utility/curve.ts
+++ b/src/utility/curve.ts
@@ -1,31 +1,31 @@
 /**
  * Quadratic Curve Class
- * 
+ *
  * Used to define a quadratic curve of the form y = ax^2 + bx + c
  */
 export class QuadraticCurve {
-    a: number;
-    b: number;
-    c: number;
+	a: number;
+	b: number;
+	c: number;
 
-    /**
-     * @constructor
-     * @param{number} a - Coefficient of the second order term
-     * @param{number} b - Coefficient of the first order term
-     * @param{number} c - Intercept of the curve
-     */
-    constructor(a: number, b: number, c: number) {
-        this.a = a;
-        this.b = b;
-        this.c = c;
-    }
+	/**
+	 * @constructor
+	 * @param{number} a - Coefficient of the second order term
+	 * @param{number} b - Coefficient of the first order term
+	 * @param{number} c - Intercept of the curve
+	 */
+	constructor(a: number, b: number, c: number) {
+		this.a = a;
+		this.b = b;
+		this.c = c;
+	}
 
-    /**
-     * Calculates the resulting y value given x
-     * @param{number} x - the x value to use for calculation
-     * @returns{number} y - the resulting y value
-     */
-    calc_y(x: number): number {
-        return this.a*Math.pow(x, 2) + this.b*x + this.c;
-    }
+	/**
+	 * Calculates the resulting y value given x
+	 * @param{number} x - the x value to use for calculation
+	 * @returns{number} y - the resulting y value
+	 */
+	calc_y(x: number): number {
+		return this.a * Math.pow(x, 2) + this.b * x + this.c;
+	}
 }

--- a/src/utility/curve.ts
+++ b/src/utility/curve.ts
@@ -1,0 +1,31 @@
+/**
+ * Quadratic Curve Class
+ * 
+ * Used to define a quadratic curve of the form y = ax^2 + bx + c
+ */
+export class QuadraticCurve {
+    a: number;
+    b: number;
+    c: number;
+
+    /**
+     * @constructor
+     * @param{number} a - Coefficient of the second order term
+     * @param{number} b - Coefficient of the first order term
+     * @param{number} c - Intercept of the curve
+     */
+    constructor(a: number, b: number, c: number) {
+        this.a = a;
+        this.b = b;
+        this.c = c;
+    }
+
+    /**
+     * Calculates the resulting y value given x
+     * @param{number} x - the x value to use for calculation
+     * @returns{number} y - the resulting y value
+     */
+    calc_y(x: number): number {
+        return this.a*Math.pow(x, 2) + this.b*x + this.c;
+    }
+}


### PR DESCRIPTION
This fixes issue #720

This PR makes edits to the existing death animation by adding on additional flourishes:
- Enemies will "launch" off the board when they die, following a curve as they drop
- Enemies will rotate to the side as they die
- Enemies still fade away as before

Additions to the code include methods in the CreatureSprite class, namely:
- Added new tween method setAngle()
- Added new helper method getPos()

and a new animation the Animations class:
- death()

Currently some properties are hard-coded into the death method itself, though changes can be made to attach these to the animationOptions property.