### PR TITLE
showcase ability range on click

### DIFF
--- a/src/abilities/Abolished.js
+++ b/src/abilities/Abolished.js
@@ -108,12 +108,28 @@ export default (G) => {
 				return true;
 			},
 
-			query() {
+			query(isPreview = false) {
 				const ability = this;
 				const abolished = this.creature;
 
 				// TODO: Visually show reduced damage hexes for 4-6 range
-
+				const forwardHexes = G.grid.getHexLine(
+					abolished.x,
+					abolished.y,
+					abolished.facing,
+					this.range.regular // Distance: 3 hexes straight ahead
+				);
+			
+				if (isPreview) {
+					G.grid.queryHexes({
+						hexes: forwardHexes,
+						hideNonTarget: true,
+						id: abolished.id,
+						size: abolished.size,
+						flipped: abolished.player.flipped,
+					});
+					return;
+				}
 				G.grid.queryDirection({
 					fnOnConfirm: function () {
 						ability.animation(...arguments);
@@ -216,12 +232,25 @@ export default (G) => {
 				return this.testRequirements();
 			},
 
-			query() {
+			query(isPreview = false) {
 				const ability = this;
 				const crea = this.creature;
 				let totalRange = this.range;
 				if (this.isUpgraded()) {
 					totalRange = this.range + this.creature.accumulatedTeleportRange - 1;
+				}
+
+				const range = G.grid.getFlyingRange(crea.x, crea.y, totalRange, crea.size, crea.id);
+
+				if (isPreview) {
+					G.grid.queryHexes({
+						hexes: range,
+						hideNonTarget: true,
+						id: crea.id,
+						size: crea.size,
+						flipped: crea.player.flipped,
+					});
+					return;
 				}
 
 				// Relocates to any hex within range except for the current hex
@@ -319,13 +348,24 @@ export default (G) => {
 			require() {
 				return this.testRequirements();
 			},
-			query() {
+			query(isPreview = false) {
 				const ability = this;
 				const crea = this.creature;
 
 				// var inRangeCreatures = crea.hexagons[1].adjacentHex(1);
 
 				const range = crea.adjacentHexes(1);
+
+				if (isPreview) {
+					G.grid.queryHexes({
+						hexes: range,
+						hideNonTarget: true,
+						id: crea.id,
+						size: crea.size,
+						flipped: crea.player.flipped,
+					});
+					return;
+				}
 
 				G.grid.queryHexes({
 					fnOnConfirm: function () {

--- a/src/abilities/Asher.js
+++ b/src/abilities/Asher.js
@@ -79,7 +79,8 @@ export default (G) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) return;
 				const ability = this;
 				const crea = this.creature;
 
@@ -129,9 +130,22 @@ export default (G) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
 				const ability = this;
 				const crea = this.creature;
+				
+				const hexRange = G.grid.getFlyingRange(crea.x, crea.y, 50, crea.size, crea.id);
+
+				if (isPreview) {
+					G.grid.queryHexes({
+						hexes: hexRange,
+						hideNonTarget: true,
+						id: crea.id,
+						flipped: crea.player.flipped,
+						size: crea.size,
+					});
+					return;
+				}
 
 				crea.queryMove({
 					noPath: true,
@@ -233,7 +247,7 @@ export default (G) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
 				const ability = this;
 				const crea = this.creature;
 
@@ -243,7 +257,18 @@ export default (G) => {
 				const tail = range.indexOf(crea.hexagons[2]);
 				range.splice(head, 1);
 				range.splice(tail, 1);
-
+				
+				if (isPreview) {
+					G.grid.queryHexes({
+						hexes: range,
+						hideNonTarget: true,
+						id: crea.id,
+						flipped: crea.player.flipped,
+						size: crea.size,
+					});
+					return;
+				}
+				
 				G.grid.queryHexes({
 					fnOnConfirm: function () {
 						ability.animation(...arguments);

--- a/src/abilities/Bounty-Hunter.ts
+++ b/src/abilities/Bounty-Hunter.ts
@@ -125,7 +125,8 @@ export default (G: Game) => {
 			},
 
 			//query():
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) return;
 				const ability = this;
 				const crea = this.creature;
 
@@ -236,7 +237,7 @@ export default (G: Game) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
 				const bellowrow = matrices.bellowrow;
 				const straitrow = matrices.straitrow;
 
@@ -257,6 +258,18 @@ export default (G: Game) => {
 				choices.forEach(function (choice) {
 					arrayUtils.filterCreature(choice, true, true, swine.id);
 				});
+
+				if (isPreview) {
+					G.grid.queryChoice({
+						choices: choices,
+						id: swine.id,
+						hideNonTarget: true,
+						flipped: swine.player.flipped,
+						team: this._targetTeam,
+						requireCreature: 1,
+					});
+					return;
+				}
 
 				G.grid.queryChoice({
 					fnOnConfirm: function () {
@@ -337,7 +350,7 @@ export default (G: Game) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
 				const ability = this;
 				const swine = this.creature;
 
@@ -350,6 +363,14 @@ export default (G: Game) => {
 					hexes = G.grid.getFlyingRange(swine.x, swine.y, 50, 1, 0);
 				}
 				hexes.push(G.grid.hexes[swine.y][swine.x]);
+
+				if (isPreview) {
+					G.grid.queryHexes({
+						hexes: hexes,
+						hideNonTarget: true,
+					});
+					return;
+				}
 
 				G.grid.queryHexes({
 					fnOnCancel: function () {

--- a/src/abilities/Chimera.js
+++ b/src/abilities/Chimera.js
@@ -67,7 +67,8 @@ export default (G) => {
 			},
 
 			//	query() :
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) return;
 				const ability = this;
 				const chimera = this.creature;
 
@@ -128,9 +129,28 @@ export default (G) => {
 			},
 
 			//	query() :
-			query: function () {
+			query: function (isPreview = false) {
 				const ability = this;
 				const chimera = this.creature;
+
+				if (isPreview) {
+					
+					let forward = G.grid.getHexMap(chimera.x, chimera.y, 0, false, matrices.straitrow);
+					let backward = G.grid.getHexMap(chimera.x, chimera.y, 0, true, matrices.straitrow);
+					const hexes = forward.concat(backward).sort(function (a, b) {
+						return a.x - b.x;
+					});
+
+					G.grid.queryHexes({
+						hexes: hexes,
+						id: chimera.id,
+						size: chimera.size,
+						flipped: chimera.player.flipped,
+						hideNonTarget: true,
+					});
+					return;
+				
+				}
 
 				G.grid.queryDirection({
 					fnOnConfirm: function () {
@@ -254,7 +274,8 @@ export default (G) => {
 			},
 
 			//	query() :
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) return;
 				const ability = this;
 				const chimera = this.creature;
 

--- a/src/abilities/Cyber-Wolf.ts
+++ b/src/abilities/Cyber-Wolf.ts
@@ -79,7 +79,8 @@ export default (G: Game) => {
 			},
 
 			//	query() :
-			query: function () {
+			query: function (isPreview = false) {
+				if(isPreview){return;}
 				const ability = this;
 				const crea = this.creature;
 
@@ -154,12 +155,33 @@ export default (G: Game) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
 				const ability = this;
 				const crea = this.creature;
 
 				const straitrow = matrices.straitrow;
 				const bellowrow = matrices.bellowrow;
+				
+				const hexes = []
+					.concat(
+						G.grid.getHexMap(crea.x, crea.y - 2, 0, false, bellowrow),
+						G.grid.getHexMap(crea.x, crea.y, 0, false, straitrow),
+						G.grid.getHexMap(crea.x, crea.y, 0, false, bellowrow),
+						G.grid.getHexMap(crea.x - 1, crea.y - 2, 0, true, bellowrow),
+						G.grid.getHexMap(crea.x - 1, crea.y, 0, true, straitrow),
+						G.grid.getHexMap(crea.x - 1, crea.y, 0, true, bellowrow)
+					);
+
+				if (isPreview) {
+					G.grid.queryHexes({
+						hexes: hexes,
+						id: crea.id,
+						size: crea.size,
+						flipped: crea.player.flipped,
+						hideNonTarget: true,
+					});
+					return;
+				}
 
 				const choices = [
 					//Front
@@ -207,6 +229,7 @@ export default (G: Game) => {
 							),
 						),
 				];
+				
 
 				G.grid.queryChoice({
 					fnOnCancel: function () {
@@ -327,7 +350,8 @@ export default (G: Game) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
+				if(isPreview){return;}
 				const ability = this;
 				const crea = this.creature;
 

--- a/src/abilities/Dark-Priest.js
+++ b/src/abilities/Dark-Priest.js
@@ -86,7 +86,8 @@ export default (G) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) {return;}
 				const ability = this;
 				const dpriest = this.creature;
 
@@ -168,7 +169,8 @@ export default (G) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) {return;}
 				const ability = this;
 				const dpriest = this.creature;
 
@@ -242,7 +244,8 @@ export default (G) => {
 			summonRange: 4,
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) {return;}
 				if (this.isUpgraded()) {
 					this.summonRange = 6;
 				}

--- a/src/abilities/Golden-Wyrm.ts
+++ b/src/abilities/Golden-Wyrm.ts
@@ -109,7 +109,8 @@ export default (G: Game) => {
 				return true;
 			},
 
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) {return;}
 				const wyrm = this.creature;
 				const ability = this;
 
@@ -213,11 +214,22 @@ export default (G: Game) => {
 				return true;
 			},
 
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) {return;}
 				const ability = this;
 				const wyrm = this.creature;
 
 				const range = this.game.grid.getFlyingRange(wyrm.x, wyrm.y, 10, wyrm.size, wyrm.id);
+				if (isPreview) {
+					G.grid.queryHexes({
+						hexes: range,
+						size: wyrm.size,
+						flipped: wyrm.player.flipped,
+						id: wyrm.id,
+						hideNonTarget: true,
+					});
+					return;
+				}
 
 				this.game.grid.queryHexes({
 					fnOnSelect: function () {
@@ -342,7 +354,8 @@ export default (G: Game) => {
 				return true;
 			},
 
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) {return;}
 				const ability = this;
 				const wyrm = this.creature;
 

--- a/src/abilities/Gumble.ts
+++ b/src/abilities/Gumble.ts
@@ -82,7 +82,7 @@ export default (G: Game) => {
 			},
 
 			// query() :
-			query: function () {
+			query: function (isPreview = false) {
 				const ability = this;
 				// Gummy Mallet can hit a 7-hexagon circular area in 6 directions, where the
 				// center of each area is two hexes away. Each area can be chosen regardless
@@ -109,6 +109,20 @@ export default (G: Game) => {
 				choices.sort(function (choice1, choice2) {
 					return choice1.length - choice2.length;
 				});
+
+				/*currently not disyplaying preview hexes for Gumble*/
+				if (isPreview) {
+					console.log("PROBLEMHERE")
+					G.grid.queryChoice({
+						choices: choices,
+						id: this.creature.id,
+						hideNonTarget: true,
+						flipped: this.creature.player.flipped,
+						team: this._targetTeam,
+						requireCreature: 1,
+					});
+					return;
+				}
 				G.grid.queryChoice({
 					fnOnCancel: function () {
 						G.activeCreature.queryMove();
@@ -174,7 +188,7 @@ export default (G: Game) => {
 			},
 
 			// query() :
-			query: function () {
+			query: function (isPreview = false) {
 				const ability = this;
 				const creature = this.creature;
 
@@ -183,6 +197,17 @@ export default (G: Game) => {
 				const hexes = creature.hexagons.concat(
 					G.grid.getFlyingRange(creature.x, creature.y, range, creature.size, creature.id),
 				);
+
+				if (isPreview) {
+					G.grid.queryHexes({
+						hexes: hexes,
+						size: creature.size,
+						flipped: creature.player.flipped,
+						id: creature.id,
+						hideNonTarget: true,
+					});
+					return;
+				}
 
 				G.grid.queryHexes({
 					fnOnConfirm: function () {
@@ -295,10 +320,25 @@ export default (G: Game) => {
 			},
 
 			// query() :
-			query: function () {
+			query: function (isPreview = false) {
 				const ability = this;
 				const crea = this.creature;
 
+				if (isPreview) {
+					
+					let forward = G.grid.getHexMap(crea.x, crea.y, 0, false, matrices.straitrow);
+					const hexes = forward;
+
+					G.grid.queryHexes({
+						hexes: hexes,
+						id: crea.id,
+						size: crea.size,
+						flipped: crea.player.flipped,
+						hideNonTarget: true,
+					});
+					return;
+				
+				}
 				G.grid.queryDirection({
 					fnOnConfirm: function () {
 						// eslint-disable-next-line

--- a/src/abilities/Headless.ts
+++ b/src/abilities/Headless.ts
@@ -3,6 +3,7 @@ import { isTeam, Team } from '../utility/team';
 import * as matrices from '../utility/matrices';
 import { Effect } from '../effect';
 import Game from '../game';
+import * as arrayUtils from '../utility/arrayUtils';
 
 /** Creates the abilities
  * @param {Object} G the game object
@@ -128,7 +129,8 @@ export default (G: Game) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) {return;}
 				const ability = this;
 				const crea = this.creature;
 
@@ -240,9 +242,27 @@ export default (G: Game) => {
 				return true;
 			},
 
-			query: function () {
+			query: function (isPreview = false) {
 				const ability = this;
 				const headless = this.creature;
+
+				if (isPreview){
+					let forward = G.grid.getHexMap(headless.x, headless.y, 0, false, matrices.straitrow).slice(0, this._getMaxDistance()+1);
+					let backward = G.grid.getHexMap(headless.x, headless.y, 0, true, matrices.straitrow).slice(0, this._getMaxDistance()+2);
+					// Combine and sort by X, left to right
+					const hexes = forward.concat(backward).sort(function (a, b) {
+						return a.x - b.x;
+					});
+
+					G.grid.queryHexes({
+						hexes: hexes,
+						id: headless.id,
+						size: headless.size,
+						flipped: headless.player.flipped,
+						hideNonTarget: true,
+					});
+					return;
+				}
 
 				G.grid.queryDirection({
 					fnOnConfirm: function () {
@@ -379,12 +399,23 @@ export default (G: Game) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
 				const ability = this;
 				const crea = this.creature;
 
 				const hexes = this._getHexes();
 
+				if (isPreview) {
+					let choices = [crea.getHexMap(hexes, false), crea.getHexMap(hexes, true)];
+					G.grid.queryHexes({
+						hexes: choices.flat(),
+						id: crea.id,
+						size: crea.size,
+						flipped: crea.player.flipped,
+						hideNonTarget: true,
+					});
+					return;
+				}
 				G.grid.queryChoice({
 					fnOnConfirm: function () {
 						// eslint-disable-next-line

--- a/src/abilities/Impaler.js
+++ b/src/abilities/Impaler.js
@@ -78,7 +78,8 @@ export default (G) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) {return;}
 				const ability = this;
 				const creature = this.creature;
 				G.grid.queryCreature({
@@ -157,7 +158,8 @@ export default (G) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) {return;}
 				const ability = this;
 				const creature = this.creature;
 
@@ -278,7 +280,8 @@ export default (G) => {
 			},
 
 			//	query() :
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) {return;}
 				const ability = this;
 
 				G.grid.queryCreature({

--- a/src/abilities/Infernal.js
+++ b/src/abilities/Infernal.js
@@ -102,7 +102,8 @@ export default (G) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) {return;}
 				const ability = this;
 				const magmaSpawn = this.creature;
 
@@ -189,12 +190,22 @@ export default (G) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
 				const ability = this;
 				const magmaSpawn = this.creature;
 
 				this.map.origin = [0, 2];
-
+				if (isPreview) {
+					let choices = [magmaSpawn.getHexMap(this.map), magmaSpawn.getHexMap(this.map, true)];
+					G.grid.queryHexes({
+						hexes: choices.flat(),
+						id: magmaSpawn.id,
+						size: magmaSpawn.size,
+						flipped: magmaSpawn.player.flipped,
+						hideNonTarget: true,
+					});
+					return;
+				}
 				G.grid.queryChoice({
 					fnOnConfirm: function () {
 						ability.animation(...arguments);
@@ -274,11 +285,23 @@ export default (G) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
 				const ability = this;
 				const magmaSpawn = this.creature;
 
 				const x = magmaSpawn.player.flipped ? magmaSpawn.x - magmaSpawn.size + 1 : magmaSpawn.x;
+
+				if (isPreview) {
+					let forward = G.grid.getHexMap(magmaSpawn.x, magmaSpawn.y, 0, false, matrices.straitrow);
+					G.grid.queryHexes({
+						hexes: forward,
+						id: magmaSpawn.id,
+						size: magmaSpawn.size,
+						flipped: magmaSpawn.player.flipped,
+						hideNonTarget: true,
+					});
+					return;
+				}
 
 				G.grid.queryDirection({
 					fnOnConfirm: function () {

--- a/src/abilities/Knightmare.js
+++ b/src/abilities/Knightmare.js
@@ -3,6 +3,7 @@ import { Team } from '../utility/team';
 import * as matrices from '../utility/matrices';
 import { Creature } from '../creature';
 import { Effect } from '../effect';
+import * as arrayUtils from '../utility/arrayUtils';
 
 /** Creates the abilities
  * @param {Object} G the game object
@@ -85,7 +86,8 @@ export default (G) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) {return;}
 				const ability = this;
 
 				G.grid.queryCreature({
@@ -161,7 +163,8 @@ export default (G) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) {return;}
 				const ability = this;
 
 				G.grid.queryCreature({
@@ -256,12 +259,29 @@ export default (G) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
 				const ability = this;
 				const crea = this.creature;
 
 				const x = crea.player.flipped ? crea.x - crea.size + 1 : crea.x;
+				if (isPreview){
 
+					let forward = G.grid.getHexMap(crea.x, crea.y, 0, false, matrices.straitrow).slice(0, this._getDistance()+1);
+					let backward = G.grid.getHexMap(crea.x, crea.y, 0, true, matrices.straitrow).slice(0, this._getDistance()+1);
+					// Combine and sort by X, left to right
+					const hexes = forward.concat(backward).sort(function (a, b) {
+						return a.x - b.x;
+					});
+
+					G.grid.queryHexes({
+						hexes: hexes,
+						id: crea.id,
+						size: crea.size,
+						flipped: crea.player.flipped,
+						hideNonTarget: true,
+					});
+					return;
+				}
 				G.grid.queryDirection({
 					fnOnConfirm: function () {
 						ability.animation(...arguments);

--- a/src/abilities/Nutcase.ts
+++ b/src/abilities/Nutcase.ts
@@ -146,7 +146,8 @@ export default (G: Game) => {
 			},
 
 			//	query() :
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) {return;}
 				const ability = this;
 
 				if (!this.isUpgraded()) {
@@ -324,8 +325,20 @@ export default (G: Game) => {
 				return true;
 			},
 
-			query: function () {
+			query: function (isPreview = false) {
 				const ability = this;
+
+				if (isPreview) {
+					let forward = G.grid.getHexMap(this.creature.x, this.creature.y, 0, false, matrices.straitrow)
+					G.grid.queryHexes({
+						hexes: forward,
+						id: this.creature.id,
+						size: this.creature.size,
+						flipped: this.creature.player.flipped,
+						hideNonTarget: true,
+					});
+					return;
+				}
 
 				let o: Partial<QueryOptions> = {
 					fnOnConfirm: function () {
@@ -583,7 +596,8 @@ export default (G: Game) => {
 			},
 
 			//	query() :
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) {return;}
 				const ability = this;
 
 				G.grid.queryCreature({

--- a/src/abilities/Scavenger.js
+++ b/src/abilities/Scavenger.js
@@ -88,7 +88,8 @@ export default (G) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) {return;}
 				const ability = this;
 
 				G.grid.queryCreature({
@@ -200,7 +201,8 @@ export default (G) => {
 				return true;
 			},
 
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) {return;}
 				const ability = this;
 				const crea = this.creature;
 
@@ -347,7 +349,8 @@ export default (G) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) {return;}
 				const ability = this;
 
 				G.grid.queryCreature({

--- a/src/abilities/Snow-Bunny.ts
+++ b/src/abilities/Snow-Bunny.ts
@@ -244,7 +244,8 @@ export default (G: Game) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) {return;}
 				const ability = this;
 				const snowBunny = this.creature;
 
@@ -318,10 +319,28 @@ export default (G: Game) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
 				const ability = this;
 				const snowBunny = this.creature;
 
+				if (isPreview){
+				
+					let forward = G.grid.getHexMap(snowBunny.x, snowBunny.y, 0, false, matrices.straitrow);
+					let backward = G.grid.getHexMap(snowBunny.x, snowBunny.y, 0, true, matrices.straitrow);
+					// Combine and sort by X, left to right
+					const hexes = forward.concat(backward).sort(function (a, b) {
+						return a.x - b.x;
+					});
+
+					G.grid.queryHexes({
+						hexes: hexes,
+						id: snowBunny.id,
+						size: snowBunny.size,
+						flipped: snowBunny.player.flipped,
+						hideNonTarget: true,
+					});
+					return;
+				}
 				G.grid.queryDirection({
 					fnOnConfirm: function () {
 						// eslint-disable-next-line
@@ -438,10 +457,24 @@ export default (G: Game) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
 				const ability = this;
 				const snowBunny = this.creature;
+				if (isPreview){
+				
+					let forward = G.grid.getHexMap(snowBunny.x, snowBunny.y, 0, false, matrices.straitrow);
+					// Combine and sort by X, left to right
 
+
+					G.grid.queryHexes({
+						hexes: forward,
+						id: snowBunny.id,
+						size: snowBunny.size,
+						flipped: snowBunny.player.flipped,
+						hideNonTarget: true,
+					});
+					return;
+				}
 				G.grid.queryDirection({
 					fnOnConfirm: function () {
 						// eslint-disable-next-line

--- a/src/abilities/Stomper.ts
+++ b/src/abilities/Stomper.ts
@@ -97,7 +97,8 @@ export default (G: Game) => {
 			},
 
 			// query() :
-			query: function () {
+			query: function (isPreview = false) {
+				
 				const stomper = this.creature;
 				const ability = this;
 
@@ -106,6 +107,7 @@ export default (G: Game) => {
 					G.grid.queryDirection({
 						fnOnConfirm: function () {
 							// eslint-disable-next-line
+							if (isPreview) {return;}
 							ability.animation(...arguments);
 						},
 						flipped: stomper.player.flipped,
@@ -122,6 +124,7 @@ export default (G: Game) => {
 				else {
 					G.grid.queryDirection({
 						fnOnConfirm: function () {
+							if (isPreview) {return;}
 							// eslint-disable-next-line
 							if (arguments[1].hex.creature) {
 								// eslint-disable-next-line
@@ -353,7 +356,8 @@ export default (G: Game) => {
 			},
 
 			// query() :
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) {return;}
 				const ability = this;
 				const stomper = this.creature;
 				// Get the direction of the melee target, the dashed hex and the targets
@@ -472,10 +476,27 @@ export default (G: Game) => {
 			},
 
 			// query() :
-			query: function () {
+			query: function (isPreview = false) {
 				const ability = this;
 				const stomper = this.creature;
+				if (isPreview) {
 
+					let forward = stomper.getHexMap(matrices.frontAndBack8Hex, false);
+					let backward = stomper.getHexMap(matrices.frontAndBack8Hex, true);
+					// Combine and sort by X, left to right
+					const hexes = forward.concat(backward).sort(function (a, b) {
+						return a.x - b.x;
+					});
+					G.grid.queryHexes({
+						hexes: hexes,
+						id: stomper.id,
+						size: stomper.size,
+						flipped: stomper.player.flipped,
+						hideNonTarget: true,
+					});
+					return;
+
+				}
 				G.grid.queryChoice({
 					fnOnConfirm: function () {
 						// eslint-disable-next-line

--- a/src/abilities/Swine-Thug.ts
+++ b/src/abilities/Swine-Thug.ts
@@ -132,7 +132,8 @@ export default (G: Game) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
+				if(isPreview){return;}
 				const ability = this;
 				const swine = this.creature;
 
@@ -288,7 +289,7 @@ export default (G: Game) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
 				const bellowrow = matrices.bellowrow;
 				const straitrow = matrices.straitrow;
 
@@ -309,6 +310,17 @@ export default (G: Game) => {
 				choices.forEach(function (choice) {
 					arrayUtils.filterCreature(choice, true, true, swine.id);
 				});
+
+				if (isPreview) {
+					G.grid.queryHexes({
+						hexes: choices.flat(),
+						size: swine.size,
+						flipped: swine.player.flipped,
+						id: swine.id,
+						hideNonTarget: true,
+					});
+					return;
+				}
 
 				G.grid.queryChoice({
 					fnOnConfirm: function () {
@@ -389,7 +401,7 @@ export default (G: Game) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
 				const ability = this;
 				const swine = this.creature;
 
@@ -402,6 +414,17 @@ export default (G: Game) => {
 					hexes = G.grid.getFlyingRange(swine.x, swine.y, 50, 1, 0);
 				}
 				hexes.push(G.grid.hexes[swine.y][swine.x]);
+
+				if (isPreview) {
+					G.grid.queryHexes({
+						hexes: hexes,
+						size: swine.size,
+						flipped: swine.player.flipped,
+						id: swine.id,
+						hideNonTarget: true,
+					});
+					return;
+				}
 
 				G.grid.queryHexes({
 					fnOnCancel: function () {

--- a/src/abilities/Uncle-Fungus.ts
+++ b/src/abilities/Uncle-Fungus.ts
@@ -103,7 +103,8 @@ export default (G: Game) => {
 			},
 
 			// query() :
-			query: function () {
+			query: function (isPreview = false) {
+				if(isPreview){return;}
 				const uncle = this.creature;
 
 				G.grid.queryCreature({
@@ -191,13 +192,24 @@ export default (G: Game) => {
 			},
 
 			// query() :
-			query: function () {
+			query: function (isPreview = false) {
 				const uncle = this.creature;
 
 				// Don't jump over creatures if we're not upgraded, or we are in a second
 				// "low" jump
 				const stopOnCreature = !this.isUpgraded() || this._isSecondLowJump();
 				const hexes = this._getHexRange(stopOnCreature);
+
+				if (isPreview) {
+					G.grid.queryHexes({
+						hexes: hexes,
+						size: uncle.size,
+						flipped: uncle.player.flipped,
+						id: uncle.id,
+						hideNonTarget: true,
+					});
+					return;
+				}
 
 				G.grid.queryHexes({
 					fnOnSelect: function (...args) {
@@ -361,7 +373,8 @@ export default (G: Game) => {
 			},
 
 			// query() :
-			query: function () {
+			query: function (isPreview = false) {
+				if(isPreview){return;}
 				const uncle = this.creature;
 
 				G.grid.queryCreature({

--- a/src/abilities/Vehemoth.js
+++ b/src/abilities/Vehemoth.js
@@ -114,7 +114,8 @@ export default (G) => {
 			},
 
 			// 	query() :
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) {return;}
 				const ability = this;
 				const vehemoth = this.creature;
 
@@ -315,7 +316,8 @@ export default (G) => {
 				return true;
 			},
 
-			query: function () {
+			query: function (isPreview = false) {
+				if (isPreview) {return;}
 				const ability = this;
 				const vehemoth = this.creature;
 
@@ -451,10 +453,19 @@ export default (G) => {
 				return true;
 			},
 
-			query: function () {
+			query: function (isPreview = false) {
 				const ability = this;
 				const vehemoth = this.creature;
-
+				if (isPreview) {
+					G.grid.queryHexes({
+						hexes: this._getHexes(),
+						size: vehemoth.size,
+						flipped: vehemoth.player.flipped,
+						id: vehemoth.id,
+						hideNonTarget: true,
+					});
+					return;
+				}
 				this.game.grid.queryCreature({
 					fnOnConfirm: function () {
 						ability.animation(...arguments);

--- a/src/ability.ts
+++ b/src/ability.ts
@@ -160,11 +160,6 @@ export class Ability {
 	_findEnemyHexInFront: (hexWithEnemy: Hex) => Hex | undefined;
 	_getHopHex: () => Hex | undefined;
 	_getUsesPerTurn: () => 1 | 2;
-
-	resetTimesUsed(): void {
-		this.timesUsedThisTurn = 0;
-	}
-	
 	directions: [1, 1, 1, 1, 1, 1];
 	constructor(creature: Creature, abilityID: AbilitySlot, game: Game) {
 		this.creature = creature;
@@ -283,7 +278,7 @@ export class Ability {
 
 		if (this.used === true) {
 			game.log('Ability already used!');
-			return;
+			/*return;*/
 		}
 
 		game.clearOncePerDamageChain();

--- a/src/ui/fullscreen.ts
+++ b/src/ui/fullscreen.ts
@@ -1,50 +1,40 @@
 export class Fullscreen {
-	public button: HTMLElement;
+	private button: HTMLElement;
 
 	constructor(button: HTMLElement, isFullscreen = false) {
 		this.button = button;
 		if (isFullscreen) {
 			button.classList.add('fullscreenMode');
 		}
-		// Add listener for fullscreen changes to update UI state
-		document.addEventListener('fullscreenchange', () => this.updateButtonState());
-		document.addEventListener('webkitfullscreenchange', () => this.updateButtonState());
-		document.addEventListener('mozfullscreenchange', () => this.updateButtonState());
 	}
 
 	toggle() {
-		if (document.fullscreenElement) {
-			document.exitFullscreen();
-		} else {
-			const gameElement = document.getElementById('AncientBeast');
-			if (gameElement) {
-				gameElement.requestFullscreen();
-			}
-		}
-
-		// Update button state after a short delay
-		setTimeout(() => this.updateButtonState(), 100);
-	}
-
-	updateButtonState() {
-		if (document.fullscreenElement) {
-			this.button.classList.add('fullscreenMode');
-			this.button
-				.querySelectorAll('.fullscreen__title')
-				.forEach((el) => (el.textContent = 'Contract'));
-		} else {
+		if (isAppInNativeFullscreenMode()) {
 			this.button.classList.remove('fullscreenMode');
 			this.button
 				.querySelectorAll('.fullscreen__title')
 				.forEach((el) => (el.textContent = 'FullScreen'));
+			document.exitFullscreen();
+		} else if (!isAppInNativeFullscreenMode() && window.innerHeight === screen.height) {
+			alert('Use F11 to exit fullscreen');
+		} else {
+			this.button.classList.add('fullscreenMode');
+			this.button
+				.querySelectorAll('.fullscreen__title')
+				.forEach((el) => (el.textContent = 'Contract'));
+			document.getElementById('AncientBeast').requestFullscreen();
 		}
 	}
 }
 
+/**
+ * @returns {boolean} true if app is currently in [fullscreen mode using the native API](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API), else false.
+ */
 function isAppInNativeFullscreenMode(): boolean {
-	return !!(
-		document.fullscreenElement ||
-		(document as Document & { webkitFullscreenElement?: Element }).webkitFullscreenElement ||
-		(document as Document & { mozFullScreenElement?: Element }).mozFullScreenElement
+	// NOTE: These properties were vendor-prefixed until very recently.
+	// Keeping vendor prefixes, though they make TS report an error.
+	return (
+		// @ts-expect-error 2551
+		document.fullscreenElement || document.webkitFullscreenElement || document.mozFullScreenElement
 	);
 }

--- a/src/ui/hotkeys.js
+++ b/src/ui/hotkeys.js
@@ -111,13 +111,6 @@ export class Hotkeys {
 			this.ui.selectAbility(-1);
 		}
 
-		// Check if we were in fullscreen mode and update button state accordingly
-		setTimeout(() => {
-			if (this.ui.fullscreen) {
-				this.ui.fullscreen.updateButtonState();
-			}
-		}, 100);
-
 		this.ui.game.signals.ui.dispatch('closeInterfaceScreens');
 	}
 
@@ -272,24 +265,6 @@ export function getHotKeys(hk) {
 		Space: {
 			onkeydown() {
 				hk.pressSpace();
-			},
-		},
-		F11: {
-			onkeydown() {
-				// Update UI state on F11 key press
-				setTimeout(() => {
-					const fullscreenButton =
-						document.querySelector('#fullscreen.button') || document.getElementById('fullscreen');
-					if (fullscreenButton && fullscreenButton.__proto__.constructor.name === 'HTMLElement') {
-						// Get the Fullscreen instance if possible
-						const game = window.G;
-						if (game && game.ui && game.ui.fullscreen) {
-							game.ui.fullscreen.updateButtonState();
-						} else if (window.fullscreen) {
-							window.fullscreen.updateButtonState();
-						}
-					}
-				}, 100);
 			},
 		},
 	};

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -318,9 +318,6 @@ export class UI {
 								// After 2 seconds, revert UI to the currently selected ability
 								setTimeout(() => {
 									// Reselect the current active ability (re-applies highlight range)
-									console.log("HERE")
-									console.log(this.selectedAbility)
-									//this.abilitiesButtons[1].triggerClick();
 									game.activeCreature.queryMove();
 									this.selectAbility(-1);
 								}, 500);


### PR DESCRIPTION
Shows a preview for non-melee abilities that disappears after a delay when clicking an ability when it is unavailable. Changes the way handling abilities work with a new isPreview condition for query. Possible phase out the strict way of disabling abilities after 1 use and simply treats them as lacking suitable targets.

This fixes issue #970

(I do not have a ERC20 wallet)
