### PR TITLE
added progress cursor when hovering a creature

### DIFF
--- a/src/creature.ts
+++ b/src/creature.ts
@@ -324,6 +324,36 @@ export class Creature {
 		this.updateHex();
 
 		this.creatureSprite = new CreatureSprite(this);
+		const sprite = this.creatureSprite.sprite;
+		sprite.inputEnabled = true;
+
+		sprite.events.onInputOver.add(() => {
+			const selectedAbilityIndex = game.UI.selectedAbility;
+
+			// Check if this is your active creature, and no ability is selected
+			if (
+				game.activeCreature === this &&
+				this.player === game.activePlayer &&
+				selectedAbilityIndex === -1
+			) {
+				console.log('[✅] Progress cursor conditions met for:', this.name);
+				document.body.style.cursor = 'progress';
+				const canvas = document.querySelector('canvas');
+				if (canvas) canvas.style.cursor = 'progress';
+
+				game.UI.cursorFrozen = true;
+			} else {
+				console.log('[❌] Conditions not met for:', this.name);
+			}
+		}, this);
+
+		sprite.events.onInputOut.add(() => {
+			document.body.style.cursor = 'default';
+			const canvas = document.querySelector('canvas');
+			if (canvas) canvas.style.cursor = 'default';
+
+			game.UI.cursorFrozen = false;
+		});
 
 		if (!this.temp) {
 			let tempCreature: Creature | undefined = undefined;

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -20,7 +20,6 @@ import { DEBUG_DISABLE_HOTKEYS } from '../debug';
 
 import { cycleAudioMode, getAudioMode, AudioMode } from '../sound/soundsys';
 
-
 /**
  * Class UI
  *
@@ -125,24 +124,24 @@ export class UI {
 		);
 		this.buttons.push(this.btnFullscreen);
 
-// Audio Button
-this.btnAudio = new Button(
-	{
-		$button: $j('.toggle-music-player'),
-		hasShortcut: true,
-		click: () => {
-			this.game.signals.ui.dispatch('toggleMusicPlayer');
-		},
-		overridefreeze: true,
-	},
-	{ isAcceptingInput: () => this.interfaceAPI.isAcceptingInput },
-);
-this.buttons.push(this.btnAudio);
-this.btnAudio.$button.on('contextmenu', (e) => {
-	e.preventDefault();
-	const newMode = cycleAudioMode(this.game.soundsys);
-	this.updateAudioIcon(newMode); 
-});
+		// Audio Button
+		this.btnAudio = new Button(
+			{
+				$button: $j('.toggle-music-player'),
+				hasShortcut: true,
+				click: () => {
+					this.game.signals.ui.dispatch('toggleMusicPlayer');
+				},
+				overridefreeze: true,
+			},
+			{ isAcceptingInput: () => this.interfaceAPI.isAcceptingInput },
+		);
+		this.buttons.push(this.btnAudio);
+		this.btnAudio.$button.on('contextmenu', (e) => {
+			e.preventDefault();
+			const newMode = cycleAudioMode(this.game.soundsys);
+			this.updateAudioIcon(newMode);
+		});
 		// Skip Turn Button
 		this.btnSkipTurn = new Button(
 			{
@@ -1909,7 +1908,7 @@ this.btnAudio.$button.on('contextmenu', (e) => {
 	updateAudioIcon(mode) {
 		let iconKey = 'icons/audio';
 		let tooltipText = 'Audio: Full';
-	
+
 		if (mode === 'sfx') {
 			iconKey = 'icons/SFX';
 			tooltipText = 'Audio: SFX';
@@ -1917,18 +1916,18 @@ this.btnAudio.$button.on('contextmenu', (e) => {
 			iconKey = 'icons/muted';
 			tooltipText = 'Audio: Muted';
 		}
-		
+
 		const iconUrl = getUrl(iconKey);
 		const $audioImg = $j('#audio img');
 		if ($audioImg.length) {
 			$audioImg.attr('src', iconUrl);
 		}
-	
+
 		const $tooltip = $j('#audio-tooltip');
 		if ($tooltip.length) {
 			$tooltip.text(tooltipText);
 		}
-	}			
+	}
 	updateAbilityUpgrades() {
 		const game = this.game,
 			creature = game.activeCreature;
@@ -2454,6 +2453,13 @@ this.btnAudio.$button.on('contextmenu', (e) => {
 		document.addEventListener('visibilitychange', function () {
 			if (document.hidden) {
 				ui.$brandlogo.addClass('hide');
+			}
+		});
+		document.addEventListener('mousemove', () => {
+			if (ui.cursorFrozen) {
+				const canvas = document.querySelector('canvas');
+				if (canvas) canvas.style.cursor = 'progress';
+				document.body.style.cursor = 'progress';
 			}
 		});
 


### PR DESCRIPTION
This PR implements the behavior described in #2246, making the cursor change to progress when:

. It is the player's turn

. The hovered creature is the currently active creature

. No ability is selected

In `creature.ts`:

Attached `onInputOver` and `onInputOut` handlers to the creature’s sprite
When hovering the active unit with no selected ability:

Set cursor: progress on both document.body and <canvas>

Enabled a cursorFrozen flag in the UI to track override state

```
const sprite = this.creatureSprite.sprite;
sprite.inputEnabled = true;

sprite.events.onInputOver.add(() => {
  const selectedAbilityIndex = game.UI.selectedAbility;

  if (
    game.activeCreature === this &&
    this.player === game.activePlayer &&
    selectedAbilityIndex === -1
  ) {
    console.log('[✅] Progress cursor conditions met for:', this.name);
    document.body.style.cursor = 'progress';
    const canvas = document.querySelector('canvas');
    if (canvas) canvas.style.cursor = 'progress';

    game.UI.cursorFrozen = true;
  } else {
    console.log('[❌] Conditions not met for:', this.name);
  }
}, this);

sprite.events.onInputOut.add(() => {
  document.body.style.cursor = 'default';
  const canvas = document.querySelector('canvas');
  if (canvas) canvas.style.cursor = 'default';

  game.UI.cursorFrozen = false;
});
``` 

In `interface.js`:

    Added a global mousemove listener that maintains the progress cursor when cursorFrozen is true.
    
```
document.addEventListener('mousemove', () => {
  if (ui.cursorFrozen) {
    const canvas = document.querySelector('canvas');
    if (canvas) canvas.style.cursor = 'progress';
    document.body.style.cursor = 'progress';
  }
});
```
PS : the audio updated files somehow appeared when i created my branch as i didnt touch anything related to the audio i think it belongs to the latest merge that you did i only modifed `interface.js` and `creature.ts`
