### PR TITLE
fixed flickering of priest 2 (player 2) when escorting with scavenger

### DIFF
--- a/src/abilities/Scavenger.js
+++ b/src/abilities/Scavenger.js
@@ -211,25 +211,36 @@ export default (G) => {
 
 				const select = (hex) => {
 					for (let i = 0; i < trg.hexagons.length; i++) {
-						G.grid.cleanHex(trg.hexagons[i]);
-						trg.hexagons[i].displayVisualState('dashed');
+						const hexTrg = trg.hexagons[i];
+						G.grid.cleanHex(hexTrg);
+						hexTrg.cleanDisplayVisualState();
+						hexTrg.cleanOverlayVisualState();
+						hexTrg.displayVisualState('creature hover player' + trg.player.id); // ✅ fixed
 					}
+
 					for (let i = 0; i < crea.hexagons.length; i++) {
-						G.grid.cleanHex(crea.hexagons[i]);
-						crea.hexagons[i].overlayVisualState('hover h_player' + crea.team);
+						const hexCrea = crea.hexagons[i];
+						G.grid.cleanHex(hexCrea);
+						hexCrea.cleanDisplayVisualState();
+						hexCrea.cleanOverlayVisualState();
+						hexCrea.overlayVisualState('hover h_player' + crea.team);
 					}
+
 					for (let i = 0; i < size; i++) {
-						if (!G.grid.hexExists({ y: hex.y, x: hex.x - i })) {
-							continue;
-						}
+						if (!G.grid.hexExists({ y: hex.y, x: hex.x - i })) continue;
+
 						const h = G.grid.hexes[hex.y][hex.x - i];
+
 						let color;
 						if (trgIsInfront) {
 							color = i < trg.size ? trg.team : crea.team;
 						} else {
 							color = i > 1 ? trg.team : crea.team;
 						}
+
 						G.grid.cleanHex(h);
+						h.cleanDisplayVisualState(); // ✅ critical to stop flickering
+						h.cleanOverlayVisualState(); // ✅ critical to stop grey flash
 						h.overlayVisualState('active creature player' + color);
 						h.displayVisualState('creature player' + color);
 
@@ -241,7 +252,12 @@ export default (G) => {
 							: { x: hex.pos.x - 2, y: hex.pos.y };
 
 						G.grid.previewCreature(creaPos, creatureData, crea.player);
-						G.grid.previewCreature(trgPos, targetData, trg.player, true);
+
+						// ⚠️ Disabled due to visual conflict:
+						// previewCreature causes the target (trg) to flicker between grey and blue
+						// by overriding displayVisualState every frame.
+						// This breaks hover clarity during cross-team Escort previews.
+						// G.grid.previewCreature(trgPos, targetData, trg.player, true);
 					}
 				};
 


### PR DESCRIPTION
this fixes issue : #2698 
### **issue:**
When using the Scavenger’s Escort ability on both Player 1’s (Red) and Player 2’s (Blue) Priests, player 1(red) was escorted successfully but when we try to escort the second player (priest blue) via the same scavenger it filickers between grey and blue which is not the correct behavior it should stay blue.
here is before : 
![436785323-93f121a7-ee0f-47cd-ab00-7c1ff56a93c6](https://github.com/user-attachments/assets/c77766cd-3578-49a9-b5d2-63503dd969e5)

and here is after : 

https://github.com/user-attachments/assets/285a6d7c-4425-4d37-8afd-7cb275146666

### **Root Cause:**
The flickering was caused by G.grid.previewCreature(trgPos, targetData, trg.player, true) being called after applying the manual displayVisualState() and overlayVisualState(). The previewCreature method was continuously overriding the target’s hex visuals with a default semi-transparent or neutral (grey) model.

### **Fix:**
We commented out the call to:

`G.grid.previewCreature(trgPos, targetData, trg.player, true);`

in the `select() `function of the Scavenger’s Escort logic. This prevents the preview function from interfering with the manually applied team-colored visual states (playerX), effectively eliminating the flicker.