### PR TITLE
fix: buff/debuff colors only for materialized/alive creatures in dash view (#2852)

### DIFF
--- a/src/ui/interface.ts
+++ b/src/ui/interface.ts
@@ -992,6 +992,7 @@ export class UI {
 			creatureType == '--'
 		) {
 			// retrieve the selected unit
+			this.selectedCreatureObj = undefined;
 			game.players[player].creatures.forEach((creature) => {
 				if (creature.type == creatureType) {
 					this.selectedCreatureObj = creature;
@@ -1034,12 +1035,16 @@ export class UI {
 					} else {
 						$stat.text(this.selectedCreatureObj.stats[key]);
 					}
-					if (this.selectedCreatureObj.stats[key] > value) {
-						// Buff
-						$stat.addClass('buff');
-					} else if (this.selectedCreatureObj.stats[key] < value) {
-						// Debuff
-						$stat.addClass('debuff');
+					// Only show buff/debuff colors for materialized and alive creatures
+					// Browsing dead or non-materialized units should show white
+					if (!this.selectedCreatureObj.dead && !this.selectedCreatureObj.materializationSickness) {
+						if (this.selectedCreatureObj.stats[key] > value) {
+							// Buff
+							$stat.addClass('buff');
+						} else if (this.selectedCreatureObj.stats[key] < value) {
+							// Debuff
+							$stat.addClass('debuff');
+						}
 					}
 				} else {
 					$stat.text(value);


### PR DESCRIPTION
## Fix for Issue #2852: buffs/debuffs for stats and masteries

### Problem
When browsing units in the dash view, stats and masteries in card B were incorrectly displayed with green (buff) or red (debuff) colors even for dead or not-yet-materialized units. Additionally, stats weren't updating properly when switching between different units.

### Root Causes
1. **Stale creature reference**: `selectedCreatureObj` was never reset when browsing between units, so it could hold a reference to a previously selected creature
2. **Incorrect color logic**: Buff/debuff colors were applied whenever `selectedCreatureObj` existed, without checking if the creature was actually materialized and alive

### Changes Made (`src/ui/interface.ts`)
1. **Reset creature reference** before searching: `this.selectedCreatureObj = undefined` added before the forEach loop to prevent stale data
2. **Guard buff/debuff coloring**: Only apply `.buff` (green) and `.debuff` (red) classes when the creature is both:
   - Not dead (`!creature.dead`)
   - Not in materialization sickness (`!creature.materializationSickness`)

### Result
- Dead or non-materialized units now display stats in white (no color)
- Only truly active, materialized creatures show buff/debuff colors when their stats differ from base values
- Stats correctly update when browsing between different units

---
**Bounty**: 60 XTR | **Payment Address**: eB51DWp1uECrLZRLsE2cnyZUzfRWvzUzaJzkatTpQV9
