### PR TITLE
Fix Bonfire Spring upgrade range off-by-one (fixes #2810)

### DIFF
--- a/src/abilities/Abolished.ts
+++ b/src/abilities/Abolished.ts
@@ -206,8 +206,8 @@ export default (G: Game) => {
 				const crea = this.creature;
 				let totalRange = 3;
 				if (this.isUpgraded()) {
-					// Upgrade: increase range each usage based on accumulatedTeleportRange
-					totalRange += this.creature.accumulatedTeleportRange;
+					// Upgrade: base +1 range, plus +1 per prior successful use (accumulatedTeleportRange)
+					totalRange += 1 + this.creature.accumulatedTeleportRange;
 				}
 
 				// Relocates to any hex within range except for the current hex


### PR DESCRIPTION
The upgrade for Abolished's Bonfire Spring should increase range each usage. The previous logic subtracted 1 from accumulatedTeleportRange, delaying the effect; e.g., it took two turns before any increase was seen.

Change:
- Abolished.ts: when upgraded, totalRange += accumulatedTeleportRange (remove -1).

Related helpers already reset and increment the accumulator appropriately (reset on use, +1 on end phase).