### PR TITLE
fix: downgrade copy-webpack-plugin to 13.0.1 for Node.js 18 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"babel-loader": "^9.1.0",
 		"babel-plugin-transform-runtime": "^6.23.0",
 		"babel-polyfill": "^6.26.0",
-		"copy-webpack-plugin": "^14.0.0",
+		"copy-webpack-plugin": "^13.0.1",
 		"cross-env": "^7.0.2",
 		"css-loader": "^6.7.3",
 		"dotenv": "^16.0.3",


### PR DESCRIPTION
## Summary
Downgrade copy-webpack-plugin from ^14.0.0 to ^13.0.1 to fix the production build error:

```
TypeError: [...copiedResultMap.entries()].toSorted is not a function
at /home/runner/work/AncientBeast/AncientBeast/node_modules/copy-webpack-plugin/dist/index.js:747:61
```

## Root Cause
The .toSorted() method is ES2023 and not supported in Node.js 18.x (which the CI uses). Version 14.0.0 of copy-webpack-plugin uses .toSorted(), while version 13.0.1 uses the compatible .sort() method.

## Fix
Changed package.json from:
```json
"copy-webpack-plugin": "^14.0.0"
```
to:
```json
"copy-webpack-plugin": "^13.0.1"
```

## Verification
- npm install successfully installs copy-webpack-plugin@13.0.1
- `npx webpack --mode=production` builds successfully without the TypeError

---
**Payment**: 9 XTR to address: `YOUR_XTR_WALLET_ADDRESS` (please update with actual address)