### PR TITLE
feat: Goey Body upgrade revamp - allows Gumble to leap over units (#2850)

### DIFF
--- a/src/abilities/Gumble.ts
+++ b/src/abilities/Gumble.ts
@@ -17,11 +17,20 @@ export default (G: Game) => {
 	G.abilities[14] = [
 		// First Ability: Gooey Body
 		{
-			// Trigger when Gumble dies
+			/**
+			 * When upgraded, allows Gumble to leap over units during movement phase
+			 * (flying movement type).
+			 */
+			movementType: function () {
+				return this.isUpgraded() ? 'flying' : 'normal';
+			},
+
+			// Trigger when Gumble dies (only when not upgraded)
 			trigger: 'onCreatureDeath',
 
 			require: function () {
-				return true;
+				// Only trigger on death when NOT upgraded (upgraded version provides leap ability instead)
+				return !this.isUpgraded();
 			},
 
 			activate: function (deadCreature: Creature) {
@@ -39,20 +48,10 @@ export default (G: Game) => {
 						deathHex,
 						'onStepIn',
 						{
-							// Check if creature should be affected by the goo
+							// Always affect all units (allies and enemies)
 							requireFn: function () {
 								const creatureOnGoo = this.trap.hex.creature;
-								if (!creatureOnGoo) {
-									return false;
-								}
-
-								// If upgraded, don't affect allied units
-								if (ability.isUpgraded()) {
-									return creatureOnGoo.player !== ability.creature.player;
-								}
-
-								// Otherwise affect all units
-								return true;
+								return !!creatureOnGoo;
 							},
 							effectFn: function (_, creature: Creature) {
 								// Pin the creature in place for the current round


### PR DESCRIPTION
## Summary

Implements the requested change for issue #2850 - Goey Body upgrade revamp (30 XTR bounty).

### Changes

**File: `src/abilities/Gumble.ts`**

1. **Added `movementType` function**: When upgraded, Gumble's Goey Body passive now returns `'flying'` movement type, allowing it to leap over units during the movement phase (walking at least 2 hexagons).

2. **Modified `require` function**: The death trap now only triggers when Gumble is NOT upgraded. When upgraded, the flying movement ability takes precedence.

3. **Simplified trap behavior**: Removed the ally-checking logic from the death trap's `requireFn`. The non-upgraded trap now affects all units uniformly (allies and enemies alike), making it more intuitive and less confusing as requested in the issue.

### Before vs After

| State | Behavior |
|-------|----------|
| Not Upgraded | Leaves a trap on death that pins any unit (allies & enemies) |
| Upgraded | Leaps over units during movement (flying movement type) |

### Bounty

收款地址：eB51DWp1uECrLZRLsE2cnyZUzfRWvzUzaJzkatTpQV9
