### PR TITLE
Introduction of a basic text stroke for grid coordinates that is occupied by unit, trap or drop

### DIFF
--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -549,7 +549,7 @@ export class Hex {
 						align: 'center',
 					},
 				);
-				if (this.creature) {
+				if (this.creature || this.trap || this.drop) {
 					this.coordText.stroke = '#ffffff';
 					this.coordText.strokeThickness = 5;
 				}

--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -549,6 +549,10 @@ export class Hex {
 						align: 'center',
 					},
 				);
+				if (this.creature) {
+					this.coordText.stroke = '#ffffff';
+					this.coordText.strokeThickness = 5;
+				}
 				this.coordText.anchor.setTo(0.5);
 				this.grid.overlayHexesGroup.add(this.coordText);
 			}


### PR DESCRIPTION
<img width="943" alt="Screenshot 2024-05-22 at 7 20 21 PM" src="https://github.com/FreezingMoon/AncientBeast/assets/51870531/9280e341-8cf1-4a62-bde6-f602fccb3a2c">
#2240 
