### PR TITLE
[Issue-2542] Whip move interaction with plasma fielded dark priest

### DIFF
--- a/src/abilities/Headless.ts
+++ b/src/abilities/Headless.ts
@@ -1,5 +1,5 @@
 import { Damage } from '../damage';
-import { Team } from '../utility/team';
+import { isTeam, Team } from '../utility/team';
 import * as matrices from '../utility/matrices';
 import { Effect } from '../effect';
 import Game from '../game';
@@ -272,7 +272,22 @@ export default (G: Game) => {
 				let destinationX = null;
 				let destinationTargetX = null;
 				const isOnLeft = headless.x < target.x;
-				if (target.size === 1) {
+
+				if (
+					target.isDarkPriest() &&
+					target.hasCreaturePlayerGotPlasma() &&
+					!isTeam(this.creature, target, Team.Ally)
+				) {
+					/* Target creature is a plasma fielded enemy dark priest 
+					blocking the ability and triggering a counter damage if upgraded field */
+					destinationTargetX = 0;
+					const d = {
+						slash: 1,
+					};
+					const damage = new Damage(ability.creature, d, 1, [], G);
+
+					target.takeDamage(damage);
+				} else if (target.size === 1) {
 					/* Small creature, pull target towards self landing it in the hex directly
 					in front of the Headless. */
 					destinationTargetX = isOnLeft ? headless.x + 1 : headless.x - 2;

--- a/src/abilities/Headless.ts
+++ b/src/abilities/Headless.ts
@@ -278,7 +278,7 @@ export default (G: Game) => {
 					target.hasCreaturePlayerGotPlasma() &&
 					!isTeam(this.creature, target, Team.Ally)
 				) {
-					/* Target creature is a plasma fielded enemy dark priest 
+					/* Target creature is a plasma fielded enemy Dark Priest 
 					blocking the ability and triggering a counter damage if upgraded field */
 					destinationTargetX = 0;
 					const d = {


### PR DESCRIPTION
This fixes issue #2542 

My wallet address is 0x959E79438e522308587C3687d06bC3A467820119

**Issue summary**
Rework Headless' whip move to prevent enemy dark priest to be moved when plasma field is up and deal counter damage to headless if upgraded field.  Ability should still work on friendies.

**Actions taken**
I added a new logical condition to whip move in headless.ts checking for enemy plasma fielded dark priest which prevents the movement and added a point of damage for the ability to trigger shielded and counter. 

Preview
![Recording 2024-09-24 at 14 07 54](https://github.com/user-attachments/assets/7235d12e-3c78-40cb-a5ea-8c800be593ba)
