### PR TITLE
fixes Creature Dash arrow keys error 

### DIFF
--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -836,6 +836,7 @@ export class UI {
 
 		this.selectedCreature = creatureType;
 		const stats = game.retrieveCreatureStats(creatureType);
+		if (stats === undefined) return;
 
 		//function to add the name, realm, size etc of the current card in the menu
 		function addCardCharacterInfo() {
@@ -949,7 +950,7 @@ export class UI {
 					.children('#upgrade')
 					.text('Upgrade: ' + stats.ability_info[key].upgrade);
 
-				if (key !== 0) {
+				if (stats.ability_info[key].costs !== undefined && key !== 0) {
 					$ability
 						.children('.wrapper')
 						.children('.info')
@@ -1138,7 +1139,8 @@ export class UI {
 				} else {
 					$ability.children('.wrapper').children('.info').children('#upgrade').text(' ');
 				}
-				if (key !== 0) {
+
+				if (stats.ability_info[key].costs !== undefined && key !== 0) {
 					$ability
 						.children('.wrapper')
 						.children('.info')
@@ -1569,6 +1571,10 @@ export class UI {
 
 		if (game.realms.indexOf(creatureType[0]) - 1 > -1) {
 			const realm = game.realms[game.realms.indexOf(creatureType[0]) - 1];
+
+			if (realm === '-') {
+				return;
+			}
 			nextCreature = realm + creatureType[1];
 			this.lastViewedCreature = nextCreature;
 			this.showCreature(nextCreature, this.selectedPlayer);


### PR DESCRIPTION
This fixes issue #2476

this pull request fixed stats is undefined issue

- Fixes error being thrown for some locked entities
- Fixes error when the up arrow is repeatedly pressed
- Fixes an issue where you are unable to navigate using arrows from left to right, after reaching the top left of the creature dash


