### PR TITLE
fix: suppress redundant combat log for Toxic Spores passive (#2171)

### DIFF
--- a/src/abilities/Uncle-Fungus.ts
+++ b/src/abilities/Uncle-Fungus.ts
@@ -56,7 +56,7 @@ export default (G: Game) => {
 					stackable: true,
 				};
 
-				this.end();
+				this.end(true);
 
 				// Spore Contamination
 				const effect = new Effect(


### PR DESCRIPTION
## Summary

When Uncle Fungus' Toxic Spores passive ability triggers on a melee attack, it was showing a redundant `Uncle Fungus uses Toxic Spores` message in the combat log.

This is similar to how Nutcase's Tentacle Bush passive works silently without logging a "uses" message when it triggers.

## Fix

In `src/abilities/Uncle-Fungus.ts`, the Toxic Spores `activate` function calls `this.end()` which by default logs `%CreatureName% uses %AbilityTitle%`. For a passive ability triggered via `onUnderAttack`, this creates redundant noise in the combat log.

The fix passes `disableLogMsg=true` to `end(true)` to suppress the generic "uses" message, while keeping the specific effect log (`target's regrowth is lowered by X`).

## Testing

- The specific effect log message (`%CreatureName%'s regrowth is lowered by X`) is still shown
- The generic `Uncle Fungus uses Toxic Spores` message is no longer shown

Closes #2171

---

收款地址：eB51DWp1uECrLZRLsE2cnyZUzfRWvzUzaJzkatTpQV9