### PR TITLE
fix issue #2690 on chromium browsers / Linux

### DIFF
--- a/src/script.ts
+++ b/src/script.ts
@@ -118,6 +118,15 @@ $j(() => {
 				fullscreen.toggle();
 			},
 		},
+		F11: {
+			keyDownTest() {
+				return true;
+			},
+			keyDownAction(event) {
+				event.preventDefault();
+				fullscreen.toggle();
+			},
+		},
 		KeyL: {
 			keyDownTest(event) {
 				return event.metaKey && event.ctrlKey;

--- a/src/ui/fullscreen.ts
+++ b/src/ui/fullscreen.ts
@@ -12,18 +12,21 @@ export class Fullscreen {
 		document.addEventListener('mozfullscreenchange', () => this.updateButtonState());
 	}
 
-	toggle() {
-		if (document.fullscreenElement) {
-			document.exitFullscreen();
-		} else {
-			const gameElement = document.getElementById('AncientBeast');
-			if (gameElement) {
-				gameElement.requestFullscreen();
+	async toggle() {
+		try {
+			if (document.fullscreenElement) {
+				await document.exitFullscreen();
+			} else {
+				const gameElement = document.getElementById('AncientBeast');
+				if (gameElement) {
+					await gameElement.requestFullscreen();
+				}
 			}
-		}
 
-		// Update button state after a short delay
-		setTimeout(() => this.updateButtonState(), 100);
+			setTimeout(() => this.updateButtonState(), 100);
+		} catch (error) {
+			console.error('Error toggling fullscreen:', error);
+		}
 	}
 
 	updateButtonState() {

--- a/src/ui/hotkeys.js
+++ b/src/ui/hotkeys.js
@@ -1,4 +1,5 @@
 import { event } from 'jquery';
+import { Fullscreen } from '../ui/fullscreen';
 
 export class Hotkeys {
 	constructor(ui) {
@@ -144,6 +145,13 @@ export class Hotkeys {
 	pressSpace() {
 		!this.ui.dashopen && this.ui.game.grid.confirmHex();
 	}
+
+	pressF11(event) {
+		event.preventDefault();
+		const fullscreen = new Fullscreen(document.getElementById('fullscreen'));
+
+		fullscreen.toggle();
+	}
 }
 export function getHotKeys(hk) {
 	const hotkeys = {
@@ -275,21 +283,8 @@ export function getHotKeys(hk) {
 			},
 		},
 		F11: {
-			onkeydown() {
-				// Update UI state on F11 key press
-				setTimeout(() => {
-					const fullscreenButton =
-						document.querySelector('#fullscreen.button') || document.getElementById('fullscreen');
-					if (fullscreenButton && fullscreenButton.__proto__.constructor.name === 'HTMLElement') {
-						// Get the Fullscreen instance if possible
-						const game = window.G;
-						if (game && game.ui && game.ui.fullscreen) {
-							game.ui.fullscreen.updateButtonState();
-						} else if (window.fullscreen) {
-							window.fullscreen.updateButtonState();
-						}
-					}
-				}, 100);
+			onkeydown(event) {
+				hk.pressF11(event);
 			},
 		},
 	};


### PR DESCRIPTION
# Fix Fullscreen Handling Issues (#2690)  

## 🛠 Summary  
Resolves fullscreen interaction issues on chromium browsers:  
- ✅ Fixes Chromium browser fullscreen behavior (tested on **Arch Linux/Chrome 135.0.7049.114**)  


## 🧑‍💻 Technical Approach  
### 1. **Chromium Fixes**  

   - Added `async/await` with proper error boundaries:  
     ```ts
     try {
       await element.requestFullscreen();
     } catch (err) {
       console.error("Fullscreen failed:", err);
     }
     ```  
### 2. **Fullscreen Class Integration**
Refactored the hotkeys implementation to properly use the `Fullscreen` class methods, removing legacy code:

```typescript
// Updated F11 key handler
pressF11(event: KeyboardEvent) {
    event.preventDefault();
    const fullscreen = new Fullscreen(document.getElementById('fullscreen'));
    fullscreen.toggle();
}
```


## 🧪 Testing  
| Browser/OS          | Test Case                     | Result |  
|----------------------|-------------------------------|--------|  
| Chrome 135 (Arch)    | Keyboard toggle (F11)     | ✅     |  
| Firefox 137.0.2 (Arch)   | Keyboard toggle (F11)  + click on body     | ✅     |  


**Errors Not Fixed:**  
```log
Firefox: "Request for fullscreen was denied..."  
Phaser: "ScaleManager: requestFullscreen failed..."