### PR TITLE
feat: Goey Body upgrade revamp - leap over units

### DIFF
--- a/src/abilities/Gumble.ts
+++ b/src/abilities/Gumble.ts
@@ -17,11 +17,20 @@ export default (G: Game) => {
 	G.abilities[14] = [
 		// First Ability: Gooey Body
 		{
-			// Trigger when Gumble dies
+			/**
+			 * When upgraded, allows Gumble to leap over units during movement phase
+			 * (flying movement type).
+			 */
+			movementType: function () {
+				return this.isUpgraded() ? 'flying' : 'normal';
+			},
+
+			// Trigger when Gumble dies (only when not upgraded)
 			trigger: 'onCreatureDeath',
 
 			require: function () {
-				return true;
+				// Only trigger on death when NOT upgraded (upgraded version provides leap ability instead)
+				return !this.isUpgraded();
 			},
 
 			activate: function (deadCreature: Creature) {
@@ -39,20 +48,10 @@ export default (G: Game) => {
 						deathHex,
 						'onStepIn',
 						{
-							// Check if creature should be affected by the goo
+							// Always affect all units (allies and enemies)
 							requireFn: function () {
 								const creatureOnGoo = this.trap.hex.creature;
-								if (!creatureOnGoo) {
-									return false;
-								}
-
-								// If upgraded, don't affect allied units
-								if (ability.isUpgraded()) {
-									return creatureOnGoo.player !== ability.creature.player;
-								}
-
-								// Otherwise affect all units
-								return true;
+								return !!creatureOnGoo;
 							},
 							effectFn: function (_, creature: Creature) {
 								// Pin the creature in place for the current round

--- a/src/ui/interface.ts
+++ b/src/ui/interface.ts
@@ -92,6 +92,11 @@ export class UI {
 	queueAnimSpeed: number;
 	dashAnimSpeed: number;
 	materializeToggled: boolean;
+	/**
+	 * Guard to prevent re-entrancy in Dark Priest materialization flow.
+	 * Prevents double-clicking the materialize button while already picking a hex.
+	 */
+	materializeInProgress: boolean;
 	glowInterval: ReturnType<typeof setInterval>;
 	lastTurnWarningSecond: number | null;
 	lastTurnWarningPlayerId: number | null;
@@ -668,6 +673,7 @@ export class UI {
 		this.dashAnimSpeed = 250; // ms
 
 		this.materializeToggled = false;
+		this.materializeInProgress = false;
 		this.lastTurnWarningSecond = null;
 		this.lastTurnWarningPlayerId = null;
 		this.dashopen = false;


### PR DESCRIPTION
## Description

Revamps the Goey Body upgrade (ability #1 for Gumble) to allow Gumble to leap over units during the movement phase instead of the confusing death trap behavior.

### Changes:
- Added  function that returns  when upgraded, allowing Gumble to leap over units during movement
- Non-upgraded ability retains the original death trap behavior (now simplified to affect all units)
- Upgraded ability provides the flying movement type, enabling Gumble to bypass units when moving

### Issue:
Fixes #2850 - Goey Body upgrade revamp

The previous upgrade only prevented the death trap from affecting allies, which was confusing. The new upgrade gives Gumble a useful flying movement ability instead.

### Testing:
- TypeScript compilation passes for Gumble.ts
- Build has pre-existing errors unrelated to this change (in script.ts)