### PR TITLE
Battle long overlap fix

### DIFF
--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -302,7 +302,7 @@
 	bottom: 0;
 	height: 0;
 	width: 100%;
-	z-index: 5;
+	z-index: 1;
 }
 
 #rightpanel {


### PR DESCRIPTION
Moved the battle log behind all full screen views.

Changed the z-index value on the battle log, so that all other views should overlap it.

This fixes issue #2760

