### PR TITLE
[Feature] Added bounce animation on skip button

### DIFF
--- a/src/creature.ts
+++ b/src/creature.ts
@@ -725,6 +725,14 @@ export class Creature {
 			game.grid.querySelf({
 				fnOnConfirm: function () {
 					game.UI.btnSkipTurn.click();
+					
+					const buttonElement = game.UI.btnSkipTurn.$button;
+
+					buttonElement.addClass('bounce');
+
+					setTimeout(() => {
+						buttonElement.removeClass('bounce');
+					}, 1000);
 				},
 				fnOnCancel: function () {},
 				confirmText: 'Skip turn',

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -722,17 +722,12 @@ export class Creature {
 		const select = o.noPath || this.movementType() === 'flying' ? selectFlying : selectNormal;
 
 		if (this.noActionPossible) {
+			const buttonElement = game.UI.btnSkipTurn.$button;
+
+			buttonElement.addClass('bounce');
 			game.grid.querySelf({
 				fnOnConfirm: function () {
 					game.UI.btnSkipTurn.click();
-					
-					const buttonElement = game.UI.btnSkipTurn.$button;
-
-					buttonElement.addClass('bounce');
-
-					setTimeout(() => {
-						buttonElement.removeClass('bounce');
-					}, 1000);
 				},
 				fnOnCancel: function () {},
 				confirmText: 'Skip turn',

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -1439,6 +1439,26 @@ span.pure {
 	}
 }
 
+@keyframes button-bounce-left {
+	0% {
+		transform: translateX(0);
+	}
+	50% {
+		transform: translateX(-10px);
+	}
+	100% {
+		transform: translateX(0);
+	}
+}
+
+#skip.button {
+	transition: transform 1s ease-in-out;
+}
+
+#skip.button.bounce {
+	animation: button-bounce-left 1s ease-in-out;
+}
+
 /*--------------Framed Modal------------------*/
 /* Modal window with graphical border and close button. */
 .framed-modal {
@@ -2062,7 +2082,7 @@ input {
 	z-index: 1;
 	position: absolute;
 	top: 105px;
-	transition: opacity 300ms cubic-bezier(.39,.58,.57,1);;
+	transition: opacity 300ms cubic-bezier(0.39, 0.58, 0.57, 1);
 
 	div {
 		height: 125px;

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -1456,7 +1456,7 @@ span.pure {
 }
 
 #skip.button.bounce {
-	animation: button-bounce-left 1s ease-in-out;
+	animation: button-bounce-left 1s ease-in-out infinite;
 }
 
 /*--------------Framed Modal------------------*/

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -1460,7 +1460,7 @@ span.pure {
 }
 
 #skip.button.bounce:hover {
-	animation: none;
+	animation-iteration-count: 1;
 }
 
 /*--------------Framed Modal------------------*/

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -1459,6 +1459,10 @@ span.pure {
 	animation: button-bounce-left 1s ease-in-out infinite;
 }
 
+#skip.button.bounce:hover {
+	animation: none;
+}
+
 /*--------------Framed Modal------------------*/
 /* Modal window with graphical border and close button. */
 .framed-modal {

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -157,6 +157,9 @@ export class UI {
 						game.skipTurn();
 						this.lastViewedCreature = '';
 						this.queryUnit = '';
+						const buttonElement = this.btnSkipTurn.$button;
+
+						buttonElement.removeClass('bounce');
 					}
 				},
 			},


### PR DESCRIPTION
This fixes issue #2535 added bounce animation on skip button only when unit is out of actions and not when skip button is clicked manually.

Added animations in styles file for skip bounce button.
Attached bounce class to the skip button when the unit is out of actions. Removed the bounce class from the skip button after 3s using setTImeout.

My wallet address is 0x252b0dB01b57eC7A4A02c05cc06A0529d43C7142