### PR TITLE
1716-disable-fullscreen-button-when-not-usable

### DIFF
--- a/src/ui/fullscreen.ts
+++ b/src/ui/fullscreen.ts
@@ -6,6 +6,11 @@ export class Fullscreen {
 		if (isFullscreen) {
 			button.classList.add('fullscreenMode');
 		}
+		if (window.innerHeight === screen.height) {
+			this.button.style.pointerEvents = 'none';
+			this.button.style.opacity = '0.3';
+			return;
+		}
 	}
 
 	toggle() {
@@ -15,15 +20,13 @@ export class Fullscreen {
 				.querySelectorAll('.fullscreen__title')
 				.forEach((el) => (el.textContent = 'FullScreen'));
 			document.exitFullscreen();
-		} else if (!isAppInNativeFullscreenMode() && window.innerHeight === screen.height) {
-			alert('Use F11 to exit fullscreen');
-		} else {
-			this.button.classList.add('fullscreenMode');
-			this.button
-				.querySelectorAll('.fullscreen__title')
-				.forEach((el) => (el.textContent = 'Contract'));
-			document.getElementById('AncientBeast').requestFullscreen();
+			return;
 		}
+		this.button.classList.add('fullscreenMode');
+		this.button
+			.querySelectorAll('.fullscreen__title')
+			.forEach((el) => (el.textContent = 'Contract'));
+		document.getElementById('AncientBeast').requestFullscreen();
 	}
 }
 
@@ -31,10 +34,13 @@ export class Fullscreen {
  * @returns {boolean} true if app is currently in [fullscreen mode using the native API](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API), else false.
  */
 function isAppInNativeFullscreenMode(): boolean {
-	// NOTE: These properties were vendor-prefixed until very recently.
-	// Keeping vendor prefixes, though they make TS report an error.
-	return (
+	return !!(
+		document.fullscreenElement ||
 		// @ts-expect-error 2551
-		document.fullscreenElement || document.webkitFullscreenElement || document.mozFullScreenElement
+		document.webkitFullscreenElement ||
+		// @ts-expect-error 2551
+		document.mozFullScreenElement ||
+		// @ts-expect-error 2551
+		document.msFullscreenElement
 	);
 }


### PR DESCRIPTION
This fixes [issue](https://github.com/FreezingMoon/AncientBeast/issues/1716) by refactoring the fullscreen.ts code

**RESULT**
On emulated mobile devices
<img width="495" alt="Screenshot 2025-05-02 at 1 50 23 PM" src="https://github.com/user-attachments/assets/3b2f0e56-d672-485f-bc18-395e6fe49f55" />

On desktop with similar resolution
<img width="797" alt="Screenshot 2025-05-02 at 1 43 27 PM" src="https://github.com/user-attachments/assets/ba926d74-db64-4354-a453-8c424bd47ccf" />

Basically, i added an if statement to the constructor to fade and disable pointer events in case the page is already occupying the full inner height of the screen.

I also removed the alert that did very little for the user.

This is not a super bulletproof solution, just a potential easy fix for a pretty annoying problem, and a bit of code cleanup, as i consider that avoiding else statements as much as possible is a good practice. Hope it helps :)