### PR TITLE
fix: add error handling for JSON.parse in _restorePowers()

### DIFF
--- a/src/ui/meta-powers.ts
+++ b/src/ui/meta-powers.ts
@@ -176,13 +176,21 @@ export class MetaPowers {
 	 * If the toggled Meta Powers were persisted to a cookie, restore them
 	 */
 	_restorePowers() {
-		const powers = JSON.parse(Cookies.get(COOKIE_KEY)).toggles;
+		try {
+			const cookieValue = Cookies.get(COOKIE_KEY);
+			if (!cookieValue) return;
+			const parsed = JSON.parse(cookieValue);
+			if (!parsed || !parsed.toggles) return;
+			const powers = parsed.toggles;
 
-		Object.keys(powers).forEach((key) => {
-			if (powers[key].enabled) {
-				this._togglePower(key, this[`btn${capitalize(key)}`]);
-			}
-		});
+			Object.keys(powers).forEach((key) => {
+				if (powers[key]?.enabled) {
+					this._togglePower(key, this[`btn${capitalize(key)}`]);
+				}
+			});
+		} catch (error) {
+			console.error('Failed to restore meta powers from cookie:', error);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Wraps `JSON.parse(Cookies.get(COOKIE_KEY))` in try-catch with null checks
- `Cookies.get()` can return `undefined`, causing `JSON.parse(undefined)` to throw `SyntaxError`
- Corrupted cookie data also causes unhandled crash in the meta powers UI

## Changes
- Added null check for cookie value before parsing
- Added null check for `parsed.toggles` before iterating
- Added optional chaining on `powers[key]?.enabled`
- Wrapped in try-catch with console error logging

## Test plan
- [ ] Toggle meta powers on and off — verify persistence works
- [ ] Clear cookies and reload — verify no crash
- [ ] Manually corrupt the cookie value — verify graceful fallback