### PR TITLE
feat(Gumble): upgraded Gooey Body grants flying movement

### DIFF
--- a/src/abilities/Gumble.ts
+++ b/src/abilities/Gumble.ts
@@ -24,6 +24,17 @@ export default (G: Game) => {
 				return true;
 			},
 
+			/**
+			 * When upgraded, Gumble gains flying movement - can leap over units
+			 * when moving 2+ hexagons. This replaces the default normal movement.
+			 * @return {string} movement type, 'flying' when upgraded, otherwise undefined
+			 */
+			movementType: function () {
+				if (this.isUpgraded()) {
+					return 'flying';
+				}
+			},
+
 			activate: function (deadCreature: Creature) {
 				const deathHex = G.grid.hexAt(deadCreature.x, deadCreature.y);
 


### PR DESCRIPTION
## Summary
When Gooey Body (Gumble's first ability) is upgraded, Gumble gains flying movement type, allowing it to leap over units during the movement phase.

## Changes
- Added `movementType()` method to Gooey Body ability in `src/abilities/Gumble.ts`
- When upgraded (`this.isUpgraded()`), returns `'flying'`, otherwise `undefined`
- This hooks into the existing `creature.movementType()` system which already supports ability-defined movement types

## How It Works
The `movementType()` method on `G.abilities[14][0]` (Gooey Body) is checked by `Creature.movementType()` in `src/creature.ts`. When upgraded, `'flying'` is returned, which causes `getHexes()` to use `getFlyingRange` instead of normal pathfinding, allowing Gumble to move to any hex within its movement range regardless of obstacles.

This follows the same pattern used by Scavenger's ability, which returns `'flying'` when upgraded and `'hover'` otherwise.

## Bounty Reference
Issue #2850: Goey Body upgrade revamp [bounty: 30 XTR]

---
收款地址：eB51DWp1uECrLZRLsE2cnyZUzfRWvzUzaJzkatTpQV9
