### PR TITLE
Add sound effect for Chimera's Tooth Fairy second hit

### DIFF
--- a/src/abilities/Chimera.ts
+++ b/src/abilities/Chimera.ts
@@ -87,6 +87,8 @@ export default (G: Game) => {
 			//	activate() :
 			activate: function (target) {
 				const ability = this;
+			const game = this.game;
+
 
 				ability.end();
 
@@ -99,8 +101,11 @@ export default (G: Game) => {
 				);
 				target.takeDamage(damage);
 				if (this.isUpgraded()) {
-					// Second attack
+				// Second attack with sound effect
+				setTimeout(() => {
+					game.soundsys.playSFX('sounds/swing2');
 					target.takeDamage(damage);
+				}, 500);
 				}
 			},
 		},


### PR DESCRIPTION
## Description
This PR fixes issue #2794 by adding a sound effect for the second hit of Chimera's upgraded Tooth Fairy ability.

## Changes
- Added `game.soundsys.playSFX('sounds/swing2')` call for the second hit
- Wrapped second hit in setTimeout with 500ms delay for proper timing
- Follows the same pattern as PR #2790 which fixed a similar issue for Bounty Hunter's Sword Slit

## Testing
- Second hit now plays sound effect correctly
- No regression in first hit behavior
- Follows established pattern from similar fixes

## Related Issues
Fixes #2794
Similar to #2762 and PR #2790

---
**Bounty:** 6 XTR  
**Wallet:** 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb