### PR TITLE
Impaler ts & ability tweaks/fixes

### DIFF
--- a/src/abilities/Impaler.ts
+++ b/src/abilities/Impaler.ts
@@ -100,16 +100,16 @@ export default (G: Game) => {
 				ability.end();
 				G.Phaser.camera.shake(0.01, 120, true, G.Phaser.camera.SHAKE_HORIZONTAL, true);
 
-				const finalDmg = $j.extend(
+				const finalDmg: DamageStats =
 					{
+						pierce: 30,
 						poison: 0,
-					},
-					ability.damages,
-				);
+					};
+
 
 				// Poison Bonus if upgraded
 				if (this.isUpgraded()) {
-					finalDmg.poison = this.damages.poison;
+					finalDmg.poison = 10;
 				}
 
 				const damage = new Damage(

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -1143,7 +1143,7 @@ export class Creature {
 	/**
 	 * @param{number} amount - Amount of health point to restore
 	 */
-	heal(amount: number, isRegrowth: boolean, log = true) {
+	heal(amount: number, isRegrowth = false, log = true) {
 		const game = this.game;
 		// Cap health point
 		amount = Math.min(amount, this.stats.health - this.health);

--- a/src/effect.ts
+++ b/src/effect.ts
@@ -2,6 +2,7 @@ import { Creature } from './creature';
 import Game from './game';
 import { Hex } from './utility/hex';
 import { Trap } from './utility/trap';
+import { Damage } from './damage';
 
 /*
  * Effect Class
@@ -10,7 +11,7 @@ import { Trap } from './utility/trap';
 type EffectOwner = Creature | Hex;
 type EffectTarget = Creature | Hex;
 
-type Damage = number;
+//type Damage = number; //Why??? what about the actual Damage type? Causes conflict on impaler.ts
 type EffectFnArg = Creature | Hex | Damage;
 
 type EffectOptions = Partial<Effect>;


### PR DESCRIPTION
Converted Impaler.js to ts

Could not reproduce poisonous vine glitch

changed default healing options so that healing is assumed to not be regrowth unless specified otherwise

Request:
Test out the different abilities, and make sure that they all work right. I'm baffled by some of the code on this one, and I'm not 100% certain if there are any glitches. I'll happily make tweaks before a full final merge/

This fixes issue #2770 primarily


