### PR TITLE
feat: add dashed hexagon logic for blocked targets (#1004)

### DIFF
--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -269,19 +269,19 @@ export class Hex {
 		// NOTE: solely for compatability.
 	}
 
-	onSelectFn(arg0: this) {
+	onSelectFn(_: this) {
 		// No-op function.
 	}
 
-	onHoverOffFn(arg0: this) {
+	onHoverOffFn(_: this) {
 		// No-op function.
 	}
 
-	onConfirmFn(arg0: this) {
+	onConfirmFn(_: this) {
 		// No-op function.
 	}
 
-	onRightClickFn(arg0: this) {
+	onRightClickFn(_: this) {
 		// No-op function.
 	}
 
@@ -567,7 +567,13 @@ export class Hex {
 		} else if (this.displayClasses.match(/adj/)) {
 			this.display.loadTexture('hex_path');
 		} else if (this.displayClasses.match(/dashed/)) {
-			this.display.loadTexture('hex_dashed');
+			// Check if this is a dashed hex with a creature (blocked target)
+			if (this.creature instanceof Creature) {
+				// Use colored dashed texture for the creature's team
+				this.display.loadTexture(`hex_dashed_p${this.creature.team}`);
+			} else {
+				this.display.loadTexture('hex_dashed');
+			}
 		} else if (this.displayClasses.match(/deadzone/)) {
 			this.display.loadTexture('hex_deadzone');
 		} else {

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -10,7 +10,6 @@ import { DEBUG } from '../debug';
 import { HEX_WIDTH_PX } from './const';
 import { Point } from './pointfacade';
 import { AugmentedMatrix } from './matrices';
-import { Ability } from '../ability';
 
 interface GridDefinition {
 	numRows: number;
@@ -305,8 +304,31 @@ export class HexGrid {
 	 */
 	queryDirection(o: Partial<QueryOptions>) {
 		o.isDirectionsQuery = true;
+		const defaultOpt = {
+			team: Team.Enemy,
+			id: 0,
+			flipped: false,
+			x: 0,
+			y: 0,
+			directions: [1, 1, 1, 1, 1, 1],
+			includeCreature: true,
+			stopOnCreature: true,
+			distance: 0,
+			minDistance: 0,
+			distanceFalloff: 0,
+			dashedHexesAfterCreatureStop: true,
+			dashedHexesDistance: 0,
+			dashedHexesUnderCreature: true,
+			sourceCreature: undefined,
+			isDirectionsQuery: true,
+		};
+
+		o = { ...defaultOpt, ...o };
+
 		o = this.getDirectionChoices(o);
 		this.queryChoice(o);
+
+		return true;
 	}
 
 	/**
@@ -333,6 +355,7 @@ export class HexGrid {
 			distanceFalloff: 0,
 			dashedHexesAfterCreatureStop: true,
 			dashedHexesDistance: 0,
+			dashedHexesUnderCreature: true,
 			sourceCreature: undefined,
 			choices: [],
 			optTest: () => true,
@@ -1664,8 +1687,8 @@ export class HexGrid {
 			(!player.flipped
 				? creatureData.display['offset-x']
 				: HEX_WIDTH_PX * creatureData.size -
-				  preview.texture.width -
-				  creatureData.display['offset-x']) +
+				preview.texture.width -
+				creatureData.display['offset-x']) +
 			preview.texture.width / 2;
 		preview.y = hex.displayPos.y + creatureData.display['offset-y'] + preview.texture.height;
 		preview.alpha = 0.5;


### PR DESCRIPTION
## Description  
This PR implements **dashed color-coded hexagons** for ranged ability targets that are blocked by obstacles, as described in #1004.  
- Uses assets added in commit `152b69a`.  
- Dashed hexagons now appear when a target is within range but blocked.  

## Changes  
- Added logic to render dashed hexagons for blocked targets.  
- Updated targeting UI to differentiate blocked vs. valid targets.  

## Testing  
1. Select a unit with a ranged ability.  
2.targets:  
   - **Solid hexagon**: Valid target.  
   - **Dashed hexagon**: Blocked by obstacle.  