### PR TITLE
fix: Game Freezes and Red Title Appears After Screenshot in Firefox #…

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -377,6 +377,9 @@ export default class Game {
 		// Background
 		this.Phaser.load.image('background', getUrl('locations/' + this.background_image + '/bg'));
 
+		//Branding
+		this.Phaser.load.image('AncientBeastLogo', getUrl('interface/AncientBeast'));
+
 		// Load artwork, shout and avatar for each unit
 		this.loadUnitData(unitData);
 	}

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -666,11 +666,6 @@
 				<div id="queue">
 					<div id="queuewrapper"></div>
 				</div>
-				<div id="brandlogo" class="hide">
-					<div id="brandlogoinner" >
-						<div></div>
-					</div>
-				</div>
 			</div>
 
 

--- a/src/ui/hotkeys.js
+++ b/src/ui/hotkeys.js
@@ -76,7 +76,7 @@ export class Hotkeys {
 	pressTab(event) {
 		console.log(event);
 		if (event.shiftKey) {
-			this.ui.$brandlogo.addClass('hide');
+			this.ui.brandlogo.alpha=0;
 		}
 	}
 
@@ -123,23 +123,23 @@ export class Hotkeys {
 	}
 
 	pressShiftKeyDown(event) {
-		this.ui.$brandlogo.removeClass('hide');
+		this.ui.brandlogo.alpha=1;
 		this.ui.game.grid.showGrid(true);
 		this.ui.game.grid.showCurrentCreatureMovementInOverlay(this.ui.game.activeCreature);
 	}
 
 	pressShiftKeyUp() {
-		this.ui.$brandlogo.addClass('hide');
+		this.ui.brandlogo.alpha=0;
 		this.ui.game.grid.showGrid(false);
 		this.ui.game.grid.cleanOverlay();
 		this.ui.game.grid.redoLastQuery();
 	}
 	pressControlKeyDown() {
-		this.ui.$brandlogo.addClass('hide');
+		this.ui.brandlogo.alpha=0;
 	}
 
 	pressControlKeyUp() {
-		this.ui.$brandlogo.addClass('hide');
+		this.ui.brandlogo.alpha=0;
 	}
 
 	pressSpace() {

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -61,7 +61,8 @@ export class UI {
 		this.$grid = $j(this.#makeCreatureGrid(document.getElementById('creaturerasterwrapper')));
 		this.$activebox = $j('#activebox');
 		this.$scoreboard = $j('#scoreboard');
-		this.$brandlogo = $j('#brandlogo');
+          this.brandlogo=game.Phaser.add.image(670,200,"AncientBeastLogo");
+          this.brandlogo.alpha=0;
 		this.active = false;
 
 		this.queue = UI.#getQueue(this, document.getElementById('queuewrapper'));
@@ -2437,13 +2438,13 @@ export class UI {
 		}, 2000);
 
 		const onTurnEndMouseEnter = ifGameNotFrozen(() => {
-			ui.$brandlogo.removeClass('hide');
+			ui.brandlogo.alpha=0;
 			ui.game.grid.showGrid(true);
 			ui.game.grid.showCurrentCreatureMovementInOverlay(ui.game.activeCreature);
 		});
 
 		const onTurnEndMouseLeave = () => {
-			ui.$brandlogo.addClass('hide');
+			ui.brandlogo.alpha=0;
 			ui.game.grid.showGrid(false);
 			ui.game.grid.cleanOverlay();
 			ui.game.grid.redoLastQuery();
@@ -2452,7 +2453,7 @@ export class UI {
 		// Hide the project logo when navigating away using a hotkey
 		document.addEventListener('visibilitychange', function () {
 			if (document.hidden) {
-				ui.$brandlogo.addClass('hide');
+				ui.brandlogo.alpha=0;
 			}
 		});
 
@@ -2460,7 +2461,7 @@ export class UI {
 		document.addEventListener('keydown', (event) => {
 			if (event.ctrlKey && event.shiftKey && event.key === 'M') {
 				console.log('ctrl+shift+M pressed');
-				ui.$brandlogo.addClass('hide');
+				ui.brandlogo.alpha=0;
 			}
 		});
 


### PR DESCRIPTION
Changes:

Changed the overlay triggered by holding shift from a div to a phaser sprite.

Testing:
Holding shift does not prevent the player from making moves.

Note that is the game loses focus before the shift key is released, and then the shift key is released before giving focus back, the logo will remain until the the shift key is pressed again.
Not sure what happens if a match ends with the sprite still on screen

This fixes issue #2703
