### PR TITLE
feat(Gumble): Gooey Body upgrade allows leaping over units during movement

### DIFF
--- a/src/abilities/Gumble.ts
+++ b/src/abilities/Gumble.ts
@@ -24,6 +24,11 @@ export default (G: Game) => {
 				return true;
 			},
 
+			movementType: function () {
+				// Upgraded: Gumble can leap over creatures during movement
+				return this.isUpgraded() ? 'flying' : 'normal';
+			},
+
 			activate: function (deadCreature: Creature) {
 				const deathHex = G.grid.hexAt(deadCreature.x, deadCreature.y);
 

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -148,6 +148,7 @@ export class Creature {
 	private _hinderedTurn: number;
 	materializationSickness: boolean;
 	noActionPossible: boolean;
+	leapOverCreatures: boolean;
 
 	// Statistics
 	baseStats: CreatureStats;
@@ -430,6 +431,7 @@ export class Creature {
 		this.oldEnergy = this.energy;
 		this.oldHealth = this.health;
 		this.noActionPossible = false;
+		this.leapOverCreatures = false;
 
 		const game = this.game;
 		const stats = this.stats;

--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -422,8 +422,14 @@ export class Hex {
 
 				let isNotMovingCreature;
 				if (hex.creature instanceof Creature) {
-					isNotMovingCreature = hex.creature.id !== id;
-					blocked = blocked || isNotMovingCreature; // Not blocked if this block contains the moving creature
+					// Allow leaping over creatures if the moving creature has leapOverCreatures
+					const movingCreature = this.game.creatures.find((c) => c.id === id);
+					if (movingCreature?.leapOverCreatures) {
+						// Creature can leap over other creatures - don't block
+					} else {
+						isNotMovingCreature = hex.creature.id !== id;
+						blocked = blocked || isNotMovingCreature; // Not blocked if this block contains the moving creature
+					}
 				}
 				if (debug) {
 					console.log({ isNotMovingCreature });

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -1396,6 +1396,13 @@ export class HexGrid {
 
 		hexes = hexes.filter((hex) => hex.isWalkable(size, id, true));
 
+		// For leaping creatures, exclude creature-occupied destination hexes
+		// (the creature leaps OVER creatures but lands on empty hexes)
+		const movingCreature = this.game.creatures.find((c) => c.id === id);
+		if (movingCreature?.leapOverCreatures) {
+			hexes = hexes.filter((hex) => !hex.creature);
+		}
+
 		return arrayUtils.extendToLeft(hexes, size, this.game.grid);
 	}
 


### PR DESCRIPTION
## Summary

When Gumble's Gooey Body ability is upgraded, the creature gains the ability to leap over enemy units during the movement phase (walking at least 2 hexagons), instead of the confusing trap behavior that may or may not affect allies.

## Changes

### 1. Creature leap property (`src/creature.ts`)
- Added `leapOverCreatures: boolean` property to the Creature class
- Initialized to `false` in the constructor

### 2. Pathfinding modification (`src/utility/hex.ts`)
- Modified `isWalkable()` to skip creature collision checks when the moving creature has `leapOverCreatures = true`
- This allows the pathfinding to treat creature-occupied hexes as passable

### 3. Flying range for leaping creatures (`src/utility/hexgrid.ts`)
- Modified `getFlyingRange()` to exclude creature-occupied hexes from the destination list when `leapOverCreatures = true`
- Creatures can leap OVER other creatures but must land on empty hexes

### 4. Gumble Gooey Body ability (`src/abilities/Gumble.ts`)
- Added `movementType()` method to Gooey Body ability (ability index 0)
- When upgraded, `movementType()` returns `'flying'` to enable leap movement
- The trap on death behavior is preserved (both normal and upgraded versions)

## How it works

1. When Gumble's Gooey Body is upgraded, `creature.leapOverCreatures` is effectively `true` (via `movementType() === 'flying'`)
2. During movement, `getFlyingRange()` returns hexes within movement range
3. `isWalkable()` allows passing through creature-occupied hexes in the path
4. The creature animates with the 'fly' animation and moves directly to the destination
5. The destination must be an empty hex (not occupied by another creature)

## Testing

The build compiles successfully with `npm run build:dev`.

Fixes #2850