### PR TITLE
Ensure active unit colored overlays render above black path overlays (fixes #2734)

### DIFF
--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -635,8 +635,7 @@ export class Hex {
 			if (this.overlayClasses.match(/reachable/)) {
 				targetAlpha = true;
 				this.overlay.loadTexture('hex_path');
-				// Ensure "reachable" overlays (black path) do not cover important colored overlays
-				// Keep them behind within the overlay group so active/hovered colored ones stay on top
+				// No partially overlapped hexagons #2734
 				if (this.grid.overlayHexesGroup.sendToBack) {
 					this.grid.overlayHexesGroup.sendToBack(this.overlay);
 				}


### PR DESCRIPTION
When targeting abilities, colored overlays under the active unit could appear beneath black path overlays.

This change:
- Keeps 'reachable' (black path) overlays behind within the overlay group using sendToBack.
- Continues bringing important colored overlays (creature/hover/dashed per team) to top.
- Does not alter textures or UX otherwise.

Tested by targeting with various abilities: active unit hexes remain visibly on top of path overlays.

Fixes #2734.