### PR TITLE
fix: skip hover on touch to fix hexagon touch on Android [bounty: 234 XTR]

### DIFF
--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -180,9 +180,22 @@ export class Hex {
 			this.overlay = grid.overlayHexesGroup.create(x, y, 'hex');
 			this.overlay.alpha = 0;
 
+			// Track if last interaction was from touch to avoid double-firing
+			let lastInteractionTouch = false;
+
 			// Binding Events
-			this.hitBox.events.onInputOver.add(() => {
+			this.hitBox.events.onInputOver.add((_, pointer) => {
 				if (game.freezedInput || game.UI.dashopen) return;
+
+				// Skip hover effect for touch input - on Android, touch triggers
+				// onInputOver before onInputUp, making users tap twice to act.
+				// Touch input is handled directly in onInputDown instead.
+				if (pointer && pointer.pointerType === 'touch') {
+					lastInteractionTouch = true;
+					return;
+				}
+
+				lastInteractionTouch = false;
 
 				//  Show dashed overlay on current hexes of active creature
 				if (this.reachable && game.activeCreature) {
@@ -194,8 +207,26 @@ export class Hex {
 				this.onSelectFn(this);
 			}, this);
 
+			// onInputDown: handle touch directly to avoid double-tap issue on Android
+			this.hitBox.events.onInputDown.add((_, pointer) => {
+				if (game.freezedInput || game.UI.dashopen) return;
+
+				// For touch input, immediately trigger the confirm action.
+				// This bypasses the hover-first behavior that requires double-tapping on Android.
+				if (pointer && pointer.pointerType === 'touch') {
+					lastInteractionTouch = true;
+					this.onConfirmFn(this);
+				}
+			}, this);
+
 			this.hitBox.events.onInputOut.add((_, pointer) => {
 				if (game.freezedInput || game.UI.dashopen || !pointer.withinGame) return;
+
+				// Skip hover-off for touch since we skip hover-on for touch
+				if (lastInteractionTouch) {
+					lastInteractionTouch = false;
+					return;
+				}
 
 				// Clear dashed overlay when leaving a reachable hex
 				if (this.reachable && game.activeCreature) {
@@ -209,6 +240,11 @@ export class Hex {
 
 			this.hitBox.events.onInputUp.add((Sprite, Pointer) => {
 				if (game.freezedInput || game.UI.dashopen) {
+					return;
+				}
+
+				// Skip onInputUp for touch since we already handled it in onInputDown
+				if (Pointer.pointerType === 'touch') {
 					return;
 				}
 


### PR DESCRIPTION
## Fix: Skip hover on touch to fix hexagon touch on Android

### Issue
Touching hexagons on Android triggers hover behavior first (via touch-to-mouse emulation), requiring users to tap twice to perform an action (move unit, target ability). This makes gameplay "very cringe" as described in the issue.

### Root Cause
On Android browsers, when a user touches the screen, the browser fires synthetic mouse events (mouseover, mousemove, mousedown, mouseup, click) in addition to the touch events. Phaser's onInputOver handler was being triggered by these synthetic events, causing the hover/select behavior before the actual confirm action.

### Fix
Modified src/utility/hex.ts to detect touch input via pointer.pointerType:

1. onInputOver: Skip hover effects for touch input. Touch is handled directly elsewhere.
2. onInputDown: For touch input, immediately trigger onConfirmFn() to bypass the hover-first behavior.
3. onInputOut: Skip hover-off for touch since we never showed hover for touch.
4. onInputUp: Skip for touch since touch is already handled in onInputDown.

### Testing
- Build passes successfully (npm run build)
- The fix is minimal and targeted at the touch input path only - mouse/keyboard behavior is unaffected.

### Bounty
Issue: https://github.com/FreezingMoon/AncientBeast/issues/2803
Bounty: 234 XTR
Receiver: eB51DWp1uECrLZRLsE2cnyZUzfRWvzUzaJzkatTpQV9
