### PR TITLE
Implement Goey Body upgrade: leap over units during movement

### DIFF
--- a/src/abilities/Gumble.ts
+++ b/src/abilities/Gumble.ts
@@ -24,6 +24,15 @@ export default (G: Game) => {
 				return true;
 			},
 
+			/**
+			 * Provides leap movement when upgraded.
+			 * Allows Gumble to leap over units when moving at least 2 hexagons.
+			 * @return {string} movement type, 'leap' when upgraded, undefined otherwise
+			 */
+			movementType: function () {
+				return this.isUpgraded() ? 'leap' : undefined;
+			},
+
 			activate: function (deadCreature: Creature) {
 				const deathHex = G.grid.hexAt(deadCreature.x, deadCreature.y);
 

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -40,7 +40,7 @@ export type CreatureMasteries = {
 	mental: number;
 };
 
-export type Movement = 'normal' | 'flying' | 'hover';
+export type Movement = 'normal' | 'flying' | 'hover' | 'leap';
 
 type CreatureStats = CreatureVitals &
 	CreatureMasteries & {
@@ -718,6 +718,8 @@ export class Creature {
 
 		if (this.movementType() === 'flying') {
 			o.range = game.grid.getFlyingRange(this.x, this.y, remainingMove, this.size, this.id);
+		} else if (this.movementType() === 'leap') {
+			o.range = game.grid.getLeapRange(this.x, this.y, remainingMove, this.size, this.id);
 		}
 
 		const selectNormal = function (hex, args) {

--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -399,10 +399,11 @@ export class Hex {
 	 * @param {number} size - Size of the creature.
 	 * @param {number} id - ID of the creature.
 	 * @param {boolean} ignoreReachable - Take into account the reachable property.
+	 * @param {boolean} ignoreCreatures - Ignore creatures when checking walkability (for leap movement).
 	 * @param {boolean} debug - If true and const.DEBUG is true, print debug information to the console.
 	 * @returns True if this hex is walkable.
 	 */
-	isWalkable(size: number, id: number, ignoreReachable = false, debug = false) {
+	isWalkable(size: number, id: number, ignoreReachable = false, ignoreCreatures = false, debug = false) {
 		// NOTE: If not in DEBUG mode, don't debug.
 		debug = DEBUG && debug;
 
@@ -421,7 +422,7 @@ export class Hex {
 				}
 
 				let isNotMovingCreature;
-				if (hex.creature instanceof Creature) {
+				if (hex.creature instanceof Creature && !ignoreCreatures) {
 					isNotMovingCreature = hex.creature.id !== id;
 					blocked = blocked || isNotMovingCreature; // Not blocked if this block contains the moving creature
 				}

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -1363,12 +1363,12 @@ export class HexGrid {
 	 * @param {number} id - Integer: Creature ID
 	 * @returns {Hex[]} Set of the reachable hexes
 	 */
-	getMovementRange(x, y, distance, size, id) {
+	getMovementRange(x, y, distance, size, id, ignoreCreatures = false) {
 		//	Populate distance (hex.g) in hexes by asking an impossible
 		//	destination to test all hexagons
 		this.cleanReachable(); // If not pathfinding will bug
 		this.cleanPathAttr(true); // Erase all pathfinding data
-		search(this.hexes[y][x], new Hex(-2, -2, null, this.game), size, id, this.game.grid);
+		search(this.hexes[y][x], new Hex(-2, -2, null, this.game), size, id, this.game.grid, ignoreCreatures);
 
 		// Gather all the reachable hexes
 		const hexes: Hex[] = [];
@@ -1397,6 +1397,27 @@ export class HexGrid {
 		hexes = hexes.filter((hex) => hex.isWalkable(size, id, true));
 
 		return arrayUtils.extendToLeft(hexes, size, this.game.grid);
+	}
+
+	/**
+	 * Get movement range for leap movement (ignores creature collision, requires 2+ hex path).
+	 * Used by abilities like Gumble's Goey Body upgrade.
+	 * @param {number} x - Start x position
+	 * @param {number} y - Start y position
+	 * @param {number} distance - Maximum movement distance
+	 * @param {number} size - Creature size
+	 * @param {number} id - Creature ID
+	 * @returns {Hex[]} Set of reachable hexes (paths of 2+ hexes only)
+	 */
+	getLeapRange(x, y, distance, size, id) {
+		// Get movement range ignoring creatures
+		const hexes = this.getMovementRange(x, y, distance, size, id, true);
+		// Filter to only include hexes that are at least 2 hexes away
+		// (hex.g represents the path length from start)
+		return hexes.filter((hex) => {
+			const targetHex = this.hexes[hex.y][hex.x];
+			return targetHex.g >= 2;
+		});
 	}
 
 	/**

--- a/src/utility/pathfinding.ts
+++ b/src/utility/pathfinding.ts
@@ -8,6 +8,7 @@ import { HexGrid } from './hexgrid';
  * @param {number} creatureSize - The size of the creature who will walk the searched path
  * @param {number} creatureId - The id of the creature who will walk the searched path
  * @param {HexGrid} grid - The HexGrid instance to search
+ * @param {boolean} ignoreCreatures - If true, ignore creatures when checking walkability (for leap movement)
  * @returns {Hex[]} A path of hexes or an empty array if no path is found
  */
 export function search(
@@ -16,6 +17,7 @@ export function search(
 	creatureSize: number,
 	creatureId: number,
 	grid: HexGrid,
+	ignoreCreatures = false,
 ): Hex[] {
 	const openList = [];
 	const closedList = [];
@@ -56,7 +58,7 @@ export function search(
 
 			if (
 				arrayUtils.findPos(closedList, neighbor) ||
-				!neighbor.isWalkable(creatureSize, creatureId)
+				!neighbor.isWalkable(creatureSize, creatureId, false, ignoreCreatures)
 			) {
 				// Not a valid node to process, skip to next neighbor
 				continue;


### PR DESCRIPTION
Implements leap movement for Gumble's Goey Body ability when upgraded.
- Allows Gumble to leap over units when moving at least 2 hexagons
- Adds ignoreCreatures parameter to isWalkable and search functions
- Adds getLeapRange method in hexgrid
- Adds 'leap' movement type support in creature movement system

Fixes issue #2850
