### PR TITLE
Fix Godlet Printer double-click bug causing game freeze

### DIFF
--- a/src/abilities/Dark-Priest.ts
+++ b/src/abilities/Dark-Priest.ts
@@ -251,6 +251,12 @@ export default (G: Game) => {
 
 			// Callback function to queryCreature
 			materialize: function (creature: CreatureType) {
+				// Prevent re-entrancy from double-clicks while already picking a location
+				if (G.UI.materializeInProgress) {
+					return;
+				}
+				G.UI.materializeInProgress = true;
+
 				const ability = this;
 				const dpriest = this.creature;
 
@@ -266,6 +272,7 @@ export default (G: Game) => {
 					{ materializationSickness: creatureHasMaterializationSickness },
 				);
 				const fullCrea = new Creature(crea, G);
+				const tempCreatureId = fullCrea.id;
 				// Don't allow temporary Creature to take up space
 				fullCrea.cleanHex();
 				// Make temporary Creature invisible
@@ -296,6 +303,13 @@ export default (G: Game) => {
 						G.grid.previewCreature(hex.pos, crea, ability.creature.player);
 					},
 					fnOnCancel: function () {
+						// Clean up the temporary creature created during targeting
+						const temp = G.creatures[tempCreatureId];
+						if (temp && temp.temp) {
+							temp.destroy();
+							G.updateQueueDisplay();
+						}
+						G.UI.materializeInProgress = false;
 						G.activeCreature.queryMove();
 					},
 					fnOnConfirm: function (...args) {
@@ -304,6 +318,7 @@ export default (G: Game) => {
 					args: {
 						creature: creature,
 						cost: crea.size - 0 + ((crea.level as number) - 0),
+						tempCreatureId: tempCreatureId,
 					}, // OptionalArgs
 					size: crea.size,
 					flipped: dpriest.player.flipped,
@@ -326,6 +341,16 @@ export default (G: Game) => {
 				//TODO: Make the UI show the updated number instantly
 
 				ability.end(false, true);
+
+				// Clean up the temporary creature created during targeting
+				if (args.tempCreatureId) {
+					const temp = G.creatures[args.tempCreatureId];
+					if (temp && temp.temp) {
+						temp.destroy();
+						G.updateQueueDisplay();
+					}
+				}
+				G.UI.materializeInProgress = false;
 
 				ability.creature.player.summon(creature, pos);
 				ability.creature.queryMove();

--- a/src/ui/interface.ts
+++ b/src/ui/interface.ts
@@ -91,6 +91,11 @@ export class UI {
 	queueAnimSpeed: number;
 	dashAnimSpeed: number;
 	materializeToggled: boolean;
+	/**
+	 * Guard to prevent re-entrancy in Dark Priest materialization flow.
+	 * Prevents double-clicking the materialize button while already picking a hex.
+	 */
+	materializeInProgress: boolean;
 	glowInterval: ReturnType<typeof setInterval>;
 	selectedCreatureObj: Creature;
 	activeAbility: boolean;
@@ -665,6 +670,7 @@ export class UI {
 		this.dashAnimSpeed = 250; // ms
 
 		this.materializeToggled = false;
+		this.materializeInProgress = false;
 		this.dashopen = false;
 
 		this.glowInterval = setInterval(() => {
@@ -1134,6 +1140,10 @@ export class UI {
 
 						// Bind button
 						this.materializeButton.click = () => {
+							// Prevent double-clicking while already in materialization flow
+							if (this.materializeInProgress) {
+								return;
+							}
 							this.materializeToggled = false;
 							this.selectAbility(3);
 							this.closeDash();


### PR DESCRIPTION
## Fixes #2775: Godlet Printer selected but inactive

### Problem
When Dark Priest is active, clicking the materialize button twice quickly during location picking caused the ability to get selected but inactive, freezing the game until manually deselected.

### Root Cause
The `materialize()` function had no protection against re-entrancy. Double-clicks could:
1. Create multiple temporary creatures in the queue
2. Confuse the UI state machine  
3. Leave the ability in an inconsistent state

### Solution
1. Added `materializeInProgress` boolean flag in UI class to prevent re-entrancy
2. Guard at the start of `materialize()` to return early if already in progress
3. Proper cleanup of temporary creature on both cancel and confirm paths
4. Guard in the materialize button click handler as an additional safety layer

### Changes
- `src/ui/interface.ts`: Added `materializeInProgress` flag and guard in click handler
- `src/abilities/Dark-Priest.ts`: Added re-entrancy guard and temp creature cleanup

### Testing
- ✅ Build succeeds
- ✅ All existing tests pass (84 tests)
- Fix addresses both button clicks and hotkey triggers

### Notes
This approach is similar to PR #2831 but with the key difference that it properly cleans up the temporary creature on cancel, which was missing from that PR. The fix is minimal and focused on preventing the re-entrancy issue without changing other behavior.

---

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)