### PR TITLE
Upgrade actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/config.yaml
+++ b/.github/workflows/config.yaml
@@ -18,7 +18,7 @@ jobs:
       env:
         PUBLIC_PATH: '/AncientBeast/'
     - name: Upload build artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: deploy
         path: deploy
@@ -39,7 +39,7 @@ jobs:
     - name: Static Code Analysis (ESLint)
       run: cat eslint-report.log
     - name: Archive ESLint Report
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
        name: eslint-report
        path: eslint-report.log


### PR DESCRIPTION
## Upgrade actions/upload-artifact to v4

This fixes issue #2624

- Updated `config.yaml` to use `actions/upload-artifact@v4` for:
  1. "Upload build artifact" step
  2. "Archive ESLint Report" step

This upgrade improves performance and fixes bugs in the artifact action.

My wallet address is 0xfBA90c8Fd61AcD3aa1e086628dc402Aa34334aDc