### PR TITLE
add colour to hexagons and display dashed hexagons

### DIFF
--- a/src/abilities/Scavenger.js
+++ b/src/abilities/Scavenger.js
@@ -212,7 +212,7 @@ export default (G) => {
 				const select = (hex) => {
 					for (let i = 0; i < trg.hexagons.length; i++) {
 						G.grid.cleanHex(trg.hexagons[i]);
-						trg.hexagons[i].displayVisualState('dashed');
+						trg.hexagons[i].displayVisualState('dashed player' + trg.team);
 					}
 					for (let i = 0; i < crea.hexagons.length; i++) {
 						G.grid.cleanHex(crea.hexagons[i]);
@@ -265,7 +265,7 @@ export default (G) => {
 						console.log('cleaning');
 						for (let i = 0; i < trg.hexagons.length; i++) {
 							G.grid.cleanHex(trg.hexagons[i]);
-							trg.hexagons[i].displayVisualState('dashed');
+							trg.hexagons[i].displayVisualState('dashed player' + trg.team);
 						}
 					},
 					fillHexOnHover: false,

--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -565,13 +565,14 @@ export class Hex {
 			this.display.loadTexture(`hex_p${player}`);
 			this.grid.displayHexesGroup.bringToTop(this.display);
 		} else if (this.displayClasses.match(/adj/)) {
-			this.display.loadTexture('hex_path');		} else if (this.displayClasses.match(/dashed/)) {
-			// Check if this is a dashed hex with a creature (blocked target)
+			this.display.loadTexture('hex_path');		} else if (this.displayClasses.match(/dashed/)) {			// Check if this is a dashed hex with a creature (blocked target)
 			if (this.creature instanceof Creature) {
 				// Use colored dashed texture for the creature's team
 				this.display.loadTexture(`hex_dashed_p${this.creature.team}`);
 				// Ensure dashed hexagons are visible
 				this.display.alpha = 1;
+				// Bring dashed hexes with creatures to the top of the display group for better visibility
+				this.grid.displayHexesGroup.bringToTop(this.display);
 			} else {
 				this.display.loadTexture('hex_dashed');
 			}

--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -565,12 +565,13 @@ export class Hex {
 			this.display.loadTexture(`hex_p${player}`);
 			this.grid.displayHexesGroup.bringToTop(this.display);
 		} else if (this.displayClasses.match(/adj/)) {
-			this.display.loadTexture('hex_path');
-		} else if (this.displayClasses.match(/dashed/)) {
+			this.display.loadTexture('hex_path');		} else if (this.displayClasses.match(/dashed/)) {
 			// Check if this is a dashed hex with a creature (blocked target)
 			if (this.creature instanceof Creature) {
 				// Use colored dashed texture for the creature's team
 				this.display.loadTexture(`hex_dashed_p${this.creature.team}`);
+				// Ensure dashed hexagons are visible
+				this.display.alpha = 1;
 			} else {
 				this.display.loadTexture('hex_dashed');
 			}

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -948,15 +948,15 @@ export class HexGrid {
 		};
 		// Set reachable the given hexes
 		o.hexes.forEach((hex) => {
-			hex.setReachable();
+			hex.setReachable();	
 			if (o.hideNonTarget) {
 				hex.unsetNotTarget();
 			}
 			if (o.targeting) {
 				if (hex.creature instanceof Creature) {					if (hex.creature.id != this.game.activeCreature.id) {
 						hex.overlayVisualState('reachable h_player' + hex.creature.team);
-						// Add dashed hexagons under targets for ranged abilities
-						hex.displayVisualState('dashed');
+						// Add dashed hexagons under targets for ranged abilities with team color
+						hex.displayVisualState('dashed player' + hex.creature.team);
 						// Ensure dashed hexagons are on top for better visibility
 						hex.grid.displayHexesGroup.bringToTop(hex.display);
 					}
@@ -986,9 +986,9 @@ export class HexGrid {
 			}			creature.hexagons.forEach((h) => {
 				// Flashing outline
 				h.overlayVisualState('hover h_player' + creature.team);
-				// Keep the dashed hexagons visible under targets
+				// Keep the dashed hexagons visible under targets with team color
 				if (h.displayClasses.indexOf('dashed') === -1) {
-					h.displayVisualState('dashed');
+					h.displayVisualState('dashed player' + creature.team);
 				}
 				// Make sure the display hexagon is brought to the top for better visibility
 				h.grid.displayHexesGroup.bringToTop(h.display);

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -953,11 +953,12 @@ export class HexGrid {
 				hex.unsetNotTarget();
 			}
 			if (o.targeting) {
-				if (hex.creature instanceof Creature) {
-					if (hex.creature.id != this.game.activeCreature.id) {
+				if (hex.creature instanceof Creature) {					if (hex.creature.id != this.game.activeCreature.id) {
 						hex.overlayVisualState('reachable h_player' + hex.creature.team);
 						// Add dashed hexagons under targets for ranged abilities
 						hex.displayVisualState('dashed');
+						// Ensure dashed hexagons are on top for better visibility
+						hex.grid.displayHexesGroup.bringToTop(hex.display);
 					}
 				} else {
 					if (o.fillOnlyHoveredCreature && !emptyHexBeforeCreature(hex)) {
@@ -989,6 +990,8 @@ export class HexGrid {
 				if (h.displayClasses.indexOf('dashed') === -1) {
 					h.displayVisualState('dashed');
 				}
+				// Make sure the display hexagon is brought to the top for better visibility
+				h.grid.displayHexesGroup.bringToTop(h.display);
 			});
 			if (creature !== game.activeCreature) {
 				if (!hex.reachable) {

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -946,7 +946,6 @@ export class HexGrid {
 				return true;
 			}
 		};
-
 		// Set reachable the given hexes
 		o.hexes.forEach((hex) => {
 			hex.setReachable();
@@ -957,6 +956,8 @@ export class HexGrid {
 				if (hex.creature instanceof Creature) {
 					if (hex.creature.id != this.game.activeCreature.id) {
 						hex.overlayVisualState('reachable h_player' + hex.creature.team);
+						// Add dashed hexagons under targets for ranged abilities
+						hex.displayVisualState('dashed');
 					}
 				} else {
 					if (o.fillOnlyHoveredCreature && !emptyHexBeforeCreature(hex)) {
@@ -981,10 +982,13 @@ export class HexGrid {
 				} else {
 					creature.displayHealthStats();
 				}
-			}
-			creature.hexagons.forEach((h) => {
+			}			creature.hexagons.forEach((h) => {
 				// Flashing outline
 				h.overlayVisualState('hover h_player' + creature.team);
+				// Keep the dashed hexagons visible under targets
+				if (h.displayClasses.indexOf('dashed') === -1) {
+					h.displayVisualState('dashed');
+				}
 			});
 			if (creature !== game.activeCreature) {
 				if (!hex.reachable) {


### PR DESCRIPTION
1. Fixed the [updateStyle](vscode-file://vscode-app/c:/Users/Arpit/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) method in [hex.ts](vscode-file://vscode-app/c:/Users/Arpit/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)
I modified the [updateStyle](vscode-file://vscode-app/c:/Users/Arpit/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) method in the [Hex](vscode-file://vscode-app/c:/Users/Arpit/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) class to ensure that dashed hexagons with creatures on them (potential targets) are displayed with the correct colored texture based on the creature's team, and are always visible by setting their alpha to 1.



2. Modified the queryHexes method in hexgrid.ts
I added code to display dashed hexagons under creatures that are potential targets for ranged abilities. This ensures that when targeting with a ranged ability, the potential targets will be visually indicated with dashed hexagons.

3. Updated the onCreatureHover function in hexgrid.ts
I made changes to ensure that dashed hexagons remain visible when hovering over a potential target, preserving the visual indicator even during mouse hover interactions.

![Screenshot 2025-05-13 230546](https://github.com/user-attachments/assets/92c3ca27-9d2a-4c21-ba10-c5cf12e079dc)


![Screenshot 2025-05-13 234215](https://github.com/user-attachments/assets/345b6d98-d28f-4bef-85cd-94029d49dd7a)
These changes collectively ensure that when a player is targeting with a ranged ability, potential targets are clearly indicated with colored dashed hexagons on top of the black hexagon path, whether they're hovered or not, which solves the issue described in bug report #2713.