### PR TITLE
fix: creature vignette next turn status text

### DIFF
--- a/src/ui/queue.ts
+++ b/src/ui/queue.ts
@@ -95,8 +95,23 @@ export class Queue {
 
 		const turnEndMarkerV = [new TurnEndMarkerVignette(turnNum, eventHandlers)];
 
-		const newCreatureVNext = (c: Creature) =>
-			new CreatureVignette(c, turnNum + 1, eventHandlers, is1stCreature(), false);
+		const newCreatureVNext = (c: Creature) => {
+			let isCreatureAlreadyShown = false;
+			for (const oldC of creatures) {
+				if (oldC.id === c.id) {
+					isCreatureAlreadyShown = true;
+					break;
+				}
+			}
+			return new CreatureVignette(
+				c,
+				turnNum + 1,
+				eventHandlers,
+				is1stCreature(),
+				false,
+				isCreatureAlreadyShown,
+			);
+		};
 		const undelayedVsNext = undelayedCsNext.map(newCreatureVNext);
 		const delayMarkerVNext = hasDelayedNext
 			? [new DelayMarkerVignette(turnNum + 1, eventHandlers)]
@@ -359,6 +374,7 @@ class CreatureVignette extends Vignette {
 	creature: Creature;
 	isActiveCreature: boolean;
 	turnNumberIsCurrentTurn: boolean;
+	isAlreadyShown: boolean;
 
 	constructor(
 		creature: Creature,
@@ -366,6 +382,7 @@ class CreatureVignette extends Vignette {
 		eventHandlers: QueueEventHandlers,
 		isActiveCreature = false,
 		turnNumberIsCurrentTurn = true,
+		isAlreadyShown = false,
 	) {
 		super();
 		this.creature = creature;
@@ -373,6 +390,7 @@ class CreatureVignette extends Vignette {
 		this.eventHandlers = eventHandlers;
 		this.isActiveCreature = isActiveCreature;
 		this.turnNumberIsCurrentTurn = turnNumberIsCurrentTurn;
+		this.isAlreadyShown = isAlreadyShown;
 	}
 
 	getHash() {
@@ -431,7 +449,7 @@ class CreatureVignette extends Vignette {
 
 		this.el.style.zIndex = this.creature.temp ? '1000' : this.queuePosition + 1 + '';
 
-		const stats = this.turnNumberIsCurrentTurn ? this.creature.fatigueText : 'Queued';
+		const stats = this.isAlreadyShown ? 'Queued' : this.creature.fatigueText;
 		const statsClasses = ['stats', utils.toClassName(stats)].join(' ');
 		const statsEl = this.el.querySelector('div.stats');
 		statsEl.className = statsClasses;

--- a/src/ui/queue.ts
+++ b/src/ui/queue.ts
@@ -86,7 +86,7 @@ export class Queue {
 		const is1stCreature = utils.trueIfFirstElseFalse();
 
 		const newCreatureVCurr = (c: Creature) =>
-			new CreatureVignette(c, turnNum, eventHandlers, is1stCreature());
+			new CreatureVignette(c, turnNum, eventHandlers, is1stCreature(), true);
 		const undelayedVsCurr = undelayedCsCurr.map(newCreatureVCurr);
 		const delayMarkerVCurr = hasDelayedCurr
 			? [new DelayMarkerVignette(turnNum, eventHandlers)]
@@ -96,7 +96,7 @@ export class Queue {
 		const turnEndMarkerV = [new TurnEndMarkerVignette(turnNum, eventHandlers)];
 
 		const newCreatureVNext = (c: Creature) =>
-			new CreatureVignette(c, turnNum + 1, eventHandlers, is1stCreature());
+			new CreatureVignette(c, turnNum + 1, eventHandlers, is1stCreature(), false);
 		const undelayedVsNext = undelayedCsNext.map(newCreatureVNext);
 		const delayMarkerVNext = hasDelayedNext
 			? [new DelayMarkerVignette(turnNum + 1, eventHandlers)]
@@ -431,7 +431,7 @@ class CreatureVignette extends Vignette {
 
 		this.el.style.zIndex = this.creature.temp ? '1000' : this.queuePosition + 1 + '';
 
-		const stats = this.creature.fatigueText;
+		const stats = this.turnNumberIsCurrentTurn ? this.creature.fatigueText : 'Queued';
 		const statsClasses = ['stats', utils.toClassName(stats)].join(' ');
 		const statsEl = this.el.querySelector('div.stats');
 		statsEl.className = statsClasses;


### PR DESCRIPTION
This fixes issue #1049 
If I understood comments in the related issue, this should solve it.
It replaces status text of units in the next round queue with the word `Queued`