### PR TITLE
fixed the bug for selecting double a materialize unit

### DIFF
--- a/src/ui/interface.ts
+++ b/src/ui/interface.ts
@@ -1134,8 +1134,8 @@ export class UI {
 
 						// Bind button
 						this.materializeButton.click = () => {
-							if (this.selectedAbility === 3) {
-								// Cancel ability if already selected
+							if (this.selectedAbility === 3 && !this.dashopen) {
+								// Cancel ability if already selected and dash is not open
 								this.closeDash();
 								game.activeCreature.queryMove();
 								this.selectAbility(-1);


### PR DESCRIPTION
Fix: Dark Priest materialize button double-click freeze

Added check to prevent double-clicking materialize button from freezing game.
Cancels ability properly when clicked twice.

Fixes #2775 

Before: 

https://github.com/user-attachments/assets/fb6e60ba-4a2b-419e-a0d8-b1d8d6c4aab4


After:

https://github.com/user-attachments/assets/704b16a1-7633-4672-b2f2-adf593d92a5b

wallet address: 0x2b33E4D2bD2f34310956dCb462d58413d3dCcdf8 (Metamask)