### PR TITLE
This fixed the issue if opencollective_banner isnt visible

### DIFF
--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -809,7 +809,8 @@ div.section.info {
 	bottom: 0;
 	width: 54%;
 	position: absolute;
-	overflow: hidden;
+	overflow-x: hidden;
+	overflow-y: auto;
 	text-align: center;
 	vertical-align: middle;
 	color: white;


### PR DESCRIPTION
This fixes issue the overflow issue that makes the OC widget clipped in some devices. Hence, setting the overflow-y to auto, fixed the issue. So, if the OC widget overflows, parent div becomes scrollable otherwise it remains hidden.

![image](https://github.com/user-attachments/assets/851afdde-f7d0-4f2c-822c-fc0e6fcfe4c2)


My wallet address is 0x928f2B71B6a3C3917F5d908EdD3F7C3612a53198
