### PR TITLE
Fix Godlet Printer double-click bug causing game freeze (v2)

### DIFF
--- a/src/abilities/Dark-Priest.ts
+++ b/src/abilities/Dark-Priest.ts
@@ -251,6 +251,12 @@ export default (G: Game) => {
 
 			// Callback function to queryCreature
 			materialize: function (creature: CreatureType) {
+				// Prevent re-entrancy from double-clicks while already picking a location
+				if (G.UI.materializeInProgress) {
+					return;
+				}
+				G.UI.materializeInProgress = true;
+
 				const ability = this;
 				const dpriest = this.creature;
 
@@ -266,6 +272,7 @@ export default (G: Game) => {
 					{ materializationSickness: creatureHasMaterializationSickness },
 				);
 				const fullCrea = new Creature(crea, G);
+				const tempCreatureId = fullCrea.id;
 				// Don't allow temporary Creature to take up space
 				fullCrea.cleanHex();
 				// Make temporary Creature invisible
@@ -296,6 +303,13 @@ export default (G: Game) => {
 						G.grid.previewCreature(hex.pos, crea, ability.creature.player);
 					},
 					fnOnCancel: function () {
+						// Clean up the temporary creature created during targeting
+						const temp = G.creatures[tempCreatureId];
+						if (temp && temp.temp) {
+							temp.destroy();
+							G.updateQueueDisplay();
+						}
+						G.UI.materializeInProgress = false;
 						G.activeCreature.queryMove();
 					},
 					fnOnConfirm: function (...args) {
@@ -304,6 +318,7 @@ export default (G: Game) => {
 					args: {
 						creature: creature,
 						cost: crea.size - 0 + ((crea.level as number) - 0),
+						tempCreatureId: tempCreatureId,
 					}, // OptionalArgs
 					size: crea.size,
 					flipped: dpriest.player.flipped,
@@ -326,6 +341,16 @@ export default (G: Game) => {
 				//TODO: Make the UI show the updated number instantly
 
 				ability.end(false, true);
+
+				// Clean up the temporary creature created during targeting
+				if (args.tempCreatureId) {
+					const temp = G.creatures[args.tempCreatureId];
+					if (temp && temp.temp) {
+						temp.destroy();
+						G.updateQueueDisplay();
+					}
+				}
+				G.UI.materializeInProgress = false;
 
 				ability.creature.player.summon(creature, pos);
 				ability.creature.queryMove();

--- a/src/ui/interface.ts
+++ b/src/ui/interface.ts
@@ -91,6 +91,11 @@ export class UI {
 	queueAnimSpeed: number;
 	dashAnimSpeed: number;
 	materializeToggled: boolean;
+	/**
+	 * Guard to prevent re-entrancy in Dark Priest materialization flow.
+	 * Prevents double-clicking the materialize button while already picking a hex.
+	 */
+	materializeInProgress: boolean;
 	glowInterval: ReturnType<typeof setInterval>;
 	selectedCreatureObj: Creature;
 	activeAbility: boolean;
@@ -665,6 +670,7 @@ export class UI {
 		this.dashAnimSpeed = 250; // ms
 
 		this.materializeToggled = false;
+		this.materializeInProgress = false;
 		this.dashopen = false;
 
 		this.glowInterval = setInterval(() => {
@@ -1346,6 +1352,10 @@ export class UI {
 		} else {
 			this.hideAbilityCosts();
 			this.activeAbility = false;
+			// Reset materializeInProgress when deselecting ability (e.g., via cancel or hotkey)
+			// This ensures the flag is cleared if user cancels materialization via ability button/hotkey
+			// instead of the normal fnOnCancel/fnOnConfirm paths
+			this.materializeInProgress = false;
 		}
 	}
 


### PR DESCRIPTION
## Fixes #2775: Godlet Printer selected but inactive

### Problem
When Dark Priest is active, double-clicking the Godlet Printer button or pressing the R hotkey during location picking caused the ability to get stuck, freezing the game until manually deselected.

### Root Cause
When `materializeInProgress` flag was set to prevent re-entrancy, it was only cleared in `fnOnCancel` and `fnOnConfirm` callbacks. However, if the user cancelled the ability via:
- Clicking the ability button again
- Pressing the R hotkey  
- Pressing Esc

The `selectAbility(-1)` was called, which calls `queryMove()` to clean up the temp creature, but the `materializeInProgress` flag was never reset. This caused subsequent materialize attempts to be silently ignored.

### Solution
1. Added `materializeInProgress` flag in UI class to prevent re-entrancy
2. Guard at the start of `materialize()` to return early if already in progress
3. **Key fix**: Reset `materializeInProgress` in `selectAbility(-1)` to handle cancellation via ability button/hotkey
4. Proper cleanup of temporary creature on both cancel and confirm paths

### Changes
- `src/ui/interface.ts`: Added `materializeInProgress` flag and reset it in `selectAbility(-1)`
- `src/abilities/Dark-Priest.ts`: Added re-entrancy guard and temp creature cleanup

### Difference from PR #2835
The previous PR (#2835) only reset `materializeInProgress` in `fnOnCancel` and `fnOnConfirm`, which didn't cover the case where the user cancels via ability button or hotkey. This PR adds the reset in `selectAbility(-1)` to cover all cancellation paths.

### Testing
- ✅ Build succeeds
- ✅ All existing tests pass (84 tests)
- Fix addresses both button clicks and hotkey triggers

---

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)