### PR TITLE
 colored glowing hexagons are always displayed on top of the black ones

### DIFF
--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -565,7 +565,9 @@ export class Hex {
 			this.display.loadTexture(`hex_p${player}`);
 			this.grid.displayHexesGroup.bringToTop(this.display);
 		} else if (this.displayClasses.match(/adj/)) {
-			this.display.loadTexture('hex_path');		} else if (this.displayClasses.match(/dashed/)) {			// Check if this is a dashed hex with a creature (blocked target)
+			this.display.loadTexture('hex_path');
+		} else if (this.displayClasses.match(/dashed/)) {
+			// Check if this is a dashed hex with a creature (blocked target)
 			if (this.creature instanceof Creature) {
 				// Use colored dashed texture for the creature's team
 				this.display.loadTexture(`hex_dashed_p${this.creature.team}`);
@@ -644,7 +646,13 @@ export class Hex {
 				this.overlay.loadTexture(`hex_p${player}`);
 			}
 
-			this.grid.overlayHexesGroup.bringToTop(this.overlay);
+			// Always bring the overlay to the top when it's active
+			if (targetAlpha) {
+				// Ensure the display hex is below the overlay
+				this.grid.displayHexesGroup.bringToTop(this.display);
+				// Then bring the overlay to the top of its group
+				this.grid.overlayHexesGroup.bringToTop(this.overlay);
+			}
 		} else {
 			this.overlay.loadTexture('cancel');
 			this.overlay.anchor.set(0.5, 0.5);


### PR DESCRIPTION
This fixes issue #2734 
The key changes I made:
1) Fixed the code formatting issue in the display hex conditional statements that was causing some code to appear on the same line.
2) Modified the overlay rendering logic to ensure proper z-index ordering:

    -   Added a condition to check if the overlay is active (when targetAlpha is true)
   - When active, we now first bring the display hex to the top of its group
   - Then bring the overlay hex to the top of its group
   - This ensures the colored glowing hexagons are always displayed on top of the black ones