### PR TITLE
Fix x-ray overlap detection

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -88,7 +88,9 @@ module.exports = {
 	// ],
 
 	// A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-	// moduleNameMapper: {},
+	moduleNameMapper: {
+		'\\.(png|jpe?g|gif|svg|woff2?|ogg)$': '<rootDir>/test/fileMock.js',
+	},
 
 	// An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
 	// modulePathIgnorePatterns: [],

--- a/src/__tests__/creature.ts
+++ b/src/__tests__/creature.ts
@@ -4,6 +4,8 @@ import { jest, expect, describe, test, beforeEach, beforeAll } from '@jest/globa
 // NOTE: ts-comments are necessary in this file to avoid mocking the entire game.
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
+type JQueryMock = jest.Mock<{ removeClass: jest.Mock }, []>;
+
 describe('Creature', () => {
 	describe('creature.id', () => {
 		let game: Game;
@@ -330,6 +332,8 @@ const getPhaserMock = () => {
 };
 
 beforeAll(() => {
+	const globalWithJQuery = global as typeof global & { $j: JQueryMock };
+
 	Object.defineProperty(window, 'Phaser', {
 		get() {
 			return { Easing: { Linear: { None: 1 } } };
@@ -337,7 +341,7 @@ beforeAll(() => {
 	});
 
 	// Mock jQuery globally
-	(global as any).$j = jest.fn(() => ({
+	globalWithJQuery.$j = jest.fn(() => ({
 		removeClass: jest.fn(),
 	}));
 

--- a/src/__tests__/creature.ts
+++ b/src/__tests__/creature.ts
@@ -4,7 +4,7 @@ import { jest, expect, describe, test, beforeEach, beforeAll } from '@jest/globa
 // NOTE: ts-comments are necessary in this file to avoid mocking the entire game.
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
-type JQueryMock = jest.Mock<{ removeClass: jest.Mock }, []>;
+type JQueryMock = jest.Mock<() => { removeClass: jest.Mock }>;
 
 describe('Creature', () => {
 	describe('creature.id', () => {

--- a/src/__tests__/utility/hex.ts
+++ b/src/__tests__/utility/hex.ts
@@ -1,0 +1,201 @@
+import { beforeAll, describe, expect, jest, test } from '@jest/globals';
+import { Hex } from '../../utility/hex';
+import { Creature } from '../../creature';
+import { unitData } from '../../data/units';
+
+// NOTE: ts-comments are necessary in this file to avoid mocking the entire game.
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
+type JQueryMock = jest.Mock<() => { removeClass: jest.Mock }>;
+
+jest.mock('../../ability');
+jest.mock('phaser-ce', () => ({
+	__esModule: true,
+	default: {
+		Easing: { Linear: { None: 1 } },
+	},
+	Point: class Point {},
+	Polygon: class Polygon {},
+}));
+
+const getRandomString = (length: number) => {
+	return Array(length + 1)
+		.join((Math.random().toString(36) + '00000000000000000').slice(2, 18))
+		.slice(0, length);
+};
+
+const getPlayerMock = () => ({});
+
+const getHexesMock = () => {
+	const arr = [];
+	for (let y = 0; y < 10; y++) {
+		const row = [];
+		for (let x = 0; x < 10; x++) {
+			row.push({
+				displayPos: { x, y },
+				creature: 0,
+			});
+		}
+		arr.push(row);
+	}
+	return arr;
+};
+
+const getPhaserMock = () => {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const self: Record<string, any> = { position: { set: jest.fn() } };
+	self.add = () => self;
+	self.create = () => self;
+	self.forEach = () => self;
+	self.group = () => self;
+	self.removeChild = () => self;
+	self.setTo = () => self;
+	self.start = () => self;
+	self.text = () => self;
+	self.to = () => self;
+	self.tween = () => self;
+	self.anchor = self;
+	self.data = {};
+	self.onComplete = self;
+	self.parent = self;
+	self.sprite = self;
+	self.scale = self;
+	self.texture = {
+		width: 10,
+		height: 10,
+	};
+
+	return {
+		add: self,
+	};
+};
+
+const getGameMock = () => {
+	const self = {
+		turn: 0,
+		creatures: [],
+		players: [],
+		queue: { update: jest.fn() },
+		updateQueueDisplay: jest.fn(),
+		grid: {
+			orderCreatureZ: jest.fn(),
+			hexes: getHexesMock(),
+			getMovementRange: jest.fn(() => []),
+		},
+		Phaser: getPhaserMock(),
+		retrieveCreatureStats: (type: number) => {
+			for (const d of unitData) {
+				if (d.id === type) {
+					return d;
+				}
+			}
+			return {};
+		},
+		abilities: jest.fn(),
+		signals: {
+			metaPowers: {
+				add: jest.fn(),
+			},
+		},
+		UI: {
+			selectedAbility: -1,
+		},
+		triggers: {
+			oncePerDamageChain: {
+				test: jest.fn(() => false),
+			},
+		},
+		plasma_amount: 10,
+		onReset: jest.fn(),
+		onStartPhase: jest.fn(),
+		onEndPhase: jest.fn(),
+		log: jest.fn(),
+		onHeal: jest.fn(),
+		activeCreature: undefined,
+	};
+	self.players = [getPlayerMock(), getPlayerMock()];
+	return self;
+};
+
+const getCreatureObjMock = () => {
+	return {
+		stats: {
+			health: 10,
+			movement: 10,
+		},
+		temp: false,
+		team: 0,
+		materializationSickness: true,
+		type: getRandomString(5),
+		display: {
+			'offset-x': true,
+		},
+		size: 2,
+		x: 4,
+		y: 4,
+	};
+};
+
+beforeAll(() => {
+	const globalWithJQuery = global as typeof global & { $j: JQueryMock };
+
+	Object.defineProperty(window, 'Phaser', {
+		get() {
+			return { Easing: { Linear: { None: 1 } } };
+		},
+	});
+
+	globalWithJQuery.$j = jest.fn(() => ({
+		removeClass: jest.fn(),
+	}));
+
+	jest.doMock('jquery', () => ({
+		__esModule: true,
+		default: jest.fn(() => ({
+			removeClass: jest.fn(),
+		})),
+	}));
+});
+
+describe('Hex.ghostOverlap', () => {
+	test('does not x-ray the active creature when targeting an overlapping higher-row hex', () => {
+		const game = getGameMock();
+		// @ts-ignore
+		const activeCreature = new Creature(getCreatureObjMock(), game);
+		// @ts-ignore
+		const otherCreature = new Creature(getCreatureObjMock(), game);
+
+		game.activeCreature = activeCreature;
+		game.creatures = [activeCreature, otherCreature];
+
+		activeCreature.getScreenBounds = jest.fn(() => ({
+			left: 0,
+			right: 100,
+			top: 0,
+			bottom: 100,
+		}));
+		otherCreature.getScreenBounds = jest.fn(() => ({
+			left: 0,
+			right: 100,
+			top: 0,
+			bottom: 100,
+		}));
+		activeCreature.xray = jest.fn();
+		otherCreature.xray = jest.fn();
+
+		const targetHex = Object.create(Hex.prototype) as Hex;
+		targetHex.game = game as never;
+		targetHex.displayPos = { x: 0, y: 0 };
+		targetHex.width = 100;
+		targetHex.height = 100;
+		Object.defineProperty(targetHex, 'creature', {
+			value: undefined,
+			configurable: true,
+		});
+
+		targetHex.ghostOverlap();
+
+		expect(activeCreature.xray).not.toHaveBeenCalled();
+		expect(otherCreature.xray).toHaveBeenCalledWith(true);
+	});
+});

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -1805,6 +1805,8 @@ export class Creature {
 }
 
 class CreatureSprite {
+	private static readonly XRAY_ALPHA = 0.3;
+
 	private _group: Phaser.Group;
 	private _sprite: Phaser.Sprite;
 	private _hintGrp: Phaser.Group;
@@ -1978,7 +1980,7 @@ class CreatureSprite {
 		this._isXray = enable;
 		this._phaser.add
 			.tween(this._sprite)
-			.to({ alpha: enable ? 0.5 : 1.0 }, 250, Phaser.Easing.Linear.None)
+			.to({ alpha: enable ? CreatureSprite.XRAY_ALPHA : 1.0 }, 250, Phaser.Easing.Linear.None)
 			.start();
 		this._phaser.add
 			.tween(this._healthIndicatorGroup)

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -73,6 +73,13 @@ type Status = {
 	dizzy: boolean;
 };
 
+type ScreenBounds = {
+	left: number;
+	right: number;
+	top: number;
+	bottom: number;
+};
+
 /**
  * Creature Class
  *
@@ -1672,6 +1679,10 @@ export class Creature {
 		this.creatureSprite.xray(enable);
 	}
 
+	getScreenBounds(): ScreenBounds | null {
+		return this.creatureSprite?.getScreenBounds() ?? null;
+	}
+
 	pickupDrop() {
 		getPointFacade()
 			.getDropsAt(this)
@@ -1973,6 +1984,26 @@ class CreatureSprite {
 			.tween(this._healthIndicatorGroup)
 			.to({ alpha: enable ? 0.5 : 1.0 }, 250, Phaser.Easing.Linear.None)
 			.start();
+	}
+
+	getScreenBounds(): ScreenBounds | null {
+		const texture = this._sprite.texture;
+		const width = Math.abs(this._sprite.width || texture?.width || 0);
+		const height = Math.abs(this._sprite.height || texture?.height || 0);
+
+		if (!width || !height) {
+			return null;
+		}
+
+		const centerX = this._group.x + this._sprite.x;
+		const bottomY = this._group.y + this._sprite.y;
+
+		return {
+			left: centerX - width / 2,
+			right: centerX + width / 2,
+			top: bottomY - height,
+			bottom: bottomY,
+		};
 	}
 
 	setHealth(number: number, type: HealthBubbleType) {

--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -23,6 +23,13 @@ export enum Direction {
 
 const shrinkScale = 0.5;
 
+type ScreenBounds = {
+	left: number;
+	right: number;
+	top: number;
+	bottom: number;
+};
+
 /**
  * Object containing hex information and positions.
  */
@@ -333,51 +340,35 @@ export class Hex {
 	}
 
 	/**
-	 * Add ghosted class to creature on hexes behind this hex
+	 * X-ray creatures whose sprites overlap this hex on screen.
 	 */
 	ghostOverlap() {
-		const grid = this.grid || this.game.grid;
-		let ghostedCreature;
+		const targetBounds = this.getScreenBounds();
+		const targetCreature = this.creature;
 
-		for (let i = 1; i <= 3; i++) {
-			if (this.y % 2 == 0) {
-				if (i == 1) {
-					for (let j = 0; j <= 1; j++) {
-						if (grid.hexExists({ y: this.y + i, x: this.x + j })) {
-							if (grid.hexes[this.y + i][this.x + j].creature instanceof Creature) {
-								ghostedCreature = grid.hexes[this.y + i][this.x + j].creature;
-							}
-						}
-					}
-				} else {
-					if (grid.hexExists({ y: this.y + i, x: this.x })) {
-						if (grid.hexes[this.y + i][this.x].creature instanceof Creature) {
-							ghostedCreature = grid.hexes[this.y + i][this.x].creature;
-						}
-					}
-				}
-			} else {
-				if (i == 1) {
-					for (let j = 0; j <= 1; j++) {
-						if (grid.hexExists({ y: this.y + i, x: this.x - j })) {
-							if (grid.hexes[this.y + i][this.x - j].creature instanceof Creature) {
-								ghostedCreature = grid.hexes[this.y + i][this.x - j].creature;
-							}
-						}
-					}
-				} else {
-					if (grid.hexExists({ y: this.y + i, x: this.x })) {
-						if (grid.hexes[this.y + i][this.x].creature instanceof Creature) {
-							ghostedCreature = grid.hexes[this.y + i][this.x].creature;
-						}
-					}
-				}
+		this.game.creatures.forEach((creature) => {
+			if (!(creature instanceof Creature) || creature === targetCreature) {
+				return;
 			}
 
-			if (ghostedCreature instanceof Creature) {
-				ghostedCreature.xray(true);
+			const creatureBounds = creature.getScreenBounds();
+			if (creatureBounds && this.boundsOverlap(targetBounds, creatureBounds)) {
+				creature.xray(true);
 			}
-		}
+		});
+	}
+
+	getScreenBounds(): ScreenBounds {
+		return {
+			left: this.displayPos.x,
+			right: this.displayPos.x + this.width,
+			top: this.displayPos.y,
+			bottom: this.displayPos.y + this.height,
+		};
+	}
+
+	private boundsOverlap(a: ScreenBounds, b: ScreenBounds) {
+		return a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top;
 	}
 
 	/**

--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -345,9 +345,14 @@ export class Hex {
 	ghostOverlap() {
 		const targetBounds = this.getScreenBounds();
 		const targetCreature = this.creature;
+		const activeCreature = this.game.activeCreature;
 
 		this.game.creatures.forEach((creature) => {
-			if (!(creature instanceof Creature) || creature === targetCreature) {
+			if (
+				!(creature instanceof Creature) ||
+				creature === targetCreature ||
+				creature === activeCreature
+			) {
 				return;
 			}
 

--- a/test/fileMock.js
+++ b/test/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';


### PR DESCRIPTION
## Summary
- replace the hardcoded 3-row x-ray scan with screen-space overlap checks
- x-ray any creature whose sprite actually covers the targeted hex, including same-row and higher-row cases
- keep the existing alpha-only x-ray presentation with no tinting or extra visual effects

## Verification
- npm run lint -- --quiet
- npm run build
- npx jest --runInBand src/__tests__/creature.ts

## Notes
- This supersedes #2842 after its force-pushed branch history became unusable for review/reopen.

Fixes #2617