### PR TITLE
Fix active unit hexagons rendering on top of targeting hexagons

### DIFF
--- a/src/creature.ts
+++ b/src/creature.ts
@@ -811,6 +811,8 @@ export class Creature {
 	highlightCurrentHexesAsDashed() {
 		this.hexagons.forEach((hex) => {
 			hex.display.loadTexture(`hex_dashed_p${this.player.id}`);
+			// Bring active creature hexagons to top so they appear above targeting hexagons
+			hex.grid.displayHexesGroup.bringToTop(hex.display);
 		});
 	}
 


### PR DESCRIPTION
## Description
Fixes #2734 by ensuring active creature hexagons appear on top of targeting hexagons.

## Changes
- Added `bringToTop()` call in `highlightCurrentHexesAsDashed()` method
- Active unit hexagons now properly render above black targeting hexagons
- Maintains visual hierarchy during ability targeting

## Testing
- Tested with various abilities that show targeting hexagons
- Active creature position remains clearly visible
- No regression in other hex rendering

## Related Issues
Fixes #2734

---
**Bounty:** 8 XTR  
**Wallet:** 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb