### PR TITLE
feat: show cancel icon when clicking unusable/used abilities (#2174)

### DIFF
--- a/src/ui/interface.ts
+++ b/src/ui/interface.ts
@@ -366,8 +366,13 @@ export class UI {
 
 								return;
 							}
+							// If ability is not usable, show cancel icon and return
+							if (!ability.require() || ability.used) {
+								b.cssTransition('cancelIcon', 1000);
+								return;
+							}
 							// Colored frame around selected ability
-							if (ability.require() == true && i != 0) {
+							if (ability.require() == true) {
 								this.selectAbility(i);
 							}
 							// Activate Ability


### PR DESCRIPTION
## Summary
When clicking on an ability that is not usable (requirement not met) or already used, the cancel icon is now temporarily displayed, providing visual feedback instead of silently doing nothing.

## Changes
- In `src/ui/interface.ts`, added a check before activating an ability: if `!ability.require() || ability.used`, show cancelIcon and return early instead of calling `use()`

## Testing
- Click on an ability with unmet requirements → cancel icon appears
- Click on an already-used ability → cancel icon appears

## Bounty
Issue: https://github.com/FreezingMoon/AncientBeast/issues/2174 (4 XTR)
Payment address: eB51DWp1uECrLZRLsE2cnyZUzfRWvzUzaJzkatTpQV9