### PR TITLE
fix: lock screen orientation to landscape (#2711)

### DIFF
--- a/src/script.ts
+++ b/src/script.ts
@@ -225,6 +225,13 @@ $j(() => {
 	$j('#startButton').trigger('focus');
 
 	const startGame = () => {
+		// Attempt to lock orientation to landscape when game starts
+		// This works in fullscreen mode or PWA context on supporting browsers
+		if (screen.orientation?.lock) {
+			screen.orientation.lock('landscape').catch(() => {
+				// Lock may fail if not in fullscreen or not supported
+			});
+		}
 		G.loadGame(getGameConfig());
 	};
 

--- a/src/ui/fullscreen.ts
+++ b/src/ui/fullscreen.ts
@@ -16,16 +16,35 @@ export class Fullscreen {
 		try {
 			if (document.fullscreenElement) {
 				await document.exitFullscreen();
+				// Unlock orientation when exiting fullscreen
+				if (screen.orientation?.unlock) {
+					screen.orientation.unlock();
+				}
 			} else {
 				const gameElement = document.getElementById('AncientBeast');
 				if (gameElement) {
 					await gameElement.requestFullscreen();
+					// Lock to landscape after entering fullscreen
+					this.lockOrientation();
 				}
 			}
 
 			setTimeout(() => this.updateButtonState(), 100);
 		} catch (error) {
 			console.error('Error toggling fullscreen:', error);
+		}
+	}
+
+	private async lockOrientation() {
+		// Lock orientation to landscape using Screen Orientation API
+		// This requires fullscreen on most browsers (Chrome Android, etc.)
+		if (screen.orientation?.lock) {
+			try {
+				await screen.orientation.lock('landscape');
+			} catch (error) {
+				// Lock may fail if not in fullscreen, not supported, or already locked
+				console.warn('Orientation lock not available:', error);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
Locks the game screen to landscape orientation using the Screen Orientation API.

### Changes:
- `src/ui/fullscreen.ts`: Added `lockOrientation()` method that calls `screen.orientation.lock('landscape')` when entering fullscreen, and `screen.orientation.unlock()` when exiting
- `src/script.ts`: Added orientation lock attempt in `startGame()` for non-fullscreen PWA contexts

### How it works:
- When entering fullscreen mode (via the fullscreen button or F11 hotkey), the screen orientation is locked to landscape using the Screen Orientation API
- When exiting fullscreen, the orientation is unlocked
- When the game starts, an orientation lock is attempted (works in fullscreen or PWA context on supporting browsers like Chrome Android)
- The existing PWA manifest already has `"orientation": "landscape"` for installed apps
- The existing orientation message overlay still serves as a fallback for browsers that don't support the API

Closes #2711