### PR TITLE
Move preview

### DIFF
--- a/src/creature.ts
+++ b/src/creature.ts
@@ -647,6 +647,20 @@ export class Creature {
 						return;
 					}
 
+					if (game.grid.materialize_overlay) {
+						const creature = game.retrieveCreatureStats(game.activeCreature.type);
+						game.Phaser.add
+							.tween(game.grid.materialize_overlay)
+							.to(
+								{
+									alpha: 0,
+								},
+								creature.animation.walk_speed,
+								Phaser.Easing.Linear.None,
+							)
+							.start();
+					}
+
 					game.gamelog.add({
 						action: 'move',
 						target: {
@@ -697,6 +711,8 @@ export class Creature {
 		};
 
 		const selectFlying = function (hex, args) {
+			const creature = game.retrieveCreatureStats(game.activeCreature.type);
+			game.grid.previewCreature(hex, creature, game.activePlayer);
 			args.creature.tracePosition({
 				x: hex.x,
 				y: hex.y,
@@ -738,11 +754,13 @@ export class Creature {
 	 */
 	previewPosition(hex: Hex) {
 		const game = this.game;
-
 		game.grid.cleanOverlay('hover h_player' + this.team);
 		if (!game.grid.hexes[hex.y][hex.x].isWalkable(this.size, this.id)) {
 			return; // Break if not walkable
 		}
+
+		const creat = game.retrieveCreatureStats(game.activeCreature.type);
+		game.grid.previewCreature(hex.pos, creat, game.activePlayer);
 
 		this.tracePosition({
 			x: hex.x,
@@ -935,6 +953,8 @@ export class Creature {
 		// Highlight final position
 		const last: any = arrayUtils.last(path);
 
+		const creature = this.game.retrieveCreatureStats(this.game.activeCreature.type);
+		this.game.grid.previewCreature(last, creature, this.game.activePlayer);
 		this.tracePosition({
 			x: last.x,
 			y: last.y,
@@ -951,7 +971,6 @@ export class Creature {
 			displayClass: '',
 			drawOverCreatureTiles: true,
 		};
-
 		args = $j.extend(defaultArgs, args);
 
 		for (let i = 0; i < this.size; i++) {

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -1609,15 +1609,19 @@ export class HexGrid {
 	previewCreature(pos, creatureData, player) {
 		const game = this.game;
 		const hex = this.hexes[pos.y][pos.x - (creatureData.size - 1)];
+		const cardboard =
+			creatureData.type == '--'
+				? creatureData.name + game.activePlayer.color + '_cardboard'
+				: creatureData.name + '_cardboard';
 
 		if (!this.materialize_overlay) {
 			// If sprite does not exists
 			// Adding sprite
-			this.materialize_overlay = this.creatureGroup.create(0, 0, creatureData.name + '_cardboard');
+			this.materialize_overlay = this.creatureGroup.create(0, 0, cardboard);
 			this.materialize_overlay.anchor.setTo(0.5, 1);
 			this.materialize_overlay.posy = pos.y;
 		} else {
-			this.materialize_overlay.loadTexture(creatureData.name + '_cardboard');
+			this.materialize_overlay.loadTexture(cardboard);
 			if (this.materialize_overlay.posy != pos.y) {
 				this.materialize_overlay.posy = pos.y;
 				this.orderCreatureZ();


### PR DESCRIPTION
This fixes issue #2533

My wallet address is 0x89F606eec3FC99ed4cE78BBf4E378baCAa0B458f

Solution:

- call the hexgrid's previewCreature function in the while calling queryMove on the active creature.
- in the previewCreature fuction, check if the active creature is a Dark Priest, if so, add the player's color to the sprite name.
- when the move is confirmed, use a tween to fade the preview cardboard's alpha to 0.