### PR TITLE
fix issue #2521

### DIFF
--- a/src/ui/hotkeys.js
+++ b/src/ui/hotkeys.js
@@ -1,3 +1,5 @@
+import { event } from 'jquery';
+
 export class Hotkeys {
 	constructor(ui) {
 		this.ui = ui;
@@ -135,12 +137,30 @@ export class Hotkeys {
 	pressSpace() {
 		!this.ui.dashopen && this.ui.game.grid.confirmHex();
 	}
+	handleKeyDown(event) {
+		if (event.key === 'Control') {
+			this.isCtrlPressed = true;
+		} else if (event.key === 'Shift') {
+			this.isShiftPressed = true;
+		} else if (event.key === 'M') {
+			this.isMPressed = true;
+			// Prevent the default behavior for Ctrl+Shift+M
+			if (this.isCtrlPressed && this.isShiftPressed) {
+				event.preventDefault();
+			}
+		}
+	}
 }
 export function getHotKeys(hk) {
 	const hotkeys = {
 		KeyS: {
 			onkeydown(event) {
 				hk.pressS(event);
+			},
+		},
+		KeyM: {
+			onkeydown(event) {
+				hk.handleKeyDown(event);
 			},
 		},
 		KeyT: {
@@ -229,8 +249,9 @@ export function getHotKeys(hk) {
 			},
 		},
 		ShiftLeft: {
-			onkeydown() {
+			onkeydown(event) {
 				hk.pressShiftKeyDown();
+				hk.handleKeyDown(event);
 			},
 			onkeyup() {
 				hk.pressShiftKeyUp();
@@ -245,8 +266,9 @@ export function getHotKeys(hk) {
 			},
 		},
 		ControlLeft: {
-			onkeydown() {
+			onkeydown(event) {
 				hk.pressControlKeyDown();
+				hk.handleKeyDown(event);
 			},
 			onkeyup() {
 				hk.pressControlKeyUp();

--- a/src/ui/hotkeys.js
+++ b/src/ui/hotkeys.js
@@ -114,7 +114,7 @@ export class Hotkeys {
 		this.ui.game.signals.ui.dispatch('closeInterfaceScreens');
 	}
 
-	pressShiftKeyDown() {
+	pressShiftKeyDown(event) {
 		this.ui.$brandlogo.removeClass('hide');
 		this.ui.game.grid.showGrid(true);
 		this.ui.game.grid.showCurrentCreatureMovementInOverlay(this.ui.game.activeCreature);
@@ -137,30 +137,12 @@ export class Hotkeys {
 	pressSpace() {
 		!this.ui.dashopen && this.ui.game.grid.confirmHex();
 	}
-	handleKeyDown(event) {
-		if (event.key === 'Control') {
-			this.isCtrlPressed = true;
-		} else if (event.key === 'Shift') {
-			this.isShiftPressed = true;
-		} else if (event.key === 'M') {
-			this.isMPressed = true;
-			// Prevent the default behavior for Ctrl+Shift+M
-			if (this.isCtrlPressed && this.isShiftPressed) {
-				event.preventDefault();
-			}
-		}
-	}
 }
 export function getHotKeys(hk) {
 	const hotkeys = {
 		KeyS: {
 			onkeydown(event) {
 				hk.pressS(event);
-			},
-		},
-		KeyM: {
-			onkeydown(event) {
-				hk.handleKeyDown(event);
 			},
 		},
 		KeyT: {
@@ -249,9 +231,8 @@ export function getHotKeys(hk) {
 			},
 		},
 		ShiftLeft: {
-			onkeydown(event) {
+			onkeydown() {
 				hk.pressShiftKeyDown();
-				hk.handleKeyDown(event);
 			},
 			onkeyup() {
 				hk.pressShiftKeyUp();
@@ -260,16 +241,14 @@ export function getHotKeys(hk) {
 		ShiftRight: {
 			onkeydown() {
 				hk.pressShiftKeyDown();
-				hk.handleKeyDown(event);
 			},
 			onkeyup() {
 				hk.pressShiftKeyUp();
 			},
 		},
 		ControlLeft: {
-			onkeydown(event) {
+			onkeydown() {
 				hk.pressControlKeyDown();
-				hk.handleKeyDown(event);
 			},
 			onkeyup() {
 				hk.pressControlKeyUp();
@@ -278,7 +257,6 @@ export function getHotKeys(hk) {
 		ControlRight: {
 			onkeydown() {
 				hk.pressControlKeyDown();
-				hk.handleKeyDown(event);
 			},
 			onkeyup() {
 				hk.pressControlKeyUp();

--- a/src/ui/hotkeys.js
+++ b/src/ui/hotkeys.js
@@ -260,6 +260,7 @@ export function getHotKeys(hk) {
 		ShiftRight: {
 			onkeydown() {
 				hk.pressShiftKeyDown();
+				hk.handleKeyDown(event);
 			},
 			onkeyup() {
 				hk.pressShiftKeyUp();
@@ -277,6 +278,7 @@ export function getHotKeys(hk) {
 		ControlRight: {
 			onkeydown() {
 				hk.pressControlKeyDown();
+				hk.handleKeyDown(event);
 			},
 			onkeyup() {
 				hk.pressControlKeyUp();

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -2383,6 +2383,14 @@ export class UI {
 			}
 		});
 
+		// Hide the project logo when navigating away using a hotkey (Ctrl+Shift+M)
+		document.addEventListener('keydown', (event) => {
+			if (event.ctrlKey && event.shiftKey && event.key === 'M') {
+				console.log('ctrl+shift+M pressed');
+				ui.$brandlogo.addClass('hide');
+			}
+		});
+
 		const SIGNAL_CREATURE_CLICK = 'vignettecreatureclick';
 		const SIGNAL_CREATURE_MOUSE_ENTER = 'vignettecreaturemouseenter';
 		const SIGNAL_CREATURE_MOUSE_LEAVE = 'vignettecreaturemouseleave';


### PR DESCRIPTION
This PR addresses an issue (#2521) related to certain browser hotkeys, specifically those that involve the Shift key and steal focus, such as **Ctrl+Shift+M**. When these hotkeys are pressed, they cause the project logo to remain visible over the combat location's background, which is unintended behavior. This pull request aims to resolve this issue by ensuring that the project logo behaves as expected when these hotkeys are used. The changes made in this PR will enhance the user experience by providing consistent and correct functionality.