### PR TITLE
fix: block multiple file pickers when holding Ctrl+Meta+L (#2363)

### DIFF
--- a/src/script.ts
+++ b/src/script.ts
@@ -42,6 +42,9 @@ window.AB = AB;
 const connect = new Connect(G);
 G.connect = connect;
 
+// Guard flag to prevent multiple file pickers from opening when Ctrl+Meta+L is held down
+let filePickerOpen = false;
+
 // Load the abilities
 unitData.forEach(async (creature) => {
 	if (!creature.playable) {
@@ -132,7 +135,7 @@ $j(() => {
 		},
 		KeyL: {
 			keyDownTest(event) {
-				return event.metaKey && event.ctrlKey;
+				return event.metaKey && event.ctrlKey && !filePickerOpen;
 			},
 			keyDownAction() {
 				readLogFromFile()
@@ -395,6 +398,7 @@ function getReg() {
  * @returns {Promise<string>}
  */
 function readLogFromFile() {
+	filePickerOpen = true;
 	// TODO: This would probably be better off in ./src/utility/gamelog.ts
 	return new Promise((resolve, reject) => {
 		const fileInput = document.createElement('input') as HTMLInputElement;
@@ -402,7 +406,14 @@ function readLogFromFile() {
 		fileInput.type = 'file';
 
 		fileInput.onchange = (event) => {
+			filePickerOpen = false;
 			const file = (event.target as HTMLInputElement).files[0];
+
+			if (!file) {
+				resolve('');
+				return;
+			}
+
 			const reader = new FileReader();
 
 			reader.readAsText(file);


### PR DESCRIPTION
## Summary

Fixes #2363 - Block multiple file pickers when holding Ctrl+Meta+L

### Problem
Holding Ctrl+Meta+L in the pre-match screen causes multiple file pickers to appear due to key repeat triggering the hotkey multiple times.

### Solution
Added a module-level `filePickerOpen` flag that:
- Is checked in the KeyL hotkey's `keyDownTest` to prevent re-triggering while picker is open
- Is set to `true` when `readLogFromFile()` opens a file picker  
- Is reset to `false` in the `onchange` handler (fires on both file selection and cancel)

Also added handling for when user cancels the file picker (`files[0]` is null) to avoid passing null to FileReader.

### Testing
- [x] Build passes

### Bounty
Issue #2363 has a bounty of **2 XTR**. Payment address: eB51DWp1uECrLZRLsE2cnyZUzfRWvzUzaJzkatTpQV9