### PR TITLE
Escort service

### DIFF
--- a/src/abilities/Scavenger.js
+++ b/src/abilities/Scavenger.js
@@ -216,6 +216,16 @@ export default (G) => {
 						G.grid.cleanHex(h);
 						h.overlayVisualState('active creature player' + color);
 						h.displayVisualState('creature player' + color);
+
+						const creatureData = G.retrieveCreatureStats(crea.type);
+						const targetData = G.retrieveCreatureStats(trg.type);
+						const creaPos = trgIsInfront ? { x: hex.pos.x - trg.size, y: hex.pos.y } : hex.pos;
+						const trgPos = trgIsInfront
+							? { x: hex.pos.x, y: hex.pos.y }
+							: { x: hex.pos.x - 2, y: hex.pos.y };
+
+						G.grid.previewCreature(creaPos, creatureData, crea.player);
+						G.grid.previewCreature(trgPos, targetData, trg.player, true);
 					}
 				};
 
@@ -223,6 +233,8 @@ export default (G) => {
 
 				G.grid.queryHexes({
 					fnOnConfirm: function () {
+						G.grid.fadeOutTempCreature();
+						G.grid.fadeOutTempCreature(G.grid.secondary_overlay);
 						ability.animation(...arguments);
 					}, // fnOnConfirm
 					fnOnSelect: select, // fnOnSelect,
@@ -243,6 +255,7 @@ export default (G) => {
 						trgIsInfront: trgIsInfront,
 					},
 					callbackAfterQueryHexes: () => {
+						console.log('cleaning');
 						for (let i = 0; i < trg.hexagons.length; i++) {
 							G.grid.cleanHex(trg.hexagons[i]);
 							trg.hexagons[i].displayVisualState('dashed');

--- a/src/abilities/Uncle-Fungus.ts
+++ b/src/abilities/Uncle-Fungus.ts
@@ -212,6 +212,8 @@ export default (G: Game) => {
 								overlayClass: 'creature moveto selected player' + uncle.team,
 							});
 							hex.game.activeCreature.faceHex(hex);
+							const crea = G.retrieveCreatureStats(uncle.type);
+							G.grid.previewCreature(hex.pos, crea, uncle.player);
 						}
 					},
 					fnOnConfirm: (...args) => {
@@ -223,6 +225,7 @@ export default (G: Game) => {
 							return;
 						}
 						this.animation(...args);
+						G.grid.fadeOutTempCreature();
 					},
 					size: uncle.size,
 					flipped: uncle.player.flipped,
@@ -236,7 +239,6 @@ export default (G: Game) => {
 			// activate() :
 			activate: function (hex) {
 				this.end(false, true); // Deferred ending
-
 				// If upgraded and we haven't leapt over creatures/obstacles, allow a second
 				// jump of the same kind
 				if (this.isUpgraded() && !this._isSecondLowJump()) {


### PR DESCRIPTION
This fixes issue [#2573](https://github.com/FreezingMoon/AncientBeast/issues/2573)

1) Updates the hexgrid's previewCreature function to be able to preview two creatures at once.
2) Updates the Scavenger's Escort Service ability to call previewCreature on both the Scavenger and its target.
3) Fades out preview cardboards on move selection

My wallet address is 0x89F606eec3FC99ed4cE78BBf4E378baCAa0B458f
