### PR TITLE
fix: suppress redundant Toxic Spores log + improve Chilling Spit hit feel

### DIFF
--- a/src/abilities/Snow-Bunny.ts
+++ b/src/abilities/Snow-Bunny.ts
@@ -461,7 +461,6 @@ export default (G: Game) => {
 			activate: function (path, args) {
 				const ability = this;
 				ability.end();
-				G.Phaser.camera.shake(0.01, 90, true, G.Phaser.camera.SHAKE_HORIZONTAL, true);
 
 				const hexWithTarget = path.find((hex: Hex) => {
 					const creature = getPointFacade().getCreaturesAt({ x: hex.x, y: hex.y })[0];
@@ -492,6 +491,10 @@ export default (G: Game) => {
 				tween.onComplete.add(function () {
 					// @ts-expect-error this refers to the animation object, _not_ the ability
 					this.destroy();
+
+					// Hit feedback: shake screen and play sound when projectile reaches target
+					G.Phaser.camera.shake(0.01, 90, true, G.Phaser.camera.SHAKE_HORIZONTAL, true);
+					G.soundsys.playSFX('sounds/swing');
 
 					// Copy to not alter ability strength
 					const dmg = $j.extend({}, ability.damages);

--- a/src/abilities/Uncle-Fungus.ts
+++ b/src/abilities/Uncle-Fungus.ts
@@ -56,7 +56,7 @@ export default (G: Game) => {
 					stackable: true,
 				};
 
-				this.end();
+				this.end(true);
 
 				// Spore Contamination
 				const effect = new Effect(


### PR DESCRIPTION
## Summary

Fixes two bounty issues:

### #2171 - redundancy suppression for Toxic Spores ability
Uncle Fungus's Toxic Spores passive was logging 'Uncle Fungus uses Toxic Spores' redundantly alongside the melee attack log. Fixed by passing `disableLogMsg=true` to `this.end()`, consistent with Nutcase's Tentacle Bush approach.

### #2234 - Chilling Spit improved hit feel
Snow Bunny's Freezing Spit ability was shaking the screen immediately upon activation rather than when the projectile actually hits. Fixed by moving the camera shake into the projectile's `onComplete` callback, and added a hit sound (`sounds/swing`) for better feedback.

## Testing
- Webpack build: ✅ compiled successfully
- Jest tests: ✅ 88 passed