### PR TITLE
fix health indicators across browser

### DIFF
--- a/src/creature.ts
+++ b/src/creature.ts
@@ -1834,23 +1834,28 @@ class CreatureSprite {
 				: HEX_WIDTH_PX * size - sprite.texture.width - display['offset-x']) +
 			sprite.texture.width / 2;
 		sprite.y = display['offset-y'] + sprite.texture.height;
+		
+		const centerX = HEX_WIDTH_PX * (size - 0.5);
+		const healthY = - sprite.texture.height - 10;
 
 		// Hint Group
 		const hintGrp = phaser.add.group(group, 'creatureHintGrp_' + id);
-		hintGrp.x = 0.5 * HEX_WIDTH_PX * size;
-		hintGrp.y = -sprite.texture.height + 5;
+		hintGrp.x = centerX;
+		hintGrp.y = -sprite.texture.height - 5;
 
 		const healthIndicatorGroup = phaser.add.group(group, 'creatureHealthGrp_' + id);
+		healthIndicatorGroup.x = 0;
+		healthIndicatorGroup.y = healthY;
 
 		const healthIndicatorSprite = healthIndicatorGroup.create(
-			player.flipped ? 19 : 19 + HEX_WIDTH_PX * (size - 1),
-			49,
+			centerX,
+			0,
 			'p' + team + '_health',
 		);
 
 		const healthIndicatorText = phaser.add.text(
-			player.flipped ? HEX_WIDTH_PX * 0.5 : HEX_WIDTH_PX * (size - 0.5),
-			63,
+			centerX,
+			14,
 			health,
 			{
 				font: 'bold 15pt Play',

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -1827,35 +1827,61 @@ class CreatureSprite {
 		// Adding sprite
 		const sprite = group.create(0, 0, creature.name + darkPriestColorOrEmpty + '_cardboard');
 		sprite.anchor.setTo(0.5, 1);
+		//sprite.x=horizontal center
+		//sprite.y=bottom edge of sprite
 		// Placing sprite
+		//display['offset-x'] places center of sprite at offset-x
+		
 		sprite.x =
 			(!player.flipped
 				? display['offset-x']
-				: HEX_WIDTH_PX * size - sprite.texture.width - display['offset-x']) +
-			sprite.texture.width / 2;
-		sprite.y = display['offset-y'] + sprite.texture.height;
+				: HEX_WIDTH_PX * size - sprite.width - display['offset-x']) +
+			sprite.width / 2;
+		sprite.y = display['offset-y'] + sprite.height;
+
+		// sprite.x = !player.flipped
+		// 	? display['offset-x']
+		// 	: HEX_WIDTH_PX * size - display['offset-x'];
+		// sprite.y = display['offset-y'];
 		
 		const centerX = HEX_WIDTH_PX * (size - 0.5);
-		const healthY = - sprite.texture.height - 10;
+		// const healthY = - sprite.texture.height - 10;
 
 		// Hint Group
 		const hintGrp = phaser.add.group(group, 'creatureHintGrp_' + id);
 		hintGrp.x = centerX;
-		hintGrp.y = -sprite.texture.height - 5;
+		//place hint above creature
+		//hintGrp.y = -sprite.texture.height + 5;
+		//parent = sprite, y=-10, above sprite, no texture needed
+		hintGrp.y = -sprite.height-5;
 
+		//define central UI position once to avoid duplication
+		const uiX = player.flipped? HEX_WIDTH_PX * 0.5 : HEX_WIDTH_PX * (size-0.5);
+		const uiY = 63; //using original text center as new unified Y baseline
+
+		//another child group with no position set, defaults (0,0) in group space
+		//const healthIndicatorGroup = phaser.add.group(group, 'creatureHealthGrp_' + id);
+		//health ui moves with sprite
 		const healthIndicatorGroup = phaser.add.group(group, 'creatureHealthGrp_' + id);
-		healthIndicatorGroup.x = 0;
-		healthIndicatorGroup.y = healthY;
+		// healthIndicatorGroup.x = 0;
+		// healthIndicatorGroup.y = -sprite.height - 10;
 
+		//create pill at (0,0)
+		//hardcoded pixel offsets
+		//position pill sprite
 		const healthIndicatorSprite = healthIndicatorGroup.create(
-			centerX,
-			0,
+			uiX,
+			uiY,
 			'p' + team + '_health',
 		);
-
+		//set anchor center so this aligns with text
+		healthIndicatorSprite.anchor.setTo(0.5, 0.5);
+		//differ across browsers, 
+		//center text on pill
+		//position text at exact same coordinates as pill
 		const healthIndicatorText = phaser.add.text(
-			centerX,
-			14,
+			uiX,
+			uiY,
 			health,
 			{
 				font: 'bold 15pt Play',
@@ -1865,7 +1891,9 @@ class CreatureSprite {
 				strokeThickness: 6,
 			},
 		);
+		//centers text to it's position
 		healthIndicatorText.anchor.setTo(0.5, 0.5);
+		//text moves with pill, pill is mispositioned
 		healthIndicatorGroup.add(healthIndicatorText);
 		healthIndicatorGroup.visible = false;
 
@@ -1960,9 +1988,11 @@ class CreatureSprite {
 				  this._sprite.texture.width -
 				  this._frameInfo.originX) +
 			this._sprite.texture.width / 2;
-		this._healthIndicatorSprite.x = dir === -1 ? 19 : 19 + HEX_WIDTH_PX * (this._creatureSize - 1);
-		this._healthIndicatorText.x =
-			dir === -1 ? HEX_WIDTH_PX * 0.5 : HEX_WIDTH_PX * (this._creatureSize - 0.5);
+		
+		//both pill and text are center-anchored(0.5)
+		const targetX = dir === -1? HEX_WIDTH_PX* 0.5 : HEX_WIDTH_PX * (this._creatureSize - 0.5);
+		this._healthIndicatorSprite.x = targetX;
+		this._healthIndicatorText.x = targetX;
 	}
 
 	xray(enable: boolean) {

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -1827,10 +1827,6 @@ class CreatureSprite {
 		// Adding sprite
 		const sprite = group.create(0, 0, creature.name + darkPriestColorOrEmpty + '_cardboard');
 		sprite.anchor.setTo(0.5, 1);
-		//sprite.x=horizontal center
-		//sprite.y=bottom edge of sprite
-		// Placing sprite
-		//display['offset-x'] places center of sprite at offset-x
 		
 		sprite.x =
 			(!player.flipped
@@ -1838,62 +1834,63 @@ class CreatureSprite {
 				: HEX_WIDTH_PX * size - sprite.width - display['offset-x']) +
 			sprite.width / 2;
 		sprite.y = display['offset-y'] + sprite.height;
-
-		// sprite.x = !player.flipped
-		// 	? display['offset-x']
-		// 	: HEX_WIDTH_PX * size - display['offset-x'];
-		// sprite.y = display['offset-y'];
 		
 		const centerX = HEX_WIDTH_PX * (size - 0.5);
-		// const healthY = - sprite.texture.height - 10;
-
+		
 		// Hint Group
 		const hintGrp = phaser.add.group(group, 'creatureHintGrp_' + id);
 		hintGrp.x = centerX;
-		//place hint above creature
-		//hintGrp.y = -sprite.texture.height + 5;
-		//parent = sprite, y=-10, above sprite, no texture needed
+		//Position hint above the creature
 		hintGrp.y = -sprite.height-5;
 
 		//define central UI position once to avoid duplication
 		const uiX = player.flipped? HEX_WIDTH_PX * 0.5 : HEX_WIDTH_PX * (size-0.5);
-		const uiY = 63; //using original text center as new unified Y baseline
+		const uiY = 46; //adjusted baseline for consistent cross-browser centering
 
-		//another child group with no position set, defaults (0,0) in group space
-		//const healthIndicatorGroup = phaser.add.group(group, 'creatureHealthGrp_' + id);
-		//health ui moves with sprite
+		//group for health UI elements that move with creature
 		const healthIndicatorGroup = phaser.add.group(group, 'creatureHealthGrp_' + id);
-		// healthIndicatorGroup.x = 0;
-		// healthIndicatorGroup.y = -sprite.height - 10;
 
-		//create pill at (0,0)
-		//hardcoded pixel offsets
-		//position pill sprite
+		//health indicator pill 
 		const healthIndicatorSprite = healthIndicatorGroup.create(
 			uiX,
 			uiY,
 			'p' + team + '_health',
 		);
-		//set anchor center so this aligns with text
+
+		//set anchor to center so this aligns with text
 		healthIndicatorSprite.anchor.setTo(0.5, 0.5);
-		//differ across browsers, 
-		//center text on pill
-		//position text at exact same coordinates as pill
+
+		//browser detection for font metric offset
+		const agent = navigator.userAgent.toLowerCase();
+		const isFirefox = agent.indexOf('firefox') > -1;
+		const isBrave = (navigator as any).brave !== undefined || agent.indexOf('brave') > -1;
+
+		//apply nudges:  Firefox text is too low , brave text is too high(nudge down)
+		let browserNudge = 0;
+		if(isFirefox) {
+			browserNudge = 1; //use positive nudge to move it DOWN
+		} else if (isBrave) {
+			browserNudge = -5; //pulls text UP into pill container
+		}
+		
+		//center text pill to minimize cross-browser font metric differences,
 		const healthIndicatorText = phaser.add.text(
 			uiX,
-			uiY,
+			uiY+ browserNudge,
 			health,
 			{
-				font: 'bold 15pt Play',
+				font: 'bold 14pt Play',
 				fill: '#fff',
 				align: 'center',
 				stroke: '#000',
-				strokeThickness: 6,
+				strokeThickness: 5,
+				// vertical padding helps prevent stroke from clipping in Firefox
+				padding:{x:0, y:4},
 			},
 		);
 		//centers text to it's position
 		healthIndicatorText.anchor.setTo(0.5, 0.5);
-		//text moves with pill, pill is mispositioned
+		//text is grouped with pill to ensure consistent relative positioning
 		healthIndicatorGroup.add(healthIndicatorText);
 		healthIndicatorGroup.visible = false;
 

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -1827,58 +1827,59 @@ class CreatureSprite {
 		// Adding sprite
 		const sprite = group.create(0, 0, creature.name + darkPriestColorOrEmpty + '_cardboard');
 		sprite.anchor.setTo(0.5, 1);
-		
+
 		sprite.x =
 			(!player.flipped
 				? display['offset-x']
 				: HEX_WIDTH_PX * size - sprite.width - display['offset-x']) +
 			sprite.width / 2;
 		sprite.y = display['offset-y'] + sprite.height;
-		
+
 		const centerX = HEX_WIDTH_PX * (size - 0.5);
-		
+
 		// Hint Group
 		const hintGrp = phaser.add.group(group, 'creatureHintGrp_' + id);
 		hintGrp.x = centerX;
-		//Position hint above the creature
-		hintGrp.y = -sprite.height-5;
 
-		//Define central UI position once to avoid duplication
-		const uiX = player.flipped? HEX_WIDTH_PX * 0.5 : HEX_WIDTH_PX * (size-0.5);
+		// Position hint above the creature
+		hintGrp.y = -sprite.height - 5;
+
+		// Define central UI position once to avoid duplication
+		const uiX = player.flipped ? HEX_WIDTH_PX * 0.5 : HEX_WIDTH_PX * (size - 0.5);
 		const uiY = 58; //Base position for health pill
 
-		//Group for health UI elements that move with creature
+		// Group for health UI elements that move with creature
 		const healthIndicatorGroup = phaser.add.group(group, 'creatureHealthGrp_' + id);
 
-		//Health indicator pill 
+		// Health indicator pill 
 		const healthIndicatorSprite = healthIndicatorGroup.create(
 			uiX,
 			uiY,
 			'p' + team + '_health',
 		);
 
-		//Set anchor to center so this aligns with text
+		// Set anchor to center so this aligns with text
 		healthIndicatorSprite.anchor.setTo(0.5, 0.5);
 
-		//Browser detection for font metric offset
+		// Browser detection for font metric offset
 		const agent = navigator.userAgent.toLowerCase();
 		const isFirefox = agent.indexOf('firefox') > -1;
 		const isBrave = (navigator as any).brave !== undefined || agent.indexOf('brave') > -1;
-
-		//Apply nudges to minimize cross-browser font metric differences
-		let browserNudge = 0;
-		if(isFirefox) {
-			//Firefox renders low , use positive nudge to move it DOWN
-			browserNudge = 1; 
-		} else if (isBrave) {
-			//Brave renders high, pull text UP into pill container
-			browserNudge = -7; 
-		}
 		
-		//Health text centered on the pill 
+		// Apply nudges to minimize cross-browser font metric differences
+		let browserNudge = 0;
+		if (isFirefox) {
+			// Firefox renders low , use positive nudge to move it DOWN
+			browserNudge = 1;
+		} else if (isBrave) {
+			// Brave renders high, pull text UP into pill container
+			browserNudge = -7;
+		} 
+
+		// Health text centered on the pill 
 		const healthIndicatorText = phaser.add.text(
 			uiX,
-			uiY+ browserNudge,
+			uiY + browserNudge,
 			health,
 			{
 				font: 'bold 14pt Play',
@@ -1886,13 +1887,14 @@ class CreatureSprite {
 				align: 'center',
 				stroke: '#000',
 				strokeThickness: 5,
-				// vertical padding helps prevent stroke from clipping in Firefox
-				padding:{x:0, y:4},
+				// Vertical padding helps prevent stroke from clipping in Firefox
+				padding: { x: 0, y: 4 },
 			},
 		);
-		//centers text to it's position
+		// Centers text to its position
 		healthIndicatorText.anchor.setTo(0.5, 0.5);
-		//Text is grouped with pill to ensure consistent relative positioning
+		
+		// Text is grouped with pill to ensure consistent relative positioning
 		healthIndicatorGroup.add(healthIndicatorText);
 		healthIndicatorGroup.visible = false;
 

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -1843,37 +1843,39 @@ class CreatureSprite {
 		//Position hint above the creature
 		hintGrp.y = -sprite.height-5;
 
-		//define central UI position once to avoid duplication
+		//Define central UI position once to avoid duplication
 		const uiX = player.flipped? HEX_WIDTH_PX * 0.5 : HEX_WIDTH_PX * (size-0.5);
-		const uiY = 46; //adjusted baseline for consistent cross-browser centering
+		const uiY = 58; //Base position for health pill
 
-		//group for health UI elements that move with creature
+		//Group for health UI elements that move with creature
 		const healthIndicatorGroup = phaser.add.group(group, 'creatureHealthGrp_' + id);
 
-		//health indicator pill 
+		//Health indicator pill 
 		const healthIndicatorSprite = healthIndicatorGroup.create(
 			uiX,
 			uiY,
 			'p' + team + '_health',
 		);
 
-		//set anchor to center so this aligns with text
+		//Set anchor to center so this aligns with text
 		healthIndicatorSprite.anchor.setTo(0.5, 0.5);
 
-		//browser detection for font metric offset
+		//Browser detection for font metric offset
 		const agent = navigator.userAgent.toLowerCase();
 		const isFirefox = agent.indexOf('firefox') > -1;
 		const isBrave = (navigator as any).brave !== undefined || agent.indexOf('brave') > -1;
 
-		//apply nudges:  Firefox text is too low , brave text is too high(nudge down)
+		//Apply nudges to minimize cross-browser font metric differences
 		let browserNudge = 0;
 		if(isFirefox) {
-			browserNudge = 1; //use positive nudge to move it DOWN
+			//Firefox renders low , use positive nudge to move it DOWN
+			browserNudge = 1; 
 		} else if (isBrave) {
-			browserNudge = -5; //pulls text UP into pill container
+			//Brave renders high, pull text UP into pill container
+			browserNudge = -7; 
 		}
 		
-		//center text pill to minimize cross-browser font metric differences,
+		//Health text centered on the pill 
 		const healthIndicatorText = phaser.add.text(
 			uiX,
 			uiY+ browserNudge,
@@ -1890,7 +1892,7 @@ class CreatureSprite {
 		);
 		//centers text to it's position
 		healthIndicatorText.anchor.setTo(0.5, 0.5);
-		//text is grouped with pill to ensure consistent relative positioning
+		//Text is grouped with pill to ensure consistent relative positioning
 		healthIndicatorGroup.add(healthIndicatorText);
 		healthIndicatorGroup.visible = false;
 

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -1846,12 +1846,12 @@ class CreatureSprite {
 
 		// Define central UI position once to avoid duplication
 		const uiX = player.flipped ? HEX_WIDTH_PX * 0.5 : HEX_WIDTH_PX * (size - 0.5);
-		const uiY = 58; //Base position for health pill
+		const uiY = 54; //Base position for health pill, move a fix pixels up
 
 		// Group for health UI elements that move with creature
 		const healthIndicatorGroup = phaser.add.group(group, 'creatureHealthGrp_' + id);
 
-		// Health indicator pill 
+		// Health indicator pill
 		const healthIndicatorSprite = healthIndicatorGroup.create(
 			uiX,
 			uiY,
@@ -1865,7 +1865,7 @@ class CreatureSprite {
 		const agent = navigator.userAgent.toLowerCase();
 		const isFirefox = agent.indexOf('firefox') > -1;
 		const isBrave = (navigator as any).brave !== undefined || agent.indexOf('brave') > -1;
-		
+
 		// Apply nudges to minimize cross-browser font metric differences
 		let browserNudge = 0;
 		if (isFirefox) {
@@ -1874,15 +1874,15 @@ class CreatureSprite {
 		} else if (isBrave) {
 			// Brave renders high, pull text UP into pill container
 			browserNudge = -7;
-		} 
+		}
 
-		// Health text centered on the pill 
+		// Health text centered on the pill
 		const healthIndicatorText = phaser.add.text(
 			uiX,
 			uiY + browserNudge,
 			health,
 			{
-				font: 'bold 14pt Play',
+				font: 'bold 11pt Play',
 				fill: '#fff',
 				align: 'center',
 				stroke: '#000',
@@ -1893,7 +1893,7 @@ class CreatureSprite {
 		);
 		// Centers text to its position
 		healthIndicatorText.anchor.setTo(0.5, 0.5);
-		
+
 		// Text is grouped with pill to ensure consistent relative positioning
 		healthIndicatorGroup.add(healthIndicatorText);
 		healthIndicatorGroup.visible = false;
@@ -1989,7 +1989,7 @@ class CreatureSprite {
 				  this._sprite.texture.width -
 				  this._frameInfo.originX) +
 			this._sprite.texture.width / 2;
-		
+
 		//both pill and text are center-anchored(0.5)
 		const targetX = dir === -1? HEX_WIDTH_PX* 0.5 : HEX_WIDTH_PX * (this._creatureSize - 0.5);
 		this._healthIndicatorSprite.x = targetX;


### PR DESCRIPTION
Description:
This PR fixes misalignment of hanging creature health indicators, this appears in certain browser (Brave).

Changes:

- Ensured health badge sprite and health text use same X coordinates.
- Used hex footprint math with centering health indicators
- Adjusted vertical placement so health indicators appear consistent above creature sprite

This fixes issue #2088 

My wallet address is 0x1834Ad801952DcB73E88700c889C180d13eF919F
