### PR TITLE
fixed the double clicking of materalization button, and freezing problem

### DIFF
--- a/src/ui/interface.ts
+++ b/src/ui/interface.ts
@@ -91,6 +91,11 @@ export class UI {
 	queueAnimSpeed: number;
 	dashAnimSpeed: number;
 	materializeToggled: boolean;
+	/**
+	 * Guard to prevent re-entrancy in Dark Priest materialization flow.
+	 * (e.g. double-clicking the materialize button while already picking a hex)
+	 */
+	materializeInProgress: boolean;
 	glowInterval: ReturnType<typeof setInterval>;
 	selectedCreatureObj: Creature;
 	activeAbility: boolean;
@@ -665,6 +670,7 @@ export class UI {
 		this.dashAnimSpeed = 250; // ms
 
 		this.materializeToggled = false;
+		this.materializeInProgress = false;
 		this.dashopen = false;
 
 		this.glowInterval = setInterval(() => {


### PR DESCRIPTION

This fixes issue #2775  Godlet Printer selected but inactive [bounty: 33 XTR] 

Issues:
1. The dash “materialize” click handler calls activeCreature.abilities[3].materialize(...) immediately. If anyone double-click, it can call materialize() twice while the game is already in the middle of hex location picking.
2. In Dark-Priest.ts, materialize() creates a temporary Creature (with { temp: true }) to show in the queue. If we double-click, we can create multiple temp creatures, and the second targeting setup overwrites the first’s query state.

and after the second click, because the UI sets selection directly, the grid’s active query state are now in an overwritten state, so the player ends up in a “selected ability but no effective interaction” situation.

What i fixed:
1.Added a guard flag UI.materializeInProgress in interface.ts , so a second click does nothing while a pick is already active.
2. Also added some cleanups.