### PR TITLE
fix: cursor progress state when hovering active unit with no ability selected (#2246)

### DIFF
--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -1022,6 +1022,8 @@ export class HexGrid {
 					// Filled hex with color
 					hex.displayVisualState('creature player' + hex.creature.team);
 				}
+			} else if (game.UI.selectedAbility === -1) {
+				$j('canvas').css('cursor', 'progress');
 			} else if (game.activeCreature.noActionPossible) {
 				$j('canvas').css('cursor', 'wait');
 			}


### PR DESCRIPTION
## Bounty Issue #2246
**Title:** cursor state to showcase active unit better [bounty: 6 XTR]

### Changes
When hovering the active unit with no ability selected, the cursor now shows the `progress` type pointer instead of the `wait` cursor.

**Before:** Cursor was always `wait` when hovering active creature with `noActionPossible`
**After:** Cursor shows `progress` when no ability is selected (even if unit might still be targetable); `wait` is only shown when an ability is selected but no action is possible

### Implementation
In `src/utility/hexgrid.ts`, added a check for `game.UI.selectedAbility === -1` before the existing `noActionPossible` check in the `onCreatureHover` callback.

**收款地址：** eB51DWp1uECrLZRLsE2cnyZUzfRWvzUzaJzkatTpQV9