### PR TITLE
Fix for issue #2562

### DIFF
--- a/src/creature.ts
+++ b/src/creature.ts
@@ -2003,13 +2003,14 @@ class CreatureSprite {
 		};
 
 		// Remove constant element
+		// Animation length reduced from 250 to 100 to prevent animation overlap
 		this._hintGrp.forEach(
 			(hint: Phaser.Text | Phaser.Sprite) => {
 				if (hint.data.hintType === 'confirm' || hint.data.hintType === 'no_action') {
 					hint.data.hintType = 'confirm_deleted';
 					hint.data.tweenAlpha = this._phaser.add
 						.tween(hint)
-						.to({ alpha: 0 }, tooltipSpeed, tooltipTransition)
+						.to({ alpha: 0 }, 100, tooltipTransition)
 						.start();
 					hint.data.tweenAlpha.onComplete.add(() => hint.destroy());
 				}


### PR DESCRIPTION
This fixes issue #2562: Don't show duplicated "Skip turn" text on hover.
The issue was caused by overlapping animations. The element removal animation length was reduced from 250ms to 100ms to avoid overlap without the transition being too sudden.

My wallet address is 0xb23290AD0d05a9b43154F4bd4112Af0e67ba02FB.
