### PR TITLE
add dashed hexagon logic for blocked targets (#1004)

### DIFF
--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -567,7 +567,13 @@ export class Hex {
 		} else if (this.displayClasses.match(/adj/)) {
 			this.display.loadTexture('hex_path');
 		} else if (this.displayClasses.match(/dashed/)) {
-			this.display.loadTexture('hex_dashed');
+			// Check if this is a dashed hex with a creature (blocked target)
+			if (this.creature instanceof Creature) {
+				// Use colored dashed texture for the creature's team
+				this.display.loadTexture(`hex_dashed_p${this.creature.team}`);
+			} else {
+				this.display.loadTexture('hex_dashed');
+			}
 		} else if (this.displayClasses.match(/deadzone/)) {
 			this.display.loadTexture('hex_deadzone');
 		} else {

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -304,9 +304,31 @@ export class HexGrid {
 	 * @param {QueryOptions} o
 	 */
 	queryDirection(o: Partial<QueryOptions>) {
-		o.isDirectionsQuery = true;
+		const defaultOpt = {
+			team: Team.Enemy,
+			id: 0,
+			flipped: false,
+			x: 0,
+			y: 0,
+			directions: [1, 1, 1, 1, 1, 1],
+			includeCreature: true,
+			stopOnCreature: true,
+			distance: 0,
+			minDistance: 0,
+			distanceFalloff: 0,
+			dashedHexesAfterCreatureStop: true,
+			dashedHexesDistance: 0,
+			dashedHexesUnderCreature: true,
+			sourceCreature: undefined,
+			isDirectionsQuery: true,
+		};
+
+		o = { ...defaultOpt, ...o };
+
 		o = this.getDirectionChoices(o);
 		this.queryChoice(o);
+
+		return true;
 	}
 
 	/**
@@ -333,6 +355,7 @@ export class HexGrid {
 			distanceFalloff: 0,
 			dashedHexesAfterCreatureStop: true,
 			dashedHexesDistance: 0,
+			dashedHexesUnderCreature: true,
 			sourceCreature: undefined,
 			choices: [],
 			optTest: () => true,


### PR DESCRIPTION
## Description  
This PR implements **dashed color-coded hexagons** for ranged ability targets that are blocked by obstacles, as described in #1004.  
- Uses assets added in commit `152b69a`.  
- Dashed hexagons now appear when a target is within range but blocked.  

## Changes  
- Added logic to render dashed hexagons for blocked targets.  
- Updated targeting UI to differentiate blocked vs. valid targets.  

## Testing  
1. Select a unit with a ranged ability.  
2. targets:  
   - **Solid hexagon**: Valid target.  
   - **Dashed hexagon**: Blocked by obstacle.  