### PR TITLE
Revamped Gumble passive ability

### DIFF
--- a/src/data/units.ts
+++ b/src/data/units.ts
@@ -1360,9 +1360,9 @@ export const unitData: UnitDataStructure = [
 		ability_info: [
 			{
 				title: 'Gooey Body',
-				desc: 'Receives bonus pierce, slash and crush masteries based on remaining health.',
-				info: '3 bonus points each for every 7 health.',
-				upgrade: 'Health threshold becomes 5.',
+				desc: 'When killed, it melts into a puddle that traps any unit that walks on top of it.',
+				info: "Can't move current round while on goo.",
+				upgrade: 'Does not affect allied units.',
 			},
 			{
 				title: 'Gummy Mallet',

--- a/src/game.ts
+++ b/src/game.ts
@@ -136,9 +136,9 @@ export default class Game {
 
 	startMatchTime?: Date;
 	$combatFrame?: JQuery<HTMLElement>; //eslint-disable-line no-undef
-	timeInterval?: NodeJS.Timer; //eslint-disable-line no-undef
+	timeInterval?: NodeJS.Timeout; //eslint-disable-line no-undef
 
-	windowResizeTimeout?: string | number | NodeJS.Timer; //eslint-disable-line no-undef
+	windowResizeTimeout?: string | number | NodeJS.Timeout; //eslint-disable-line no-undef
 
 	pauseStartTime?: Date;
 

--- a/src/game.ts
+++ b/src/game.ts
@@ -1132,7 +1132,8 @@ export default class Game {
 
 		// For triggered creature
 		triggeredCreature.abilities.forEach((ability) => {
-			if (triggeredCreature.dead === true) {
+			// If the creature is dead and the trigger is not onCreatureDeath, return
+			if (triggeredCreature.dead === true && trigger !== 'onCreatureDeath') {
 				return;
 			}
 
@@ -1320,8 +1321,8 @@ export default class Game {
 	onCreatureDeath(/* creature, callback */) {
 		const creature = arguments[0];
 
-		this.triggerAbility('onCreatureDeath', arguments);
-		this.triggerEffect('onCreatureDeath', [creature, creature]);
+		this.triggerAbility('onCreatureDeath', [creature, creature]);
+		this.triggerEffect('onCreatureDeath', arguments);
 
 		// Looks for traps owned by this creature and destroy them
 		this.traps


### PR DESCRIPTION
This fixes issue #2635

### Revamped the Gumble passive ability

### Gumble –  Trap Ability


>  Effect on Death: When Gumble dies, it leaves behind a pinkish, gooey mud on the battlefield.
> 
>   Trapping Mechanics:
> 
> 
>  1.  Unupgraded: All units (including allies) that enter the mud get trapped. 
>  2.  Upgraded: Only enemy units are trapped; allied units can move freely.
> 
>  Interaction with Other Traps: If another trap is placed on top of Gumble’s mud, it destroys the original mud, removing its effects immediately.
> 
> 
> 

My wallet address is 0x928f2B71B6a3C3917F5d908EdD3F7C3612a53198
