### PR TITLE
Fix unit stats UI and restore tooltips in Dash View

### DIFF
--- a/src/creature.ts
+++ b/src/creature.ts
@@ -161,6 +161,7 @@ export class Creature {
 	remainingMove: number;
 	abilities: Ability[];
 	accumulatedTeleportRange = 0; // Used for Abolished's third ability
+	statsModifiers: { [key: string]: { name: string; value: number | string }[] } = {};
 
 	creatureSprite: CreatureSprite;
 
@@ -1458,16 +1459,23 @@ export class Creature {
 		this.creatureSprite.hint(text, hintType);
 	}
 
-	/**
-	 * Update the stats taking into account the effects' alteration
-	 */
 	updateAlteration() {
 		this.stats = { ...this.baseStats };
+		this.statsModifiers = {};
 
 		const buffDebuffArray = [...this.effects, ...this.dropCollection];
 
 		buffDebuffArray.forEach((buff) => {
-			$j.each(buff.alterations, (key, value) => {
+			Object.keys(buff.alterations).forEach((key) => {
+				const value = buff.alterations[key];
+				if (!this.statsModifiers[key]) {
+					this.statsModifiers[key] = [];
+				}
+				this.statsModifiers[key].push({
+					name: buff.name,
+					value: value,
+				});
+
 				if (typeof value === 'string') {
 					// Multiplication Buff
 					if (value.match(/\*/)) {

--- a/src/ui/interface.ts
+++ b/src/ui/interface.ts
@@ -992,6 +992,7 @@ export class UI {
 			creatureType == '--'
 		) {
 			// retrieve the selected unit
+			this.selectedCreatureObj = null;
 			game.players[player].creatures.forEach((creature) => {
 				if (creature.type == creatureType) {
 					this.selectedCreatureObj = creature;
@@ -1016,8 +1017,11 @@ export class UI {
 				)}')`,
 			});
 			$j.each(stats.stats, (key, value) => {
-				const $stat = $j('#card .sideB .' + key + ' .value');
+				const $statWrap = $j('#card .sideB .' + key);
+				const $stat = $statWrap.find('.value');
 				$stat.removeClass('buff debuff');
+				$statWrap.find('.modifiers').remove();
+
 				if (this.selectedCreatureObj) {
 					if (key == 'health') {
 						$stat.text(this.selectedCreatureObj.health + '/' + this.selectedCreatureObj.stats[key]);
@@ -1034,12 +1038,30 @@ export class UI {
 					} else {
 						$stat.text(this.selectedCreatureObj.stats[key]);
 					}
-					if (this.selectedCreatureObj.stats[key] > value) {
-						// Buff
-						$stat.addClass('buff');
-					} else if (this.selectedCreatureObj.stats[key] < value) {
-						// Debuff
-						$stat.addClass('debuff');
+
+					// Buff/Debuff colors only for materialized/alive units
+					if (!this.selectedCreatureObj.temp && !this.selectedCreatureObj.dead) {
+						if (this.selectedCreatureObj.stats[key] > value) {
+							// Buff
+							$stat.addClass('buff');
+						} else if (this.selectedCreatureObj.stats[key] < value) {
+							// Debuff
+							$stat.addClass('debuff');
+						}
+
+						// Modifiers Tooltip
+						if (
+							this.selectedCreatureObj.statsModifiers[key] &&
+							this.selectedCreatureObj.statsModifiers[key].length > 0
+						) {
+							let modifiersHTML = '<div class="modifiers">';
+							this.selectedCreatureObj.statsModifiers[key].forEach((mod) => {
+								const sign = typeof mod.value === 'number' && mod.value > 0 ? '+' : '';
+								modifiersHTML += `<div>${mod.name}: ${sign}${mod.value}</div>`;
+							});
+							modifiersHTML += '</div>';
+							$statWrap.append(modifiersHTML);
+						}
 					}
 				} else {
 					$stat.text(value);


### PR DESCRIPTION
This PR fixes the unit stats and masteries UI in the Dash View. 
- It ensures stats update correctly when switching units.
- It shows white stats for unmaterialized units browsing the pool.
- It restores the hover tooltips for stat modifiers by tracking them in the Creature class.
fixes #2852
My XDC wallet address is: xdc31ad70bb6a4c99f47c482b2c923bad472e9d662f
