### PR TITLE
fix: cursor progress for inactive unit + block multiple file pickers (#2246, #2363)

### DIFF
--- a/src/script.ts
+++ b/src/script.ts
@@ -394,14 +394,28 @@ function getReg() {
  * read log from file
  * @returns {Promise<string>}
  */
+let isLoadingLogFile = false;
+
 function readLogFromFile() {
+	// Guard: prevent multiple file pickers from being opened
+	if (isLoadingLogFile) {
+		return Promise.resolve();
+	}
 	// TODO: This would probably be better off in ./src/utility/gamelog.ts
 	return new Promise((resolve, reject) => {
+		isLoadingLogFile = true;
+		// Fallback: reset flag after 5 seconds to prevent stuck state
+		const timeout = setTimeout(() => {
+			isLoadingLogFile = false;
+		}, 5000);
+
 		const fileInput = document.createElement('input') as HTMLInputElement;
 		fileInput.accept = '.ab';
 		fileInput.type = 'file';
 
 		fileInput.onchange = (event) => {
+			isLoadingLogFile = false;
+			clearTimeout(timeout);
 			const file = (event.target as HTMLInputElement).files[0];
 			const reader = new FileReader();
 

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -1023,7 +1023,7 @@ export class HexGrid {
 					hex.displayVisualState('creature player' + hex.creature.team);
 				}
 			} else if (game.activeCreature.noActionPossible) {
-				$j('canvas').css('cursor', 'wait');
+				$j('canvas').css('cursor', 'progress');
 			}
 			queueEffect(creature.id);
 		};


### PR DESCRIPTION
## Summary

Fixes two bounty issues:

### #2246 - cursor state to showcase active unit better [bounty: 6 XTR]
When hovering active unit, the cursor now turns into a 'progress' type pointer if there's no ability selected or unit is not a viable target. Previously used 'wait' cursor.

### #2363 - block multiple file pickers [bounty: 2 XTR]
Guards against multiple file pickers opening when Ctrl+Meta+L is held too long in the pre-match screen by tracking an `isLoadingLogFile` flag. The flag is set when opening the picker and cleared on onchange or after a 5 second timeout fallback.

## Changes
- `src/utility/hexgrid.ts`: Changed cursor from 'wait' to 'progress' for inactive units with no actions possible
- `src/script.ts`: Added `isLoadingLogFile` guard flag to `readLogFromFile()`
