### PR TITLE
Dev-only: allow materializing 'secret' units (fixes #2184)

### DIFF
--- a/src/data/units.ts
+++ b/src/data/units.ts
@@ -32,7 +32,11 @@ type Stats = {
 type UnitDataStructure = readonly {
 	id: number;
 	name: string;
-	playable: boolean;
+	// playable can be:
+	// - true: fully available
+	// - false: not available
+	// - 'secret': materializable in development builds only
+	playable: boolean | 'secret';
 	level: number | string;
 	realm: string;
 	size: UnitSize;
@@ -203,7 +207,7 @@ export const unitData: UnitDataStructure = [
 			sonic: 5,
 			mental: 8,
 		},
-				drop: {
+		drop: {
 			name: 'gold coin',
 			meditation: 6,
 			initiative: 4,

--- a/src/data/units.ts
+++ b/src/data/units.ts
@@ -3362,7 +3362,7 @@ export const unitData: UnitDataStructure = [
 	{
 		id: 41,
 		name: 'Mangler',
-		playable: false,
+		playable: 'secret',
 		level: 1,
 		realm: 'W',
 		size: 1,
@@ -3420,7 +3420,7 @@ export const unitData: UnitDataStructure = [
 	{
 		id: 42,
 		name: 'Batmadillo',
-		playable: false,
+		playable: 'secret',
 		level: 7,
 		realm: 'E',
 		size: 3,
@@ -3509,7 +3509,7 @@ export const unitData: UnitDataStructure = [
 	{
 		id: 43,
 		name: 'Volpyr',
-		playable: false,
+		playable: 'secret',
 		level: 7,
 		realm: 'L',
 		size: 3,

--- a/src/game.ts
+++ b/src/game.ts
@@ -276,7 +276,10 @@ export default class Game {
 		this.creatureData = data;
 
 		data.forEach((creature) => {
-			if (!creature.playable) {
+			const isSecret = creature.playable === 'secret';
+			const isDev = process.env.NODE_ENV === 'development';
+			const isPlayable = creature.playable === true || (isSecret && isDev);
+			if (!isPlayable) {
 				return;
 			}
 


### PR DESCRIPTION
Implements a 'secret' value for unit.playable to allow selecting and materializing under-development units in development builds only.

- game.ts: loads units when playable === true OR (playable === 'secret' AND NODE_ENV=development)
- units.ts: marks Mangler, Batmadillo, Volpyr as playable: 'secret' to demo the flow.

Players on production (NODE_ENV=production) remain unaffected; only fully playable units appear. This enables faster iteration on WIP units without exposing them in stable builds.

Fixes #2184.