### PR TITLE
fix: hexagon coordinate view tweaks (#2250)

### DIFF
--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -190,12 +190,14 @@ export class HexGrid {
 		this.trapGroup = game.Phaser.add.group(this.gridGroup, 'trapGrp');
 		this.hexesGroup = game.Phaser.add.group(this.gridGroup, 'hexesGroup');
 		this.displayHexesGroup = game.Phaser.add.group(this.gridGroup, 'displayHexesGroup');
-		this.overlayHexesGroup = game.Phaser.add.group(this.gridGroup, 'overlayHexesGroup');
 		this.dropGroup = game.Phaser.add.group(this.display, 'dropGrp');
 		this.creatureGroup = game.Phaser.add.group(this.display, 'creaturesGrp');
 		// Parts of traps displayed over creatures
 		this.trapOverGroup = game.Phaser.add.group(this.display, 'trapOverGrp');
 		this.trapOverGroup.scale.set(1, 0.75);
+		// overlayHexesGroup moved here so coordinates display on top of creatures
+		this.overlayHexesGroup = game.Phaser.add.group(this.display, 'overlayHexesGroup');
+		this.overlayHexesGroup.scale.set(1, 0.75);
 
 		// Populate grid
 		for (let row = 0; row < numRows; row++) {
@@ -1456,18 +1458,21 @@ export class HexGrid {
 
 	showGrid(val) {
 		this.forEachHex((hex) => {
-			if (hex.creature) {
-				hex.creature.xray(val);
-			}
-
 			if (hex.drop) {
 				return;
 			}
 
 			if (val) {
 				hex.displayVisualState('showGrid');
+				// Show dashed overlay at 25% opacity for non-unit occupied hexes
+				if (!hex.creature) {
+					hex.overlay.loadTexture('hex_dashed');
+					hex.overlay.alpha = 0.25;
+				}
 			} else {
 				hex.cleanDisplayVisualState('showGrid');
+				// Restore overlay opacity
+				hex.overlay.alpha = 1;
 			}
 		});
 	}


### PR DESCRIPTION
## Summary

Fixes bounty issue #2250 - hexagon coordinate view tweaks [bounty: 7 XTR]

### Changes Made:

1. **Removed x-ray mode on units**: When the coordinate grid is shown, units no longer go into x-ray (50% opacity) mode, which was described as tedious.

2. **Coordinates now display on top of units**: Moved `overlayHexesGroup` from being a child of `gridGroup` to being a direct child of `display`, positioned after `creatureGroup`. This ensures coordinates are visible above creatures.

3. **Dashed hex overlay at 25% opacity for empty hexes**: When the coordinate view is active, non-unit hexes now display a dashed overlay at 25% opacity, making the grid clearly visible without obstructing the view of units.

## Technical Details

- `src/utility/hexgrid.ts`: 
  - Reordered group hierarchy to place `overlayHexesGroup` above `creatureGroup`
  - Modified `showGrid()` to remove xray calls and add dashed overlay for empty hexes
  - Applied consistent scale (1, 0.75) to the moved group for proper positioning
