### PR TITLE
Hide flashing text caret in Firefox on pre-match and loader (fixes #2809)

### DIFF
--- a/src/style/pre-match.less
+++ b/src/style/pre-match.less
@@ -163,7 +163,7 @@ body {
 	display: none;
 }
 
-/* Also hide caret near START area */
+/* Hide caret in Firefox near START area */
 #start-btn,
 #start,
 #pre-match {


### PR DESCRIPTION
In Firefox, a caret was flashing in the pre-match screen near START and on the loading screen due to focus on focusable containers. This hides the caret via CSS without altering behavior:

- pre-match.less: add  and remove outlines for , , , , , and .

Selection is already disabled globally (), and this addresses the Firefox caret specifically while keeping keyboard handling intact.

Fixes #2809.

ERC20 Address: 0x3Ed5041bAED3e28c072Ac92021487a7add9FF7FF