### PR TITLE
fix: Dark Priest loss of color coding [bounty: 26 XTR] #2698

### DIFF
--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -139,6 +139,7 @@ export class HexGrid {
 	secondary_overlay: any;
 	lastQueryOpt: any;
 	_flickerTween: any;
+	_flickerTweenSecondary: any;
 
 	get allhexes(): Hex[] {
 		return this.hexes.flat(1);
@@ -900,6 +901,9 @@ export class HexGrid {
 		if (this._flickerTween) {
 			this._flickerTween.stop(true);
 		}
+		if (this._flickerTweenSecondary) {
+			this._flickerTweenSecondary.stop(true);
+		}
 
 		if (!o.ownCreatureHexShade) {
 			if (o.id instanceof Array) {
@@ -948,7 +952,7 @@ export class HexGrid {
 		};
 		// Set reachable the given hexes
 		o.hexes.forEach((hex) => {
-			hex.setReachable();	
+			hex.setReachable();
 			if (o.hideNonTarget) {
 				hex.unsetNotTarget();
 			}
@@ -1653,7 +1657,7 @@ export class HexGrid {
 		const hex = this.hexes[pos.y][pos.x - (creatureData.size - 1)];
 		const cardboard =
 			creatureData.type == '--'
-				? creatureData.name + game.activePlayer.color + '_cardboard'
+				? creatureData.name + player.color + '_cardboard'
 				: creatureData.name + '_cardboard';
 
 		if (!secondary) {
@@ -1706,7 +1710,7 @@ export class HexGrid {
 			preview.scale.setTo(1, 1);
 		}
 
-		this._flickerTween = game.Phaser.add
+		let flickering = game.Phaser.add
 			.tween(preview)
 			.to(
 				{
@@ -1718,6 +1722,18 @@ export class HexGrid {
 			.yoyo(true)
 			.repeat(-1)
 			.start();
+		if (!secondary) {
+			if(this._flickerTween){//These stop animations that are about to be orphaned. For some reason. See issue #2698
+				this._flickerTween.stop(true)
+			}
+			this._flickerTween=flickering
+		}
+		else{
+			if(this._flickerTweenSecondary){
+				this._flickerTweenSecondary.stop(true)
+			}
+			this._flickerTweenSecondary=flickering
+		}
 
 		for (let i = 0, size = creatureData.size; i < size; i++) {
 			const hexInstance = this.hexes[pos.y][pos.x - i];

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -1723,13 +1723,14 @@ export class HexGrid {
 			.repeat(-1)
 			.start();
 		if (!secondary) {
-			if(this._flickerTween){//These stop animations that are about to be orphaned. For some reason. See issue #2698
+			if(this._flickerTween) {
+				// Stop animations that are about to be orphaned #2698
 				this._flickerTween.stop(true)
 			}
 			this._flickerTween=flickering
 		}
-		else{
-			if(this._flickerTweenSecondary){
+		else {
+			if(this._flickerTweenSecondary) {
 				this._flickerTweenSecondary.stop(true)
 			}
 			this._flickerTweenSecondary=flickering


### PR DESCRIPTION
Changes:

Fixed the bug where when using the scavenger's escort ability (or any ability that moved two creatures), the semi-transparent preview of where the creature would go would become permanently bugged and wouldn't disappear.

Also fixed the bug causing the preview for dark priests to show up as the wrong color when being escorted by the opponent's scavenger.

Testing:
(Hand tested, not sure how to write the scripts)
>Confirmed that when selecting a hex to move to during movement phase, the preview shows up as expected, and flashes as expected
>When selecting a hex in the movement phase, confirming or moving the mouse off a valid hex makes the preview disappear.
>The preview for summoning new creatures also behaves the exact same as for movement
>Dark priest color in the preview is correct in movement phase
>Abilities featuring only one creatures preview do not glitch the preview, or have any graphical glitches of its own. (Tested using uncle fungus's frog jump ability)
>Scavenger's preview in the escort ability flickers, moves, and disappears as normal.
>Dark priest's of the same color as the scavenger also have correctly behaving previews during escort.
>Escort does not glitch the movement preview
>Escort does not create a permanent preview of the targeted creature
>Dark priests of different colors from the scavenger have their preview colors displayed correctly during escort.

This fixes issue #2698 
