### PR TITLE
fix: block multiple file pickers when loading game log (#2363)

### DIFF
--- a/src/script.ts
+++ b/src/script.ts
@@ -390,18 +390,36 @@ function getReg() {
 	return reg;
 }
 
+let isFilePickerOpen = false;
+let filePickerTimeout: ReturnType<typeof setTimeout>;
+
 /**
  * read log from file
  * @returns {Promise<string>}
  */
 function readLogFromFile() {
 	// TODO: This would probably be better off in ./src/utility/gamelog.ts
+	if (isFilePickerOpen) {
+		return Promise.reject(new Error('File picker already open'));
+	}
+	isFilePickerOpen = true;
+	// Fallback: reset flag after 30s in case picker is cancelled without triggering onchange
+	if (filePickerTimeout) {
+		clearTimeout(filePickerTimeout);
+	}
+	filePickerTimeout = setTimeout(() => {
+		isFilePickerOpen = false;
+	}, 30000);
 	return new Promise((resolve, reject) => {
 		const fileInput = document.createElement('input') as HTMLInputElement;
 		fileInput.accept = '.ab';
 		fileInput.type = 'file';
 
 		fileInput.onchange = (event) => {
+			isFilePickerOpen = false;
+			if (filePickerTimeout) {
+				clearTimeout(filePickerTimeout);
+			}
 			const file = (event.target as HTMLInputElement).files[0];
 			const reader = new FileReader();
 


### PR DESCRIPTION
## Fix: Block Multiple File Pickers (#2363)

### Problem
Holding `Ctrl+Meta+L` in the pre-match screen opens multiple file pickers because the hotkey triggers repeatedly while keys are held down, and each call to `readLogFromFile()` creates a new file picker.

### Solution
Added a guard flag `isFilePickerOpen` to prevent multiple simultaneous file pickers. Also added a 30-second timeout fallback to reset the flag if the picker is cancelled without firing `onchange`.

### Changes
- `src/script.ts`: Added `isFilePickerOpen` flag and `filePickerTimeout` to `readLogFromFile()`

### Testing
1. Hold `Ctrl+Meta+L` — only one file picker should open
2. Cancel the picker (press Escape) — flag should reset after 30s
3. Pick a file normally — flag resets immediately on `onchange`