### PR TITLE
Fix #2736: vine trap destruction

### DIFF
--- a/src/abilities/Impaler.js
+++ b/src/abilities/Impaler.js
@@ -218,7 +218,7 @@ export default (G) => {
 							// from appearing on screen.
 							getPointFacade()
 								.getTrapsAt(target)
-								.forEach((trap) => trap.destroy);
+								.forEach((trap) => trap.destroy());
 						}),
 					},
 					G,


### PR DESCRIPTION
This fixes issue #2736 which was missing a function call on line 221 of the file AncientBeast/src/abilities/Impaler.js.

I do not have a wallet address, but I am happy to contribute regardless!
