### PR TITLE
Issue fix #2557

### DIFF
--- a/src/abilities/Stomper.ts
+++ b/src/abilities/Stomper.ts
@@ -486,8 +486,8 @@ export default (G: Game) => {
 					id: stomper.id,
 					flipped: stomper.player.flipped,
 					choices: [
-						stomper.getHexMap(matrices.stomperEarthShaker, false),
-						stomper.getHexMap(matrices.stomperEarthShaker, true),
+						stomper.getHexMap(matrices.frontAndBack8Hex, false),
+						stomper.getHexMap(matrices.frontAndBack8Hex, true),
 					],
 				});
 			},

--- a/src/utility/matrices.ts
+++ b/src/utility/matrices.ts
@@ -227,7 +227,7 @@ export const fourDistanceCone: AugmentedMatrix = asAugmentedMatrix(
 	[0, 4],
 );
 
-export const stomperEarthShaker: AugmentedMatrix = asAugmentedMatrix(
+export const frontAndBack8Hex: AugmentedMatrix = asAugmentedMatrix(
 	[
 		[0, 0, 1, 0],
 		[0, 0, 1, 1],


### PR DESCRIPTION
Changed the name of the stomperEarthShaker matrix to frontAndBack8Hex as described in the issue thread.

Does not address the part about reusabilty of matrices. Perhaps that should be an issue of its own. For example adding matrix frontAndBack9Hex to be used in Infernal.js

This fixes issue #2557 