### PR TITLE
Fix: Sync grid highlight with selected creature during keyboard navigation

### DIFF
--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -1604,7 +1604,8 @@ export class UI {
 		this.materializeToggled = false;
 	}
 
-	gridSelectUp() { // 🔁 Updated: Use showCreature(...) to ensure both UI panel and grid highlight stay in sync
+	gridSelectUp() {
+		// 🔁 Updated: Use showCreature(...) to ensure both UI panel and grid highlight stay in sync
 
 		const game = this.game;
 		const creatureType = this.selectedCreature;
@@ -1623,7 +1624,8 @@ export class UI {
 		}
 	}
 
-	gridSelectDown() {// 🔁 Updated: Use showCreature(...) to ensure both UI panel and grid highlight stay in sync
+	gridSelectDown() {
+		// 🔁 Updated: Use showCreature(...) to ensure both UI panel and grid highlight stay in sync
 
 		const game = this.game;
 		const creatureType = this.selectedCreature;
@@ -1642,7 +1644,8 @@ export class UI {
 		}
 	}
 
-	gridSelectLeft() {// 🔁 Updated: Use showCreature(...) to ensure both UI panel and grid highlight stay in sync
+	gridSelectLeft() {
+		// 🔁 Updated: Use showCreature(...) to ensure both UI panel and grid highlight stay in sync
 
 		const creatureType = this.selectedCreature === '--' ? 'A0' : this.selectedCreature;
 
@@ -1653,7 +1656,8 @@ export class UI {
 		this.showCreature(nextCreature, this.selectedPlayer);
 	}
 
-	gridSelectRight() {// 🔁 Updated: Use showCreature(...) to ensure both UI panel and grid highlight stay in sync
+	gridSelectRight() {
+		// 🔁 Updated: Use showCreature(...) to ensure both UI panel and grid highlight stay in sync
 
 		const creatureType = this.selectedCreature === '--' ? 'A8' : this.selectedCreature;
 

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -875,6 +875,10 @@ export class UI {
 			.addClass('active');
 
 		this.selectedCreature = creatureType;
+		// Added: Visually highlight the selected creature on the grid
+		// This ensures the tile matches the active creature shown in the UI panel
+		this.$grid.find('.vignette').removeClass('active');
+		this.$grid.find(".vignette[creature='" + creatureType + "']").addClass('active');
 		const stats = game.retrieveCreatureStats(creatureType);
 		if (stats === undefined) return;
 
@@ -1600,76 +1604,64 @@ export class UI {
 		this.materializeToggled = false;
 	}
 
-	gridSelectUp() {
+	gridSelectUp() { // 🔁 Updated: Use showCreature(...) to ensure both UI panel and grid highlight stay in sync
+
 		const game = this.game;
 		const creatureType = this.selectedCreature;
-		let nextCreature;
 
-		const isDarkPriest = creatureType === '--';
-		if (isDarkPriest) {
+		if (creatureType === '--') {
 			this.showCreature('W1', this.selectedPlayer);
 			return;
 		}
 
-		if (game.realms.indexOf(creatureType[0]) - 1 > -1) {
-			const realm = game.realms[game.realms.indexOf(creatureType[0]) - 1];
+		const currentRealmIndex = game.realms.indexOf(creatureType[0]);
+		const newRealm = game.realms[currentRealmIndex - 1];
 
-			if (realm === '-') {
-				return;
-			}
-			nextCreature = realm + creatureType[1];
-			this.lastViewedCreature = nextCreature;
+		if (newRealm && newRealm !== '-') {
+			const nextCreature = newRealm + creatureType[1];
 			this.showCreature(nextCreature, this.selectedPlayer);
 		}
 	}
 
-	gridSelectDown() {
+	gridSelectDown() {// 🔁 Updated: Use showCreature(...) to ensure both UI panel and grid highlight stay in sync
+
 		const game = this.game;
 		const creatureType = this.selectedCreature;
-		let nextCreature;
 
-		const isDarkPriest = creatureType === '--';
-		if (isDarkPriest) {
+		if (creatureType === '--') {
 			this.showCreature('A1', this.selectedPlayer);
 			return;
 		}
 
-		if (game.realms.indexOf(creatureType[0]) + 1 < game.realms.length) {
-			const realm = game.realms[game.realms.indexOf(creatureType[0]) + 1];
-			nextCreature = realm + creatureType[1];
-			this.lastViewedCreature = nextCreature;
+		const currentRealmIndex = game.realms.indexOf(creatureType[0]);
+		const newRealm = game.realms[currentRealmIndex + 1];
+
+		if (newRealm) {
+			const nextCreature = newRealm + creatureType[1];
 			this.showCreature(nextCreature, this.selectedPlayer);
 		}
 	}
 
-	gridSelectLeft() {
-		const isDarkPriest = this.selectedCreature === '--';
-		const creatureType = isDarkPriest ? 'A0' : this.selectedCreature;
-		let nextCreature;
+	gridSelectLeft() {// 🔁 Updated: Use showCreature(...) to ensure both UI panel and grid highlight stay in sync
 
-		if (creatureType[1] - 1 < 1) {
-			// End of row
-			return;
-		} else {
-			nextCreature = creatureType[0] + (creatureType[1] - 1);
-			this.lastViewedCreature = nextCreature;
-			this.showCreature(nextCreature, this.selectedPlayer);
-		}
+		const creatureType = this.selectedCreature === '--' ? 'A0' : this.selectedCreature;
+
+		const col = parseInt(creatureType[1]);
+		if (col - 1 < 1) return;
+
+		const nextCreature = creatureType[0] + (col - 1);
+		this.showCreature(nextCreature, this.selectedPlayer);
 	}
 
-	gridSelectRight() {
-		const isDarkPriest = this.selectedCreature === '--';
-		const creatureType = isDarkPriest ? 'A8' : this.selectedCreature;
-		let nextCreature;
+	gridSelectRight() {// 🔁 Updated: Use showCreature(...) to ensure both UI panel and grid highlight stay in sync
 
-		if (creatureType[1] - 0 + 1 > 7) {
-			// End of row
-			return;
-		} else {
-			nextCreature = creatureType[0] + (creatureType[1] - 0 + 1);
-			this.lastViewedCreature = nextCreature;
-			this.showCreature(nextCreature, this.selectedPlayer);
-		}
+		const creatureType = this.selectedCreature === '--' ? 'A8' : this.selectedCreature;
+
+		const col = parseInt(creatureType[1]);
+		if (col + 1 > 7) return;
+
+		const nextCreature = creatureType[0] + (col + 1);
+		this.showCreature(nextCreature, this.selectedPlayer);
 	}
 
 	gridSelectNext() {


### PR DESCRIPTION
### This fixes #2477 : 
### Grid Highlight and UI Panel Desync During Keyboard Navigation

### Summary

This PR fixes a UI bug where the creature grid highlight would not update correctly when navigating with arrow keys. As a result, the left-side panel would reflect the newly selected creature, but the visual highlight would remain on the previously selected tile, creating a confusing and desynchronized user experience.

### Bug Reproduction
- Navigate the grid using arrow keys (↑ ↓ ← →)

- Observe that the left panel updates to the correct creature

- However, the grid highlight remains stuck on the previous tile

### What This PR Changes

### 1. Keyboard Navigation Refactor
Rewrote `gridSelectUp`, `gridSelectDown`, `gridSelectLeft`, and `gridSelectRight`

These functions now use `this.showCreature(...) `instead of manually updating internal state

This ensures the **UI and game logic stay synchronized**

**2. Grid Highlight Synchronization**
Added the following logic inside showCreature(...):
`this.$grid.find('.vignette').removeClass('active');`
`this.$grid.find(".vignette[creature='" + creatureType + "']").addClass('active');`

This ensures that whenever a creature is selected, the correct tile is visually highlighted on the grid.

### Testing 
- Arrow keys now update both the left panel and the grid highlight



Thank you again for your patience @DreadKnight and i'm waiting for this to be merged !