### PR TITLE
added random location button and changed maps rendering

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -153,10 +153,7 @@
 								<div class="gameOption">
 									<h2>Combat Location [ no influence to the actual gameplay ]</h2>
 									<div id="combatLocation" class="typeRadio">
-										<input type="radio" id="bgOpt1" name="combatLocation" value="Dark Forest"><label for="bgOpt1" class="dragIt">Dark Forest</label>
-										<input type="radio" id="bgOpt2" name="combatLocation" value="Frozen Wall"><label for="bgOpt2" class="dragIt">Frozen Wall</label>
-										<input type="radio" id="bgOpt3" name="combatLocation" value="Shadow Cave"><label for="bgOpt3" class="dragIt">Shadow Cave</label>
-										<input type="radio" id="bgOpt4" name="combatLocation" value="Dragon Bones"><label for="bgOpt4" class="dragIt">Dragon Bones</label>
+										<button id="randomLocation" type="button" class="dice-button" title="Random Location">🎲</button>
 									</div>
 								</div>
 							</div>

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -153,7 +153,7 @@
 								<div class="gameOption">
 									<h2>Combat Location [ no influence to the actual gameplay ]</h2>
 									<div id="combatLocation" class="typeRadio">
-										<button id="randomLocation" type="button" class="dice-button" title="Random Location">🎲</button>
+										<button id="randomLocation" type="button" class="dice-button" title="Random Location">⚁</button>
 									</div>
 								</div>
 							</div>

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -153,7 +153,7 @@
 								<div class="gameOption">
 									<h2>Combat Location [ no influence to the actual gameplay ]</h2>
 									<div id="combatLocation" class="typeRadio">
-										<button id="randomLocation" type="button" class="dice-button" title="Random Location">⚁</button>
+										<button id="randomLocation" type="button" class="dice-button" title="Random Location">⚄</button>
 									</div>
 								</div>
 							</div>

--- a/src/script.ts
+++ b/src/script.ts
@@ -6,6 +6,7 @@ import Game from './game';
 import { PreMatchAudioPlayer } from './sound/pre-match-audio';
 import { Fullscreen } from './ui/fullscreen';
 import { buttonSlide } from './ui/button';
+import { Maps } from './ui/maps';
 
 import Connect from './multiplayer/connect';
 import Authenticate from './multiplayer/authenticate';
@@ -57,10 +58,16 @@ $j(() => {
 	scrim.removeClass('loading');
 	renderPlayerModeType(G.multiplayer);
 
-	// Select a random combat location
-	const locationSelector = $j("input[name='combatLocation']");
-	const randomLocationIndex = Math.floor(Math.random() * locationSelector.length);
-	locationSelector.eq(randomLocationIndex).prop('checked', true).trigger('click');
+	// For the location rendering. The logic is in src/ui/maps.ts
+	const maps: Maps = new Maps();
+	maps.renderMaps();
+	
+	// Random location logic
+	$j('#randomLocation').on('click', () => {
+		const radios = $j("input[name='combatLocation']");
+		const index = Math.floor(Math.random() * radios.length);
+		radios.eq(index).prop('checked', true);
+	});
 
 	// Disable initial game setup until browser tab has focus
 	window.addEventListener('blur', G.onBlur.bind(G), false);

--- a/src/style/pre-match.less
+++ b/src/style/pre-match.less
@@ -284,19 +284,16 @@ body {
 	}
 
 	.dice-button {
+	color: white;
   background: none;
-  border: 1px solid #7a7a7a;
+  border: none;
   border-radius: 4px;
-  font-size: 1.5em;
+  font-size: 1.1em;
   cursor: pointer;
-  padding: 0.2em 0.4em;
-  margin-right: 10px;
-  transition: transform 0.2s ease, background 0.2s ease;
 	}
 
 	.dice-button:hover {
 		background: #a32d00;
-		transform: scale(1.1);
 	}
 
 	.typeRadio {

--- a/src/style/pre-match.less
+++ b/src/style/pre-match.less
@@ -283,6 +283,23 @@ body {
 		font-size: 1em;
 	}
 
+	// I've placed it next to type radio because the maps are type radio lol
+	.dice-button {
+  background: none;
+  border: 1px solid #7a7a7a;
+  border-radius: 4px;
+  font-size: 1.5em;
+  cursor: pointer;
+  padding: 0.2em 0.4em;
+  margin-right: 10px;
+  transition: transform 0.2s ease, background 0.2s ease;
+	}
+
+	.dice-button:hover {
+		background: #a32d00;
+		transform: scale(1.1);
+	}
+
 	.typeRadio {
 		white-space: nowrap;
 		display: flex;

--- a/src/style/pre-match.less
+++ b/src/style/pre-match.less
@@ -290,7 +290,7 @@ body {
   border-radius: 4px;
   cursor: pointer;
 	font-size: 1.1em;
-	padding-right: 8px;
+	margin-right: 8px;
 	}
 
 	.dice-button:hover {

--- a/src/style/pre-match.less
+++ b/src/style/pre-match.less
@@ -288,8 +288,9 @@ body {
   background: none;
   border: none;
   border-radius: 4px;
-  font-size: 1.1em;
   cursor: pointer;
+	font-size: 1.1em;
+	padding-right: 8px;
 	}
 
 	.dice-button:hover {

--- a/src/style/pre-match.less
+++ b/src/style/pre-match.less
@@ -283,7 +283,6 @@ body {
 		font-size: 1em;
 	}
 
-	// I've placed it next to type radio because the maps are type radio lol
 	.dice-button {
   background: none;
   border: 1px solid #7a7a7a;

--- a/src/ui/maps.ts
+++ b/src/ui/maps.ts
@@ -9,7 +9,7 @@ export class Maps {
     "Dragon Bones",
   ];
 
-  // gets all the maps and puts them in the UI (src/index.ejs)
+  // Gets all the maps and puts them in the UI (src/index.ejs)
   renderMaps() {
   	for (let index = 0; index < this.maps.length; index += 1) {
   		$j('#combatLocation').append(
@@ -21,7 +21,7 @@ export class Maps {
   		);
   	}
 
-    // the background opt 1 will always be default so the
+    // The background opt 1 will always be default so the
     // game won't crash when the player doesn't choose a map
     const radios = $j("input[name='combatLocation']");
 		radios.eq(0).prop('checked', true).trigger('click');

--- a/src/ui/maps.ts
+++ b/src/ui/maps.ts
@@ -1,0 +1,29 @@
+import * as $j from "jquery"
+
+export class Maps {
+  // All locations of the game (including future locations) here
+  protected readonly maps: string[] = [
+    "Dark Forest",
+    "Frozen Wall",
+    "Shadow Cave",
+    "Dragon Bones",
+  ];
+
+  // gets all the maps and puts them in the UI (src/index.ejs)
+  renderMaps() {
+  	for (let index = 0; index < this.maps.length; index += 1) {
+  		$j('#combatLocation').append(
+  			`<input type="radio" id="bgOpt${index + 1}" `  +
+  			'name="combatLocation" ' +
+  			`value="${this.maps[index]}">` +
+  			`<label for="bgOpt${index + 1}" class="dragIt">` +
+  			`${this.maps[index]}</label>`
+  		);
+  	}
+
+    // the background opt 1 will always be default so the
+    // game won't crash when the player doesn't choose a map
+    const radios = $j("input[name='combatLocation']");
+		radios.eq(0).prop('checked', true).trigger('click');
+  }
+}


### PR DESCRIPTION
Random Button for Locations
===
This PR introduces a new random map selection button (🎲) to the pre-match UI. The goal is to improve the user experience by allowing players to quickly select a combat location at random.

### Key Changes

- Added a new dice button (🎲) next to the list of combat locations.
- The button selects one of the available maps randomly and marks it as selected.
- Refactored map options into a Maps class (src/ui/maps.ts), centralizing map data and UI rendering.
- Removed hardcoded map inputs from the HTML and now render them dynamically via the class.

### Testing

- Verified that maps render correctly in the UI from the Maps class.
- Confirmed that clicking the 🎲 button selects a random map without starting the game.

Issue and wallet address
===

This fixes issue #2732.

My wallet address is 0xaa4F71244BB142D400dA3a7909a3728301FFEd68
