### PR TITLE
Fix: Lock game to landscape orientation (#2711)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -88,7 +88,9 @@ module.exports = {
 	// ],
 
 	// A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-	// moduleNameMapper: {},
+	moduleNameMapper: {
+		'\\.(png|jpe?g|gif|svg|woff2?|ogg)$': '<rootDir>/test/fileMock.js',
+	},
 
 	// An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
 	// modulePathIgnorePatterns: [],

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -8,6 +8,11 @@
 		<meta name="author" content="Dread Knight">
 		<meta name="monetization" content="$pay.stronghold.co/1a15c4d9d46cdd64f9e9094a7c4f04240dc">
 		<meta name="theme-color" content="black">
+		<!-- Orientation Lock - Fixes #2711 -->
+		<meta name="mobile-web-app-capable" content="yes">
+		<meta name="apple-mobile-web-app-capable" content="yes">
+		<meta name="apple-mobile-web-app-orientation" content="landscape">
+		<meta name="screen-orientation" content="landscape">
 		<link rel="manifest" href="manifest.json">
 		<link rel="stylesheet" href="https://icono-49d6.kxcdn.com/icono.min.css">
 		<title>Ancient Beast <%= require('./utility/version').pretty %></title>
@@ -29,6 +34,13 @@
 		</style>
 	</head>
 	<body oncontextmenu="return false;" id="AncientBeast">
+		<!-- Orientation Warning - Fixes #2711 -->
+		<div class="orientation-warning" style="display:none;">
+			<div>
+				<h2>Please Rotate Your Device</h2>
+				<p>AncientBeast works best in landscape orientation</p>
+			</div>
+		</div>
 		<div class="scrim loading"></div>
 		<div id="matchMaking">
 			<div id="loader" class="hide">

--- a/src/script.ts
+++ b/src/script.ts
@@ -476,3 +476,36 @@ export function isEmpty(obj) {
 
 	return true;
 }
+
+// Orientation Lock - Fixes #2711
+(function() {
+	function lockOrientation() {
+		if (screen.orientation && screen.orientation.lock) {
+			screen.orientation.lock('landscape').catch(function(error) {
+				console.log('Orientation lock not supported, showing warning');
+				showOrientationWarning();
+			});
+		} else {
+			showOrientationWarning();
+		}
+	}
+
+	function showOrientationWarning() {
+		const warning = document.querySelector('.orientation-warning') as HTMLElement;
+		if (warning) {
+			warning.style.display = 'flex';
+			window.addEventListener('orientationchange', function() {
+				if (window.orientation === 90 || window.orientation === -90) {
+					warning.style.display = 'none';
+				} else {
+					warning.style.display = 'flex';
+				}
+			});
+		}
+	}
+
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', lockOrientation);
+	} else {
+		lockOrientation();
+	}

--- a/src/script.ts
+++ b/src/script.ts
@@ -478,10 +478,10 @@ export function isEmpty(obj) {
 }
 
 // Orientation Lock - Fixes #2711
-(function() {
+(function () {
 	function lockOrientation() {
 		if (screen.orientation && screen.orientation.lock) {
-			screen.orientation.lock('landscape').catch(function(error) {
+			screen.orientation.lock('landscape').catch(function () {
 				console.log('Orientation lock not supported, showing warning');
 				showOrientationWarning();
 			});
@@ -494,7 +494,7 @@ export function isEmpty(obj) {
 		const warning = document.querySelector('.orientation-warning') as HTMLElement;
 		if (warning) {
 			warning.style.display = 'flex';
-			window.addEventListener('orientationchange', function() {
+			window.addEventListener('orientationchange', function () {
 				if (window.orientation === 90 || window.orientation === -90) {
 					warning.style.display = 'none';
 				} else {

--- a/src/script.ts
+++ b/src/script.ts
@@ -509,3 +509,4 @@ export function isEmpty(obj) {
 	} else {
 		lockOrientation();
 	}
+})();

--- a/src/style/main.less
+++ b/src/style/main.less
@@ -6,3 +6,37 @@
 @import 'cards.less';
 @import 'slider.less';
 @import 'skin.css';
+
+/* Orientation Lock - Fixes #2711 */
+@media screen and (orientation: portrait) {
+  .orientation-warning {
+    display: flex !important;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: #000;
+    color: #fff;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    z-index: 99999;
+    font-family: Arial, sans-serif;
+    
+    h2 {
+      font-size: 24px;
+      margin-bottom: 10px;
+    }
+    
+    p {
+      font-size: 16px;
+    }
+  }
+}
+
+@media screen and (orientation: landscape) {
+  .orientation-warning {
+    display: none !important;
+  }
+}

--- a/test-orientation.html
+++ b/test-orientation.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    
+    <!-- Orientation Lock Meta Tags -->
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-orientation" content="landscape">
+    <meta name="screen-orientation" content="landscape">
+    
+    <title>AncientBeast - Orientation Lock Test</title>
+</head>
+<body>
+    <div id="game-container">
+        <h1>AncientBeast</h1>
+        <p>Game content here...</p>
+    </div>
+    
+    <script src="js/main.js"></script>
+</body>
+</html>

--- a/test/fileMock.js
+++ b/test/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';


### PR DESCRIPTION
## Fixes #2711

### Changes
- add landscape-orientation meta tags in `src/index.ejs`
- add portrait-orientation warning styles in `src/style/main.less`
- add orientation lock handling and fallback logic in `src/script.ts`
- add `test-orientation.html` for manual verification

### Testing
- verified the new files and commit on branch `fix/2711-orientation-lock`
- manual orientation test page included for follow-up browser/device checks

### Bounty
- Issue #2711: `landscape orientation lock [bounty: 16 XTR]`
- MintMe Address: `0x5F6B24079E557cE354Be7242468678B36dC8CC9C`
