### PR TITLE
Implmented showcase ability bonus potential in Golden Wyrm (Issue #1976)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,13 @@
 				"@heroiclabs/nakama-js": "^2.0.1",
 				"compression": "^1.7.4",
 				"express": "^4.17.3",
-				"jquery": "^3.5.0",
+				"jquery": "^3.7.1",
 				"jquery.transit": "0.9.12",
 				"js-cookie": "^3.0.1",
 				"node-emoji": "^1.10.0",
 				"phaser-ce": "2.16.0",
-				"semver": "^7.5.2"
+				"semver": "^7.5.2",
+				"server.js": "^1.0.0"
 			},
 			"devDependencies": {
 				"@babel/core": "^7.21.4",
@@ -9155,9 +9156,9 @@
 			}
 		},
 		"node_modules/jquery": {
-			"version": "3.6.4",
-			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.4.tgz",
-			"integrity": "sha512-v28EW9DWDFpzcD9O5iyJXg3R3+q+mET5JhnjJzQUZMHOv67bpSIHq81GEYpPNZHG+XXHsfSme3nxp/hndKEcsQ=="
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+			"integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
 		},
 		"node_modules/jquery.transit": {
 			"version": "0.9.12",
@@ -11460,6 +11461,11 @@
 			"engines": {
 				"node": ">= 0.8.0"
 			}
+		},
+		"node_modules/server.js": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/server.js/-/server.js-1.0.0.tgz",
+			"integrity": "sha512-fO4IvzkZ09bBB++XU/gWGuzxJs0OpghSd/34mlW8coMoakLzj/+W5d1pHX+I+7H52GkBKu96UQU0K5vptNjaqg=="
 		},
 		"node_modules/setprototypeof": {
 			"version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -26,12 +26,13 @@
 		"@heroiclabs/nakama-js": "^2.0.1",
 		"compression": "^1.7.4",
 		"express": "^4.17.3",
-		"jquery": "^3.5.0",
+		"jquery": "^3.7.1",
 		"jquery.transit": "0.9.12",
 		"js-cookie": "^3.0.1",
 		"node-emoji": "^1.10.0",
 		"phaser-ce": "2.16.0",
-		"semver": "^7.5.2"
+		"semver": "^7.5.2",
+		"server.js": "^1.0.0"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.21.4",

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -381,10 +381,6 @@
 	&.potential {
 		animation: rightJump 1s infinite;
 	}
-	&.potentialoff {
-		animation: none !important;
-	}
-
 
 }
 

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -394,6 +394,10 @@
 	&.potential {
 		animation: rightJump 1s infinite;
 	}
+	&.potentialoff {
+		animation: none !important;
+	}
+
 
 }
 

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -377,6 +377,24 @@
 			cursor: help !important;
 		}
 	}
+
+	
+	@keyframes bounce {
+		0% {
+		  transform: translateX(0);
+		}
+		50% {
+		  transform: translateX(10px);
+		}
+		100% {
+		  transform: translateX(0);
+		}
+	}
+
+	&.potential {
+		animation: bounce 1s;
+	}
+
 }
 
 #fullscreen {

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -392,7 +392,7 @@
 	}
 
 	&.potential {
-		animation: bounce 1s;
+		animation: rightJump 1s infinite;
 	}
 
 }
@@ -1456,6 +1456,20 @@ span.pure {
 		transform: translate(0px, 0px);
 	}
 }
+
+@keyframes rightJump {
+	0% {
+	  transform: translateX(0);
+	}
+	50% {
+	  transform: translateX(10px);
+	}
+	100% {
+	  transform: translateX(0);
+	}
+}
+
+
 
 /*--------------Framed Modal------------------*/
 /* Modal window with graphical border and close button. */

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -378,19 +378,6 @@
 		}
 	}
 
-	
-	@keyframes bounce {
-		0% {
-		  transform: translateX(0);
-		}
-		50% {
-		  transform: translateX(10px);
-		}
-		100% {
-		  transform: translateX(0);
-		}
-	}
-
 	&.potential {
 		animation: rightJump 1s infinite;
 	}

--- a/src/ui/button.ts
+++ b/src/ui/button.ts
@@ -10,7 +10,6 @@ export const ButtonStateEnum = {
 	noClick: 'noclick',
 	slideIn: 'slideIn',
 	potential: 'potential',
-	potentialoff: 'potentialoff'
 } as const;
 
 /**
@@ -104,8 +103,6 @@ export class Button {
 				hidden: {},
 				noclick: {},
 				potential: {},
-				potentialoff: {},
-
 			},
 		};
 
@@ -209,7 +206,7 @@ export class Button {
 			}
 		});
 
-		this.$button.removeClass('disabled glowing selected active noclick slideIn hidden potential potentialoff');
+		this.$button.removeClass('disabled glowing selected active noclick slideIn hidden potential');
 		wrapperElement && wrapperElement.removeClass('hidden');
 		this.$button.css(this.css.normal);
 

--- a/src/ui/button.ts
+++ b/src/ui/button.ts
@@ -9,6 +9,7 @@ export const ButtonStateEnum = {
 	hidden: 'hidden',
 	noClick: 'noclick',
 	slideIn: 'slideIn',
+	potential: 'potential',
 } as const;
 
 /**
@@ -101,6 +102,8 @@ export class Button {
 				slideIn: {},
 				hidden: {},
 				noclick: {},
+				potential: {},
+
 			},
 		};
 

--- a/src/ui/button.ts
+++ b/src/ui/button.ts
@@ -209,7 +209,7 @@ export class Button {
 			}
 		});
 
-		this.$button.removeClass('disabled glowing selected active noclick slideIn hidden');
+		this.$button.removeClass('disabled glowing selected active noclick slideIn hidden potential');
 		wrapperElement && wrapperElement.removeClass('hidden');
 		this.$button.css(this.css.normal);
 

--- a/src/ui/button.ts
+++ b/src/ui/button.ts
@@ -10,6 +10,7 @@ export const ButtonStateEnum = {
 	noClick: 'noclick',
 	slideIn: 'slideIn',
 	potential: 'potential',
+	potentialoff: 'potentialoff'
 } as const;
 
 /**
@@ -103,6 +104,7 @@ export class Button {
 				hidden: {},
 				noclick: {},
 				potential: {},
+				potentialoff: {},
 
 			},
 		};

--- a/src/ui/button.ts
+++ b/src/ui/button.ts
@@ -209,7 +209,7 @@ export class Button {
 			}
 		});
 
-		this.$button.removeClass('disabled glowing selected active noclick slideIn hidden potential');
+		this.$button.removeClass('disabled glowing selected active noclick slideIn hidden potential potentialoff');
 		wrapperElement && wrapperElement.removeClass('hidden');
 		this.$button.css(this.css.normal);
 

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -294,8 +294,6 @@ export class UI {
 							// Activate Ability
 							game.activeCreature.abilities[i].use();
 
-							this.showBonusPotential();
-
 						} else {
 							// Cancel Ability
 							this.closeDash();
@@ -670,22 +668,27 @@ export class UI {
 
 	
 	showBonusPotential(){
+		//Shows bonus capability 
 
 		const game = this.game;
 		this.abilitiesButtons.forEach((btn) => { 
 			const ability = game.activeCreature.abilities[btn.abilityId];
 
 			//The executioner Axes for Golden Wyrm jumps to the right
-			if(	ability.used == false &&
+			//Once Dragon Flight is upgraded
+			if(ability.used == false &&
 				game.activeCreature.name == "Golden Wyrm" && 
 				game.activeCreature.abilities[2].isUpgraded() &&
 				ability.require() && 
-				game.selectedAbility != ability && 
+				game.selectedAbility != 1 && 
 				btn.abilityId == 1 
 				){
 					btn.$button.addClass('potential')
 					btn.changeState(ButtonStateEnum.potential);
 				} 
+				else{
+					btn.changeState(ButtonStateEnum.normal);
+				}
 			});
 	}
 
@@ -1857,7 +1860,6 @@ export class UI {
 					this.changeAbilityButtons();
 					// Update upgrade info
 					this.updateAbilityUpgrades();
-					//this.showBonusPotential();
 					// Callback after final transition
 					this.$activebox.children('#abilities').transition(
 						{
@@ -1889,7 +1891,7 @@ export class UI {
 
 	updateAbilityUpgrades() {
 		const game = this.game,
-			creature = game.activeCreature;
+		creature = game.activeCreature;
 
 		// Change ability buttons
 		this.abilitiesButtons.forEach((btn) => {
@@ -1970,6 +1972,7 @@ export class UI {
 				$abilityInfo.append('<div class="info upgrade">Upgrade : ' + ab.upgrade + '</div>');
 			}
 		});
+		this.showBonusPotential();
 	}
 
 	checkAbilities() {
@@ -1998,7 +2001,13 @@ export class UI {
 			}
 			if (ab.message == game.msg.abilities.passiveCycle) {
 				this.abilitiesButtons[i].changeState(ButtonStateEnum.slideIn);
-			} else if (req && !ab.used && ab.trigger == 'onQuery') {
+			} else if(this.abilitiesButtons[i].state == ButtonStateEnum.potential){
+				//Makes sure the right bounce is not stopped if ability not used yet
+				if(ab.used){
+					this.abilitiesButtons[i].changeState(ButtonStateEnum.normal);
+				}
+			}
+			else if (req && !ab.used && ab.trigger == 'onQuery') {
 				this.abilitiesButtons[i].changeState(ButtonStateEnum.slideIn);
 				oneUsableAbility = true;
 			} else if (
@@ -2032,6 +2041,8 @@ export class UI {
 					.append('<div class="message">' + ab.message + '</div>');
 			}
 		}
+
+		this.showBonusPotential();
 
 		// No action possible
 		if (!oneUsableAbility && game.activeCreature.remainingMove === 0) {

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -256,6 +256,7 @@ export class UI {
 					},
 					slideIn: {},
 					potential: {},
+					potentialoff:{},
 				},
 			},
 			{ isAcceptingInput: () => this.interfaceAPI.isAcceptingInput },
@@ -287,10 +288,14 @@ export class UI {
 							if (ability.require() == true && i != 0) {
 								this.selectAbility(i);
 							}
-							if(i == 2 && game.activeCreature == GoldenWyrm){
-								if(game.activeCreature.abilities[3].isUpgraded() &&
-								ability.require()){
+
+							if(i == 1 && game.activeCreature.name == "Golden Wyrm"){				
+								if(game.activeCreature.abilities[2].isUpgraded() &&
+								ability.require() && game.selectedAbility != ability){
 									b.changeState(ButtonStateEnum.potential);
+								} else{
+									b.cssTransition(ButtonStateEnum.potentialoff);
+									b.changeState(ButtonStateEnum.normal);
 								}
 							}
 
@@ -353,10 +358,23 @@ export class UI {
 						potential: {},
 					},
 				},
-				{ isAcceptingInput: () => this.interfaceAPI.isAcceptingInput },
+				{ isAcceptingInput: () => {
+					this.interfaceAPI.isAcceptingInput }},
 			);
 			this.buttons.push(b);
 			this.abilitiesButtons.push(b);
+
+			//upgraded
+			/**
+			if(i == 2 && game.activeCreature.name == "Golden Wyrm"){
+				b.changeState(ButtonStateEnum.potential);
+
+				
+				if(game.activeCreature.abilities[].isUpgraded() &&
+				ability.require()){
+					b.changeState(ButtonStateEnum.potential);
+				}
+			}**/
 		}
 
 		// ProgressBar
@@ -1905,6 +1923,7 @@ export class UI {
 				}, 1500);
 
 				ab.setUpgraded(); // Set the ability to upgraded
+				
 			}
 
 			// Change the ability's frame when it gets upgraded

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -256,7 +256,6 @@ export class UI {
 					},
 					slideIn: {},
 					potential: {},
-					potentialoff:{},
 				},
 			},
 			{ isAcceptingInput: () => this.interfaceAPI.isAcceptingInput },

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -18,6 +18,7 @@ import { pretty as version } from '../utility/version';
 import { capitalize } from '../utility/string';
 import { throttle } from 'underscore';
 import { DEBUG_DISABLE_HOTKEYS } from '../debug';
+import GoldenWyrm from '../abilities/Golden-Wyrm';
 
 /**
  * Class UI
@@ -255,6 +256,7 @@ export class UI {
 						cursor: 'default',
 					},
 					slideIn: {},
+					potential: {},
 				},
 			},
 			{ isAcceptingInput: () => this.interfaceAPI.isAcceptingInput },
@@ -286,6 +288,13 @@ export class UI {
 							if (ability.require() == true && i != 0) {
 								this.selectAbility(i);
 							}
+							if(i == 2 && game.activeCreature == GoldenWyrm){
+								if(game.activeCreature.abilities[3].isUpgraded() &&
+								ability.require()){
+									b.cssTransition('potential', 2000);
+								}
+							}
+
 							// Activate Ability
 							game.activeCreature.abilities[i].use();
 						} else {
@@ -342,6 +351,7 @@ export class UI {
 						slideIn: {
 							cursor: 'pointer',
 						},
+						potential: {},
 					},
 				},
 				{ isAcceptingInput: () => this.interfaceAPI.isAcceptingInput },

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -18,7 +18,6 @@ import { pretty as version } from '../utility/version';
 import { capitalize } from '../utility/string';
 import { throttle } from 'underscore';
 import { DEBUG_DISABLE_HOTKEYS } from '../debug';
-import GoldenWyrm from '../abilities/Golden-Wyrm';
 
 /**
  * Class UI
@@ -291,7 +290,7 @@ export class UI {
 							if(i == 2 && game.activeCreature == GoldenWyrm){
 								if(game.activeCreature.abilities[3].isUpgraded() &&
 								ability.require()){
-									b.cssTransition('potential', 2000);
+									b.changeState(ButtonStateEnum.potential);
 								}
 							}
 

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -268,6 +268,8 @@ export class UI {
 				{
 					$button: $j('.ability[ability="' + i + '"]'),
 					hasShortcut: true,
+					
+
 					click: () => {
 						const game = this.game;
 						if (this.selectedAbility != i) {
@@ -289,18 +291,11 @@ export class UI {
 								this.selectAbility(i);
 							}
 
-							if(i == 1 && game.activeCreature.name == "Golden Wyrm"){				
-								if(game.activeCreature.abilities[2].isUpgraded() &&
-								ability.require() && game.selectedAbility != ability){
-									b.changeState(ButtonStateEnum.potential);
-								} else{
-									b.cssTransition(ButtonStateEnum.potentialoff);
-									b.changeState(ButtonStateEnum.normal);
-								}
-							}
-
 							// Activate Ability
 							game.activeCreature.abilities[i].use();
+
+							this.showBonusPotential();
+
 						} else {
 							// Cancel Ability
 							this.closeDash();
@@ -363,18 +358,6 @@ export class UI {
 			);
 			this.buttons.push(b);
 			this.abilitiesButtons.push(b);
-
-			//upgraded
-			/**
-			if(i == 2 && game.activeCreature.name == "Golden Wyrm"){
-				b.changeState(ButtonStateEnum.potential);
-
-				
-				if(game.activeCreature.abilities[].isUpgraded() &&
-				ability.require()){
-					b.changeState(ButtonStateEnum.potential);
-				}
-			}**/
 		}
 
 		// ProgressBar
@@ -683,6 +666,27 @@ export class UI {
 			this.closeMusicPlayer();
 			this.closeScoreboard();
 		}
+	}
+
+	
+	showBonusPotential(){
+
+		const game = this.game;
+		this.abilitiesButtons.forEach((btn) => { 
+			const ability = game.activeCreature.abilities[btn.abilityId];
+
+			//The executioner Axes for Golden Wyrm jumps to the right
+			if(	ability.used == false &&
+				game.activeCreature.name == "Golden Wyrm" && 
+				game.activeCreature.abilities[2].isUpgraded() &&
+				ability.require() && 
+				game.selectedAbility != ability && 
+				btn.abilityId == 1 
+				){
+					btn.$button.addClass('potential')
+					btn.changeState(ButtonStateEnum.potential);
+				} 
+			});
 	}
 
 	showAbilityCosts(abilityId) {
@@ -1853,6 +1857,7 @@ export class UI {
 					this.changeAbilityButtons();
 					// Update upgrade info
 					this.updateAbilityUpgrades();
+					//this.showBonusPotential();
 					// Callback after final transition
 					this.$activebox.children('#abilities').transition(
 						{
@@ -1922,8 +1927,7 @@ export class UI {
 					}
 				}, 1500);
 
-				ab.setUpgraded(); // Set the ability to upgraded
-				
+				ab.setUpgraded(); // Set the ability to upgraded				
 			}
 
 			// Change the ability's frame when it gets upgraded


### PR DESCRIPTION
This Pull Request adds a feature requested in Issue #1976

When the character Golden Wyrm gets an upgrade from their Dragon Flight ability, they get an attack bonus. The Executioner's Axe is the only ability able to make use of this bonus, and the issue suggested adding a visual indication of this bonus, by bouncing the relevant button a bit to the right. 
This feature helps give player's a visual signal to remind them of the bonus they have.

There were few files that needed changes to make this possible: 

- src/style/styles.less: A new keyframes animation, and CSS class that plays that animation was added. This allowed the button state to be easily changed using the existing functions
- src/ui/button.ts: The new CSS animation had to be setup and defined so the Button data type knew to expect it.
- src/ui/interface.js: A new function showBonusPotential() was added to check for the requirements and play or stop the animation accordingly. 
    - This function was then called in the usual abilities check function checkAbilities(), and the function where upgrades are processed updateAbilityUpgrades(). 
    - In the future this function can have additional if statements added to implement the new animation onto other abilities and situations.   
