### PR TITLE
fix: make card ability update function more lenient (#1996)

### DIFF
--- a/src/ui/interface.ts
+++ b/src/ui/interface.ts
@@ -1047,6 +1047,10 @@ export class UI {
 				applyBuffDebuffStyle($stat, this.selectedCreatureObj, key, value, isBrowsing);
 			});
 			$j.each(game.abilities[stats.id], (key) => {
+				// Skip if ability_info for this slot doesn't exist (e.g., non-playable units with incomplete data)
+				if (!stats.ability_info || !stats.ability_info[key]) {
+					return;
+				}
 				const $ability = $j('#card .sideB .abilities .ability:eq(' + key + ')');
 				$ability.children('.icon').css({
 					'background-image': `url('${getUrl('units/abilities/' + stats.name + ' ' + key)}')`,
@@ -1055,35 +1059,37 @@ export class UI {
 					.children('.wrapper')
 					.children('.info')
 					.children('h3')
-					.text(stats.ability_info[key].title);
+					.text(stats.ability_info[key].title || '');
 				$ability
 					.children('.wrapper')
 					.children('.info')
 					.children('#desc')
-					.text(stats.ability_info[key].desc);
+					.text(stats.ability_info[key].desc || '');
 				$ability
 					.children('.wrapper')
 					.children('.info')
 					.children('#info')
-					.text(stats.ability_info[key].info);
-				$ability
-					.children('.wrapper')
-					.children('.info')
-					.children('#upgrade')
-					.text('Upgrade: ' + stats.ability_info[key].upgrade);
+					.text(stats.ability_info[key].info || '');
+
+				if (stats.ability_info[key].upgrade) {
+					$ability
+						.children('.wrapper')
+						.children('.info')
+						.children('#upgrade')
+						.text('Upgrade: ' + stats.ability_info[key].upgrade);
+				} else {
+					$ability.children('.wrapper').children('.info').children('#upgrade').text('');
+				}
 
 				if (stats.ability_info[key].costs !== undefined && key !== 0) {
+					const energyCost = stats.ability_info[key].costs.energy;
 					$ability
 						.children('.wrapper')
 						.children('.info')
 						.children('#cost')
-						.text(' - costs ' + stats.ability_info[key].costs.energy + ' energy pts.');
+						.text(energyCost !== undefined ? ' - costs ' + energyCost + ' energy pts.' : '');
 				} else {
-					$ability
-						.children('.wrapper')
-						.children('.info')
-						.children('#cost')
-						.text(' - this ability is passive.');
+					$ability.children('.wrapper').children('.info').children('#cost').text('');
 				}
 			});
 
@@ -1262,17 +1268,14 @@ export class UI {
 				}
 
 				if (stats.ability_info[key].costs !== undefined && key !== 0) {
+					const energyCost = stats.ability_info[key].costs.energy;
 					$ability
 						.children('.wrapper')
 						.children('.info')
 						.children('#cost')
-						.text(' - costs ' + stats.ability_info[key].costs.energy + ' energy pts.');
+						.text(energyCost !== undefined ? ' - costs ' + energyCost + ' energy pts.' : '');
 				} else {
-					$ability
-						.children('.wrapper')
-						.children('.info')
-						.children('#cost')
-						.text(' - this ability is passive.');
+					$ability.children('.wrapper').children('.info').children('#cost').text('');
 				}
 			});
 


### PR DESCRIPTION
## Fix: Make card ability update function more lenient

### Problem
The game's dash (unit card viewer) crashes or displays incomplete info when browsing units with incomplete ability data (e.g., non-playable units like Kraken where some energy values haven't been defined). The function was too strict and would either crash or show 'undefined' for missing values.

### Solution
1. **Skip missing ability_info slots**: Added a guard to skip ability slots where `stats.ability_info[key]` doesn't exist (e.g., non-playable units with incomplete data)
2. **Safe text fallback**: Use empty string fallback for missing title/desc/info fields
3. **Conditional upgrade display**: Show upgrade text only when the upgrade field exists, otherwise clear the field
4. **Safe energy cost display**: Show energy cost only when the energy value is defined (avoids 'undefined' display). If costs exist but energy is undefined, show empty string instead.
5. **No more incorrect 'this ability is passive'**: Changed the else branch to show empty string instead of incorrectly labeling all abilities without costs as passive

### Testing
- All 88 existing tests pass
- ESLint reports 0 errors

Closes #1996
