### PR TITLE
Bounty Hunter upgraded sword slitter 2nd hit sfx

### DIFF
--- a/src/abilities/Bounty-Hunter.ts
+++ b/src/abilities/Bounty-Hunter.ts
@@ -146,6 +146,8 @@ export default (G: Game) => {
 
 				const ability = this;
 
+				const game = this.game;
+
 				const damage = new Damage(
 					ability.creature, // Attacker
 					ability.damages, // Damage Type
@@ -170,6 +172,7 @@ export default (G: Game) => {
 					setTimeout(() => {
 						G.Phaser.camera.shake(0.01, 150, true, G.Phaser.camera.SHAKE_HORIZONTAL, true);
 						ability.end(true);
+						game.soundsys.playSFX('sounds/swing2');
 						target.takeDamage(damage);
 						G.log('%CreatureName' + ability.creature.id + '% used ' + ability.title + ' twice');
 					}, 1000);


### PR DESCRIPTION
Fixes issue #2762 

Changes:
Allowed Bounty Hunter's sword slitter ability to access sound system to play the second swing sfx (swing2) when the conditions for the second attack are met.

Notes:
Chimera's upgraded Tooth Fairy also hits twice, but only one sfx is played. This could be another first good issue for new contributors if this is a problem.
