### PR TITLE
fixed the escort problem issue  #2545

### DIFF
--- a/src/abilities/Scavenger.js
+++ b/src/abilities/Scavenger.js
@@ -229,7 +229,7 @@ export default (G) => {
 					team: this._targetTeam,
 					id: [crea.id, trg.id],
 					size: size,
-					flipped: crea.player.player.flipped,
+					flipped: crea.player.flipped,
 					hexes: G.grid
 						.getFlyingRange(x, crea.y, distance, size, [crea.id, trg.id])
 						.filter(function (item) {


### PR DESCRIPTION

Escort Service unusable issue #2545

Solution:  flipped property is defined inside the crea.player object, not crea.player.player(extra nested player object doesnt exists at all) which caused the error to be thrown when the player pressed on the escort service

This fixes issue #2545

![image](https://github.com/FreezingMoon/AncientBeast/assets/57382932/d5ff0cd4-5a8d-4b10-a258-0c0ab3aacd8f)
![image](https://github.com/FreezingMoon/AncientBeast/assets/57382932/4e63125d-5b86-4652-af3e-a97b0c41764f)

