### PR TITLE
fix issue 2129: Show colored dashed hexes for active unit during move preview

### DIFF
--- a/src/creature.ts
+++ b/src/creature.ts
@@ -807,6 +807,21 @@ export class Creature {
 		});
 	}
 
+highlightCurrentHexesAsDashed() {
+	this.hexagons.forEach((hex) => {
+		hex.display.loadTexture(`hex_dashed_p${this.player.id}`);
+	});
+}
+
+
+clearDashedOverlayOnHexes() {
+	this.hexagons.forEach((hex) => {
+		hex.display.loadTexture(`hex_p${this.player.id}`);
+	});
+}
+
+	
+
 	/**
 	 * Face creature at given hex
 	 * @param{Hex | Creature} facefrom - Hex to face from

--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -182,21 +182,27 @@ export class Hex {
 
 			// Binding Events
 			this.hitBox.events.onInputOver.add(() => {
-				if (game.freezedInput || game.UI.dashopen) {
-					return;
+				if (game.freezedInput || game.UI.dashopen) return;
+			
+				//  Show dashed overlay on current hexes of active creature
+				if (this.reachable && game.activeCreature) {
+					game.activeCreature.highlightCurrentHexesAsDashed();
 				}
+			
 				game.signals.hex.dispatch('over', { hex: this });
 				grid.selectedHex = this;
 				this.onSelectFn(this);
 			}, this);
 
 			this.hitBox.events.onInputOut.add((_, pointer) => {
-				if (game.freezedInput || game.UI.dashopen || !pointer.withinGame) {
-					return;
+				if (game.freezedInput || game.UI.dashopen || !pointer.withinGame) return;
+			
+				//Clear dashed overlay when leaving a reachable hex
+				if (this.reachable && game.activeCreature) {
+					game.activeCreature.clearDashedOverlayOnHexes();
 				}
-
+			
 				game.signals.hex.dispatch('out', { hex: this });
-
 				grid.clearHexViewAlterations();
 				this.onHoverOffFn(this);
 			}, this);
@@ -611,11 +617,10 @@ export class Hex {
 
 		if (this.overlayClasses.match(/0|1|2|3/)) {
 			const player = this.overlayClasses.match(/0|1|2|3/);
-
+		
 			if (this.overlayClasses.match(/reachable/)) {
 				targetAlpha = true;
 				this.overlay.loadTexture('hex_path');
-				// hover when creature is inactive
 			} else if (
 				this.overlayClasses.match(/hover/) &&
 				this.displayClasses.indexOf(`creature player${player}`) === -1
@@ -623,15 +628,17 @@ export class Hex {
 				this.display.loadTexture('hex_path');
 				this.display.alpha = 1;
 				this.overlay.loadTexture(`hex_hover_p${player}`);
-				// hover over active player
 			} else if (this.overlayClasses.match(/hover/)) {
 				this.display.loadTexture('hex_path');
+			} else if (this.overlayClasses.match(/dashed/)) {
+				this.overlay.loadTexture(`hex_dashed_p${player}`);
 			} else {
 				this.overlay.loadTexture(`hex_p${player}`);
 			}
-
+		
 			this.grid.overlayHexesGroup.bringToTop(this.overlay);
-		} else {
+		}
+		 else {
 			this.overlay.loadTexture('cancel');
 			this.overlay.anchor.set(0.5, 0.5);
 			if (!this.isSpinning) {


### PR DESCRIPTION

This PR addresses Issue #2129– "Better showcase current unit location when moving".

    When hovering over a reachable hex, the current active creature’s hexes are updated with hex_dashed_pX textures.
    When hover ends or a move is confirmed, hexes revert to the original hex_pX texture.
Changes made:
    creature.ts
    Added two helper methods:
        highlightCurrentHexesAsDashed() – swaps display to hex_dashed_pX
        clearDashedOverlayOnHexes() – restores hex_pX
    hex.ts
    Updated hover listeners:
        onInputOver – calls highlightCurrentHexesAsDashed() when hovering a reachable tile
        onInputOut – calls clearDashedOverlayOnHexes() when hover ends