### PR TITLE
Fixed Issue: double drop  #2548

### DIFF
--- a/src/animations.ts
+++ b/src/animations.ts
@@ -246,7 +246,7 @@ export class Animations {
 		creature.healthShow();
 
 		creature.hexagons.forEach((h) => {
-			h.pickupDrop(creature);
+			creature.pickupDrop(); //using the pickupDrop function from the creature class since its deprecated in hex.ts class
 		});
 
 		game.grid.orderCreatureZ();

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -1613,7 +1613,12 @@ export class Creature {
 	pickupDrop() {
 		getPointFacade()
 			.getDropsAt(this)
-			.forEach((drop) => drop.pickup(this));
+			.forEach((drop) => {
+				if (!drop.pickedUp) {
+					drop.pickup(this);
+					drop.pickedUp = true; // set the pickedUp property to true to prevent multiple pickup execution
+				}
+			});
 	}
 
 	/**

--- a/src/drop.ts
+++ b/src/drop.ts
@@ -53,6 +53,7 @@ export class Drop {
 	game: Game;
 	pos: Point;
 	alterations: DropAlterations;
+	pickedUp: boolean;
 
 	display: Phaser.Sprite;
 
@@ -98,6 +99,7 @@ export class Drop {
 
 		game.log('%CreatureName' + creature.id + '% picks up ' + this.name + ':');
 		creature.hint(this.name, 'msg_effects');
+
 		creature.dropCollection.push(this);
 
 		creature.updateAlteration();
@@ -119,11 +121,13 @@ export class Drop {
 		}
 
 		// NOTE: Log all the gained alterations.
+
 		const gainedMessage = Object.keys(alterations)
 			.map((key) => `${alterations[key]} ${key}`)
 			.join(', ')
 			// Replace last comma with "and"
 			.replace(/, ([^,]*)$/, ' and $1');
+
 		game.log(`Gains ${gainedMessage}`);
 
 		creature.player.score.push({


### PR DESCRIPTION
Added a pickedUp property of type boolean in class Drop;
 Replaced the deprecated pickupDrop method with the recommended pickupDrop method(getPointFacade().getDropsAt()) in creature.ts and animations.ts files.

Issue: double drop #2548

This fixes issue #2548

![issue_fix](https://github.com/FreezingMoon/AncientBeast/assets/57382932/d5ab2df3-1dab-4f51-9bed-f519b8a61e5e)
![uncle_fungus](https://github.com/FreezingMoon/AncientBeast/assets/57382932/8c903a3c-7a1d-4110-bee9-d6d14152ddf3)


