### PR TITLE
   Fix: Boiling Point ability respects audio mode setting

### DIFF
--- a/src/abilities/Infernal.ts
+++ b/src/abilities/Infernal.ts
@@ -6,6 +6,7 @@ import * as arrayUtils from '../utility/arrayUtils';
 import { Effect } from '../effect';
 import { getPointFacade } from '../utility/pointfacade';
 import Game from '../game';
+import { getAudioMode } from '../sound/soundsys';
 
 /** Creates the abilities
  * @param {Object} G the game object
@@ -29,9 +30,11 @@ export default (G) => {
 				this._addTrap(this.creature.hexagons[1]);
 				this._addTrap(this.creature.hexagons[this.creature.player.flipped ? 0 : 2]);
 
-				// SFX
-				const music = G.Phaser.add.audio('MagmaSpawn0');
-				music.play();
+				// SFX - Only play if audio is not muted
+				if (getAudioMode() !== 'muted') {
+					const music = G.Phaser.add.audio('MagmaSpawn0');
+					music.play();
+				}
 			},
 
 			_addTrap: function (hex) {


### PR DESCRIPTION
## Fixes Issue #2779

Problem: Infernal's passive ability "Boiling Point" was playing sound effects even when the game audio was muted.

Root Cause: The ability was directly calling `G.Phaser.add.audio('MagmaSpawn0').play()` without checking the current audio mode.

Solution: 
- Import `getAudioMode` function from the sound system
- Add conditional check: `if (getAudioMode() !== 'muted')` before playing sound
- Maintains functionality when audio is enabled

**Files Modified**: `src/abilities/Infernal.ts`

Testing: 
- Set audio mode to 'muted' via right-click on upper-right audio button
- Trigger Boiling Point ability (activates automatically at start of turn)
- Verify no sound is played when muted
- Set audio mode back to 'full' or 'sfx' and verify sound works normally



Status: Ready for review and merge.