### PR TITLE
Hide combat log when fullscreen views are open fixing issue #2760.

### DIFF
--- a/src/ui/fullscreen.ts
+++ b/src/ui/fullscreen.ts
@@ -30,16 +30,27 @@ export class Fullscreen {
 	}
 
 	updateButtonState() {
+		const chatElement = document.getElementById('chat');
+
 		if (document.fullscreenElement) {
 			this.button.classList.add('fullscreenMode');
 			this.button
 				.querySelectorAll('.fullscreen__title')
 				.forEach((el) => (el.textContent = 'Contract'));
+			// Hide the chat when entering fullscreen
+			if (chatElement) {
+				chatElement.style.display = 'none';
+			}
 		} else {
 			this.button.classList.remove('fullscreenMode');
 			this.button
 				.querySelectorAll('.fullscreen__title')
 				.forEach((el) => (el.textContent = 'FullScreen'));
+
+			// Show the chat when exiting fullscreen
+			if (chatElement) {
+				chatElement.style.display = 'block';
+			}
 		}
 	}
 }


### PR DESCRIPTION
Hides combat log when full screen to prevent overlap with UI elements, especially the materialization button on mobile devices.
### Changes Made
- Modified `src/ui/fullscreen.ts` to hide combat log when entering fullscreen mode
- Combat log is restored when exiting fullscreen mode
- Uses existing chat element ID from the chat system

This fixes issue #2760 