### PR TITLE
Fix the UI of right panel buttons

### DIFF
--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -1970,11 +1970,6 @@ input {
 
 /*------------------Interface-------------------*/
 @media screen and (min-height: 200px) and (max-height: 479px) and (orientation: landscape) {
-	#ui {
-		#fullscreen {
-			transform: scale(0.55) translate(121px, -31px);
-		}
-	}
 	#queue {
 		transform: scale(0.55) translate(-335px, -40px);
 	}
@@ -1985,12 +1980,9 @@ input {
 		transform: scale(0.55) translate(-32px, -130px);
 	}
 	#rightpanel {
-		transform: scale(0.55) translate(48px, -212px);
+		transform: scale(0.55) translate(40px, -170px);
 	}
-	#playerbutton {
-		transform: scale(0.55) translate(39px, -39px);
-	}
-
+	
 	#scoreboardTitle {
 		font-size: medium;
 		margin: 0px !important;
@@ -2024,19 +2016,11 @@ input {
 	#queue {
 		transform: scale(0.7) translate(-174px, -20px);
 	}
-	#ui {
-		#fullscreen {
-			transform: scale(0.7) translate(63px, -16px);
-		}
-	}
-	#playerbutton {
-		transform: scale(0.7) translate(20px, -20px);
-	}
 	#leftpanel {
 		transform: scale(0.7) translate(-16px, -68px);
 	}
 	#rightpanel {
-		transform: scale(0.7) translate(25px, -111px);
+		transform: scale(0.7) translate(22px, -89px);
 	}
 	#bottompanel {
 		transform: scale(0.7);


### PR DESCRIPTION
This fixes issue [#issue](https://github.com/FreezingMoon/AncientBeast/issues/2145)

My mintme address is 0xb82c1a2192090acf236f691113b2a823a15eb03b

The proposed changes are removing the transformation applied on those buttons because the transformation of the rightpannel container already handles the scaling of all those buttons.

Here are screenshots before and after :

<img width="990" alt="Screenshot 2024-08-22 at 12 16 00" src="https://github.com/user-attachments/assets/093cc2fa-00cd-4976-a55a-6decefd01e5a">
<img width="1059" alt="Screenshot 2024-08-22 at 12 16 23" src="https://github.com/user-attachments/assets/91fa5eac-6dee-447f-98fd-f9d33a12dd07">


