### PR TITLE
Fades out and deletes materialize_overlay and secondary_overlay upon skipTurn

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -901,6 +901,18 @@ export default class Game {
 		// NOTE: If skipping a turn and there is a temp creature, destroy it.
 		this.creatures.filter((c) => c.temp).forEach((c) => c.destroy());
 
+		// Removing any potential previews - specifically addressing skipTurn after Scavenger Escort Service
+		if (this.grid.materialize_overlay) {
+			this.grid.fadeOutTempCreature();                // tween alpha → 0
+			this.grid.materialize_overlay.destroy();        // remove from display list
+			this.grid.materialize_overlay = null;           // clear the reference
+		}
+		if (this.grid.secondary_overlay) {
+			this.grid.fadeOutTempCreature(this.grid.secondary_overlay);
+			this.grid.secondary_overlay.destroy();
+			this.grid.secondary_overlay = null;
+		}
+
 		// Send skip turn to server
 
 		if (this.turnThrottle) {


### PR DESCRIPTION
This PR addresses issue #2688, where using Scavenger's Escort Service -> skipTurn left the previewCreature sprites for both Scavenger and the target behind. It can be noted that Scavenger's ghost disappeared when its player generated a new one by hovering over a new move tile during their turn, but the enemy's ghost would not.

Changes: 
Added minimal logic in skipTurn() of Game.ts to fade out and replace both materialize_overlay and secondary_overlay with a null value.

https://github.com/user-attachments/assets/3d1236a5-2604-44e3-87bf-6ded1ce58ad5

Effect:
Both ghosts disappear upon skipTurn. Shouldn't be any adverse effects, as the game simply generates new materialize_overlay/secondary_overlay whenever previewCreature is called and the value is not found.

Tested on Google Chrome

No need for tokens
#2688 