### PR TITLE
Fix: limit movement preview to active unit [bounty: 8 XTR] #2627

### DIFF
--- a/src/creature.ts
+++ b/src/creature.ts
@@ -515,9 +515,10 @@ export class Creature {
 		this.status.frozen = false;
 		this.status.cryostasis = false;
 		this.status.dizzy = false;
-
 		// Effects triggers
 		if (reason === 'turn-end') {
+			this.remainingMove=0;
+			this.queryMove(null);
 			this.turnsActive += 1;
 			this._nextGameTurnActive = game.turn + 1;
 			// @ts-expect-error 2554


### PR DESCRIPTION
Attempts to fix the bug where, after skipping with movements points leftover, hovering the cursor over a hex where the skipped unit could have moved would show a preview of the next creature in the queue, as well as allow the creature to move during that time. The solution was to disable movement immediately when the turn ends.

Things to test:
I don't fully know. The idea I went for was that when the active creature becomes deactivated, AND it's the end of the creature's turn, turn off movement. This may have had unintended consequences, or leave other cases where the bug is present unfixed

This fixes issue #2627
