### PR TITLE
Lock screen orientation to landscape on fullscreen entry

### DIFF
--- a/src/ui/fullscreen.ts
+++ b/src/ui/fullscreen.ts
@@ -35,11 +35,42 @@ export class Fullscreen {
 			this.button
 				.querySelectorAll('.fullscreen__title')
 				.forEach((el) => (el.textContent = 'Contract'));
+			// Lock orientation to landscape when entering fullscreen on mobile
+			this.lockOrientation();
 		} else {
 			this.button.classList.remove('fullscreenMode');
 			this.button
 				.querySelectorAll('.fullscreen__title')
 				.forEach((el) => (el.textContent = 'FullScreen'));
+			// Unlock orientation when exiting fullscreen
+			this.unlockOrientation();
+		}
+	}
+
+	/**
+	 * Lock screen orientation to landscape using the Screen Orientation API.
+	 * This requires fullscreen mode on most mobile browsers.
+	 */
+	private async lockOrientation() {
+		const screen = window.screen;
+		if (screen?.orientation?.lock) {
+			try {
+				await screen.orientation.lock('landscape');
+			} catch (error) {
+				// Orientation lock is not supported or blocked (e.g., not in fullscreen yet,
+				// or the device doesn't support locking). Silently ignore.
+				console.debug('Screen orientation lock not available:', error);
+			}
+		}
+	}
+
+	/**
+	 * Unlock screen orientation.
+	 */
+	private unlockOrientation() {
+		const screen = window.screen;
+		if (screen?.orientation?.unlock) {
+			screen.orientation.unlock();
 		}
 	}
 }


### PR DESCRIPTION
## Description
Implement landscape orientation lock using the Screen Orientation API when entering fullscreen mode on mobile devices.

## Changes
- Added `lockOrientation()` method that calls `screen.orientation.lock('landscape')` when entering fullscreen
- Added `unlockOrientation()` method that calls `screen.orientation.unlock()` when exiting fullscreen
- Both methods are called from `updateButtonState()` which is triggered by fullscreen change events

## Why
The game previously showed a message asking users to manually rotate their device. Now the Screen Orientation API is used to automatically lock the orientation to landscape when the user enters fullscreen, providing a better mobile gaming experience.

## Related Issue
Fixes #2711

## Payment
收款地址：eB51DWp1uECrLZRLsE2cnyZUzfRWvzUzaJzkatTpQV9