### PR TITLE
Modify creature walk speed in debug mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,7 @@ DEBUG_DISABLE_HOTKEYS=false
 # If true, creature walking animation will be much shorter
 # Useful for minimizing the down time waiting for creatures to get in position
 DEBUG_ENABLE_FAST_WALKING=true
+DEBUG_WALK_SPEED=100 #ms
 
 # =============================================================================
 # SERVER

--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,10 @@ DEBUG_DISABLE_MUSIC=false
 # like Ctrl+Alt+C for developer tools, etc.
 DEBUG_DISABLE_HOTKEYS=false
 
+# If true, creature walking animation will be much shorter
+# Useful for minimizing the down time waiting for creatures to get in position
+DEBUG_ENABLE_FAST_WALKING=true
+
 # =============================================================================
 # SERVER
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -51,8 +51,8 @@ DEBUG_DISABLE_HOTKEYS=false
 
 # If true, creature walking animation will be much shorter
 # Useful for minimizing the down time waiting for creatures to get in position
-DEBUG_ENABLE_FAST_WALKING=true
-DEBUG_WALK_SPEED=100 #ms
+DEBUG_ENABLE_FAST_WALKING=false
+DEBUG_WALK_SPEED_MS=100 
 
 # =============================================================================
 # SERVER

--- a/src/animations.ts
+++ b/src/animations.ts
@@ -4,7 +4,7 @@ import { Creature } from './creature';
 import { Hex } from './utility/hex';
 import { Ability } from './ability';
 import { QuadraticCurve } from './utility/curve';
-import { DEBUG_ENABLE_FAST_WALKING, DEBUG_WALK_SPEED } from './debug';
+import { DEBUG_ENABLE_FAST_WALKING, DEBUG_WALK_SPEED_MS } from './debug';
 
 // to fix @ts-expect-error 2554: properly type the arguments for the trigger functions in `game.ts`
 
@@ -55,7 +55,7 @@ export class Animations {
 		speed = Number(speed);
 
 		if (DEBUG_ENABLE_FAST_WALKING) {
-			speed = DEBUG_WALK_SPEED;
+			speed = DEBUG_WALK_SPEED_MS;
 		}
 
 		const that = this;

--- a/src/animations.ts
+++ b/src/animations.ts
@@ -4,6 +4,7 @@ import { Creature } from './creature';
 import { Hex } from './utility/hex';
 import { Ability } from './ability';
 import { QuadraticCurve } from './utility/curve';
+import { DEBUG_ENABLE_FAST_WALKING } from './debug';
 
 // to fix @ts-expect-error 2554: properly type the arguments for the trigger functions in `game.ts`
 
@@ -52,6 +53,10 @@ export class Animations {
 
 		let speed = !opts.overrideSpeed ? creature.animation.walk_speed : opts.overrideSpeed;
 		speed = Number(speed);
+
+		if (DEBUG_ENABLE_FAST_WALKING) {
+			speed = 100;
+		}
 
 		const that = this;
 

--- a/src/animations.ts
+++ b/src/animations.ts
@@ -4,7 +4,7 @@ import { Creature } from './creature';
 import { Hex } from './utility/hex';
 import { Ability } from './ability';
 import { QuadraticCurve } from './utility/curve';
-import { DEBUG_ENABLE_FAST_WALKING } from './debug';
+import { DEBUG_ENABLE_FAST_WALKING, DEBUG_WALK_SPEED } from './debug';
 
 // to fix @ts-expect-error 2554: properly type the arguments for the trigger functions in `game.ts`
 
@@ -55,7 +55,7 @@ export class Animations {
 		speed = Number(speed);
 
 		if (DEBUG_ENABLE_FAST_WALKING) {
-			speed = 100;
+			speed = DEBUG_WALK_SPEED;
 		}
 
 		const that = this;

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -47,4 +47,4 @@ export const DEBUG_DISABLE_MUSIC =
 export const DEBUG_DISABLE_HOTKEYS = d && toBool(process.env.DEBUG_DISABLE_HOTKEYS);
 
 export const DEBUG_ENABLE_FAST_WALKING = d && toBool(process.env.DEBUG_ENABLE_FAST_WALKING);
-export const DEBUG_WALK_SPEED = d && Number(process.env.DEBUG_WALK_SPEED);
+export const DEBUG_WALK_SPEED_MS = d && Number(process.env.DEBUG_WALK_SPEED_MS);

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -47,3 +47,4 @@ export const DEBUG_DISABLE_MUSIC =
 export const DEBUG_DISABLE_HOTKEYS = d && toBool(process.env.DEBUG_DISABLE_HOTKEYS);
 
 export const DEBUG_ENABLE_FAST_WALKING = d && toBool(process.env.DEBUG_ENABLE_FAST_WALKING);
+export const DEBUG_WALK_SPEED = d && Number(process.env.DEBUG_WALK_SPEED);

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -45,3 +45,5 @@ export const DEBUG_DISABLE_MUSIC =
 	d && toBool(process.env.DEBUG_DISABLE_MUSIC) && DEBUG_AUTO_START_GAME;
 
 export const DEBUG_DISABLE_HOTKEYS = d && toBool(process.env.DEBUG_DISABLE_HOTKEYS);
+
+export const DEBUG_ENABLE_FAST_WALKING = d && toBool(process.env.DEBUG_ENABLE_FAST_WALKING);


### PR DESCRIPTION
Added debug environment variables to modify the walking speed of creatures. This helps save time when manually testing creatures abilities/targeting/movement/etc.