### PR TITLE
adds preview cardboard to Frogger Jump ability

### DIFF
--- a/src/abilities/Uncle-Fungus.ts
+++ b/src/abilities/Uncle-Fungus.ts
@@ -212,6 +212,8 @@ export default (G: Game) => {
 								overlayClass: 'creature moveto selected player' + uncle.team,
 							});
 							hex.game.activeCreature.faceHex(hex);
+							const crea = G.retrieveCreatureStats(uncle.type);
+							G.grid.previewCreature(hex.pos, crea, uncle.player);
 						}
 					},
 					fnOnConfirm: (...args) => {
@@ -223,6 +225,7 @@ export default (G: Game) => {
 							return;
 						}
 						this.animation(...args);
+						G.grid.fadeOutTempCreature();
 					},
 					size: uncle.size,
 					flipped: uncle.player.flipped,
@@ -236,7 +239,6 @@ export default (G: Game) => {
 			// activate() :
 			activate: function (hex) {
 				this.end(false, true); // Deferred ending
-
 				// If upgraded and we haven't leapt over creatures/obstacles, allow a second
 				// jump of the same kind
 				if (this.isUpgraded() && !this._isSecondLowJump()) {


### PR DESCRIPTION
This resolves issue [#2574](https://github.com/FreezingMoon/AncientBeast/issues/2574)

When the Frogger Jump ability is activated, call grid.previewCreature to show where Uncle Fungus will jump to, and when the decision is confirmed, call grid.fadeOutTempCreature.

My wallet address is 0x89F606eec3FC99ed4cE78BBf4E378baCAa0B458f
