### PR TITLE
feat: less distracting HUD when fullscreen views are open (fixes #2092)

### DIFF
--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -288,6 +288,16 @@
 	display: block;
 	width: 0;
 	height: 0;
+
+	// Less distracting HUD when fullscreen views (dash, scoreboard, music player) are open
+	&.hud-transparent {
+		#toppanel,
+		#bottompanel,
+		#leftpanel,
+		#rightpanel {
+			opacity: 0.1;
+		}
+	}
 }
 
 #toppanel {
@@ -295,6 +305,7 @@
 	top: 0;
 	width: 100%;
 	z-index: 3;
+	transition: opacity 250ms;
 }
 
 #bottompanel {
@@ -303,6 +314,7 @@
 	height: 0;
 	width: 100%;
 	z-index: 1;
+	transition: opacity 250ms;
 }
 
 #rightpanel {
@@ -310,12 +322,14 @@
 	right: 0px;
 	top: 0px;
 	z-index: 3;
+	transition: opacity 250ms;
 }
 
 #leftpanel {
 	position: absolute;
 	left: 0;
 	z-index: 3;
+	transition: opacity 250ms;
 }
 
 .button:not(.togglescore) {

--- a/src/ui/interface.ts
+++ b/src/ui/interface.ts
@@ -755,6 +755,16 @@ export class UI {
 		}
 	}
 
+	/**
+	 * Update HUD transparency based on whether any fullscreen view is open.
+	 * When dash, scoreboard, or music player is shown, the HUD becomes less distracting
+	 * by fading to low opacity.
+	 */
+	private _updateHudTransparency() {
+		const anyViewOpen = this.dashopen || !this.$scoreboard.hasClass('hide') || !$j('#musicplayerwrapper').hasClass('hide');
+		this.$display.toggleClass('hud-transparent', anyViewOpen);
+	}
+
 	showAbilityCosts(abilityId: number) {
 		const game = this.game,
 			creature = game.activeCreature,
@@ -1420,10 +1430,12 @@ export class UI {
 
 	toggleMusicPlayer() {
 		$j('#musicplayerwrapper').toggleClass('hide');
+		this._updateHudTransparency();
 	}
 
 	closeMusicPlayer() {
 		$j('#musicplayerwrapper').addClass('hide');
+		this._updateHudTransparency();
 	}
 
 	// Function to close scoreboard if pressing outside of it
@@ -1632,10 +1644,12 @@ export class UI {
 
 		// Finally, show the scoreboard
 		this.$scoreboard.removeClass('hide');
+		this._updateHudTransparency();
 	}
 
 	closeScoreboard() {
 		this.$scoreboard.addClass('hide');
+		this._updateHudTransparency();
 	}
 
 	/**
@@ -1662,6 +1676,7 @@ export class UI {
 		} else {
 			this.showCreature(game.activeCreature.type, game.activeCreature.team, '');
 		}
+		this._updateHudTransparency();
 	}
 
 	closeDash() {
@@ -1686,6 +1701,7 @@ export class UI {
 
 		this.dashopen = false;
 		this.materializeToggled = false;
+		this._updateHudTransparency();
 	}
 
 	gridSelectUp() {


### PR DESCRIPTION
Implements the less distracting HUD feature (fixes #2092). When any fullscreen view (dash, scoreboard, music player) is open, the game HUD fades to 10% opacity with a smooth 250ms transition. Bounty: 8 XTR. Payment: eB51DWp1uECrLZRLsE2cnyZUzfRWvzUzaJzkatTpQV9