### PR TITLE
Prevent duplicate log file pickers

### DIFF
--- a/src/__tests__/utility/gamelog.ts
+++ b/src/__tests__/utility/gamelog.ts
@@ -102,7 +102,7 @@ describe('GameLog', () => {
 			}
 
 			const originalFileReader = window.FileReader;
-			window.FileReader = MockFileReader as typeof FileReader;
+			window.FileReader = MockFileReader as unknown as typeof FileReader;
 
 			try {
 				const firstRead = readLogFromFile();
@@ -113,7 +113,7 @@ describe('GameLog', () => {
 					configurable: true,
 					value: [{}],
 				});
-				fileInput.onchange?.({ target: fileInput } as Event);
+				fileInput.onchange?.({ target: fileInput } as unknown as Event);
 
 				await expect(firstRead).resolves.toBe('serialized-log');
 			} finally {

--- a/src/__tests__/utility/gamelog.ts
+++ b/src/__tests__/utility/gamelog.ts
@@ -1,6 +1,11 @@
 import { jest, expect, describe, test } from '@jest/globals';
 import { full } from '../../utility/version';
-import { GameLog } from '../../utility/gamelog';
+import {
+	ConcurrentLogFilePickerError,
+	GameLog,
+	LogFileSelectionCancelledError,
+	readLogFromFile,
+} from '../../utility/gamelog';
 
 describe('GameLog', () => {
 	describe('new GameLog(onSave, onLoad)', () => {
@@ -70,6 +75,91 @@ describe('GameLog', () => {
 			const log = gl.load(str);
 			const diffSeconds = Math.abs(date.getTime() / 1000 - log.date.getTime() / 1000);
 			expect(diffSeconds).toBeLessThan(10);
+		});
+	});
+
+	describe('readLogFromFile()', () => {
+		test('blocks concurrent file pickers and resolves the selected log once', async () => {
+			const originalCreateElement = document.createElement.bind(document);
+			const fileInput = originalCreateElement('input') as HTMLInputElement;
+			const clickSpy = jest.spyOn(fileInput, 'click').mockImplementation(() => undefined);
+			const createElementSpy = jest
+				.spyOn(document, 'createElement')
+				.mockImplementation(((tagName: string) =>
+					tagName === 'input'
+						? fileInput
+						: originalCreateElement(tagName)) as typeof document.createElement);
+
+			class MockFileReader {
+				result: string | ArrayBuffer | null = 'serialized-log';
+				error: DOMException | null = null;
+				onload: ((event: ProgressEvent<FileReader>) => void) | null = null;
+				onerror: ((event: ProgressEvent<FileReader>) => void) | null = null;
+
+				readAsText() {
+					this.onload?.({} as ProgressEvent<FileReader>);
+				}
+			}
+
+			const originalFileReader = window.FileReader;
+			window.FileReader = MockFileReader as typeof FileReader;
+
+			try {
+				const firstRead = readLogFromFile();
+				await expect(readLogFromFile()).rejects.toBeInstanceOf(ConcurrentLogFilePickerError);
+				expect(clickSpy).toHaveBeenCalledTimes(1);
+
+				Object.defineProperty(fileInput, 'files', {
+					configurable: true,
+					value: [{}],
+				});
+				fileInput.onchange?.({ target: fileInput } as Event);
+
+				await expect(firstRead).resolves.toBe('serialized-log');
+			} finally {
+				window.FileReader = originalFileReader;
+				createElementSpy.mockRestore();
+				clickSpy.mockRestore();
+			}
+		});
+
+		test('cancelling the picker clears the guard so the next attempt can open', async () => {
+			jest.useFakeTimers();
+
+			const originalCreateElement = document.createElement.bind(document);
+			const firstInput = originalCreateElement('input') as HTMLInputElement;
+			const secondInput = originalCreateElement('input') as HTMLInputElement;
+			const firstClickSpy = jest.spyOn(firstInput, 'click').mockImplementation(() => undefined);
+			const secondClickSpy = jest.spyOn(secondInput, 'click').mockImplementation(() => undefined);
+			const inputs = [firstInput, secondInput];
+			const createElementSpy = jest
+				.spyOn(document, 'createElement')
+				.mockImplementation(((tagName: string) =>
+					tagName === 'input'
+						? inputs.shift() ?? originalCreateElement(tagName)
+						: originalCreateElement(tagName)) as typeof document.createElement);
+
+			try {
+				const firstRead = readLogFromFile();
+				window.dispatchEvent(new Event('focus'));
+				jest.runAllTimers();
+
+				await expect(firstRead).rejects.toBeInstanceOf(LogFileSelectionCancelledError);
+				expect(firstClickSpy).toHaveBeenCalledTimes(1);
+
+				const secondRead = readLogFromFile();
+				expect(secondClickSpy).toHaveBeenCalledTimes(1);
+
+				window.dispatchEvent(new Event('focus'));
+				jest.runAllTimers();
+
+				await expect(secondRead).rejects.toBeInstanceOf(LogFileSelectionCancelledError);
+			} finally {
+				createElementSpy.mockRestore();
+				firstClickSpy.mockRestore();
+				secondClickSpy.mockRestore();
+				jest.useRealTimers();
+			}
 		});
 	});
 });

--- a/src/script.ts
+++ b/src/script.ts
@@ -13,6 +13,11 @@ import Authenticate from './multiplayer/authenticate';
 import SessionI from './multiplayer/session';
 import { installAvatarStyles } from './style/avatar-styles';
 import {
+	ConcurrentLogFilePickerError,
+	LogFileSelectionCancelledError,
+	readLogFromFile,
+} from './utility/gamelog';
+import {
 	DEBUG_AUTO_START_GAME,
 	DEBUG_DISABLE_HOTKEYS,
 	DEBUG_GAME_LOG,
@@ -138,6 +143,13 @@ $j(() => {
 				readLogFromFile()
 					.then((log) => G.gamelog.load(log as string))
 					.catch((err) => {
+						if (
+							err instanceof ConcurrentLogFilePickerError ||
+							err instanceof LogFileSelectionCancelledError
+						) {
+							return;
+						}
+
 						alert('An error occurred while loading the log file');
 						console.log(err);
 					});
@@ -388,36 +400,6 @@ function getReg() {
 	};
 
 	return reg;
-}
-
-/**
- * read log from file
- * @returns {Promise<string>}
- */
-function readLogFromFile() {
-	// TODO: This would probably be better off in ./src/utility/gamelog.ts
-	return new Promise((resolve, reject) => {
-		const fileInput = document.createElement('input') as HTMLInputElement;
-		fileInput.accept = '.ab';
-		fileInput.type = 'file';
-
-		fileInput.onchange = (event) => {
-			const file = (event.target as HTMLInputElement).files[0];
-			const reader = new FileReader();
-
-			reader.readAsText(file);
-
-			reader.onload = () => {
-				resolve(reader.result);
-			};
-
-			reader.onerror = () => {
-				reject(reader.error);
-			};
-		};
-
-		fileInput.click();
-	});
 }
 
 /**

--- a/src/utility/gamelog.ts
+++ b/src/utility/gamelog.ts
@@ -2,6 +2,21 @@ import * as version from './version';
 import { throttle } from 'underscore';
 
 const SEPARATOR = '||';
+let pendingLogFileRead: Promise<string> | null = null;
+
+export class ConcurrentLogFilePickerError extends Error {
+	constructor() {
+		super('A log file picker is already open.');
+		this.name = 'ConcurrentLogFilePickerError';
+	}
+}
+
+export class LogFileSelectionCancelledError extends Error {
+	constructor() {
+		super('No log file selected.');
+		this.name = 'LogFileSelectionCancelledError';
+	}
+}
 
 export class SerializableLog {
 	actions: any[];
@@ -117,6 +132,66 @@ const saveFile = (data: any, fileName: string) => {
 		window.URL.revokeObjectURL(url);
 	}, 1000);
 };
+
+export function readLogFromFile() {
+	if (pendingLogFileRead !== null) {
+		return Promise.reject(new ConcurrentLogFilePickerError());
+	}
+
+	pendingLogFileRead = new Promise((resolve, reject) => {
+		const fileInput = document.createElement('input') as HTMLInputElement;
+		let settled = false;
+
+		const finish = (callback: () => void) => {
+			if (settled) {
+				return;
+			}
+
+			settled = true;
+			window.removeEventListener('focus', onWindowFocus, true);
+			pendingLogFileRead = null;
+			callback();
+		};
+
+		const onWindowFocus = () => {
+			window.setTimeout(() => {
+				if (settled || fileInput.files?.length) {
+					return;
+				}
+
+				finish(() => reject(new LogFileSelectionCancelledError()));
+			}, 0);
+		};
+
+		fileInput.accept = '.ab';
+		fileInput.type = 'file';
+
+		fileInput.onchange = (event) => {
+			const file = (event.target as HTMLInputElement).files?.[0];
+
+			if (!file) {
+				finish(() => reject(new LogFileSelectionCancelledError()));
+				return;
+			}
+
+			const reader = new FileReader();
+			reader.onload = () => {
+				finish(() => resolve(reader.result as string));
+			};
+
+			reader.onerror = () => {
+				finish(() => reject(reader.error ?? new Error('Could not read log file.')));
+			};
+
+			reader.readAsText(file);
+		};
+
+		window.addEventListener('focus', onWindowFocus, true);
+		fileInput.click();
+	});
+
+	return pendingLogFileRead;
+}
 
 function getYearMonthDayStr() {
 	return new Date().toISOString().slice(0, 10);


### PR DESCRIPTION
Fixes #2363.

## Summary
- move the log file picker helper into `src/utility/gamelog.ts`
- block concurrent log picker opens while an existing picker is pending
- treat picker cancel as a non-error and clear the guard for the next attempt
- ignore duplicate-open and cancel cases in the pre-match hotkey handler

## Testing
- `npm run test:jest -- --runInBand src/__tests__/utility/gamelog.ts`
- `npx eslint src/script.ts src/utility/gamelog.ts src/__tests__/utility/gamelog.ts`
