### PR TITLE
Fix X-Ray for multi-hex movement previews

### DIFF
--- a/src/__tests__/utility/hexgrid-xray.ts
+++ b/src/__tests__/utility/hexgrid-xray.ts
@@ -1,0 +1,42 @@
+import { describe, expect, jest, test } from '@jest/globals';
+
+jest.mock('phaser-ce', () => ({}));
+jest.mock('../../creature', () => ({
+	Creature: class Creature {},
+}));
+
+import { Creature } from '../../creature';
+import { HexGrid } from '../../utility/hexgrid';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+function makeCreature(hexagons: Array<{ ghostOverlap: jest.Mock }>) {
+	const CreatureCtor = Creature as unknown as { new (): Creature };
+	const creature = new CreatureCtor() as any;
+	creature.hexagons = hexagons;
+	creature.xray = jest.fn();
+	return creature;
+}
+
+describe('HexGrid.xray', () => {
+	test('checks every preview footprint hex for obstructing creatures', () => {
+		const activeHex = { ghostOverlap: jest.fn() };
+		const activeCreature = makeCreature([activeHex]);
+		const otherCreature = makeCreature([]);
+		const frontPreviewHex = { creature: undefined, ghostOverlap: jest.fn() };
+		const backPreviewHex = { creature: undefined, ghostOverlap: jest.fn() };
+
+		const grid = Object.create(HexGrid.prototype) as any;
+		grid.game = {
+			creatures: [activeCreature, otherCreature],
+			activeCreature,
+		};
+
+		grid.xray(frontPreviewHex as never, [frontPreviewHex as never, backPreviewHex as never]);
+
+		expect(frontPreviewHex.ghostOverlap).toHaveBeenCalledTimes(1);
+		expect(backPreviewHex.ghostOverlap).toHaveBeenCalledTimes(1);
+		expect(activeHex.ghostOverlap).toHaveBeenCalledWith(activeCreature);
+		expect(activeCreature.xray).toHaveBeenLastCalledWith(false);
+	});
+});

--- a/src/__tests__/utility/query_footprint.ts
+++ b/src/__tests__/utility/query_footprint.ts
@@ -1,0 +1,58 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import { getQueryFootprintHexes } from '../../utility/query_footprint';
+
+type TestHex = {
+	x: number;
+	y: number;
+	isWalkable: jest.Mock;
+};
+
+function buildGrid(width: number, height = 1) {
+	const hexes: TestHex[][] = [];
+
+	for (let y = 0; y < height; y++) {
+		const row: TestHex[] = [];
+		for (let x = 0; x < width; x++) {
+			row.push({
+				x,
+				y,
+				isWalkable: jest.fn((size: number) => x - size + 1 >= 0),
+			});
+		}
+		hexes.push(row);
+	}
+
+	return { hexes };
+}
+
+describe('getQueryFootprintHexes', () => {
+	test('returns every occupied hex for a non-flipped multi-hex preview', () => {
+		const grid = buildGrid(10);
+		const footprint = getQueryFootprintHexes(
+			grid as never,
+			grid.hexes[0][6] as never,
+			3,
+			false,
+			12,
+		);
+
+		expect(footprint.map(({ x, y }) => [x, y])).toEqual([
+			[6, 0],
+			[5, 0],
+			[4, 0],
+		]);
+		expect(grid.hexes[0][6].isWalkable).toHaveBeenCalledWith(3, 12);
+	});
+
+	test('offsets the footprint when the active player is flipped', () => {
+		const grid = buildGrid(10);
+		const footprint = getQueryFootprintHexes(grid as never, grid.hexes[0][6] as never, 3, true, 12);
+
+		expect(footprint.map(({ x, y }) => [x, y])).toEqual([
+			[8, 0],
+			[7, 0],
+			[6, 0],
+		]);
+		expect(grid.hexes[0][8].isWalkable).toHaveBeenCalledWith(3, 12);
+	});
+});

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -12,6 +12,7 @@ import { HEX_WIDTH_PX } from './const';
 import { Point } from './pointfacade';
 import { AugmentedMatrix } from './matrices';
 import { PierceThroughBehavior } from '../ability';
+import { getQueryFootprintHexes } from './query_footprint';
 
 const ROW_DEPTH_STRIDE = 100;
 
@@ -145,6 +146,7 @@ export class HexGrid {
 	 * Last hex passed to xray(). Used to reapply the effect on tab focus.
 	 */
 	lastXrayHex: Hex | null = null;
+	lastXrayHexes: Hex[] | null = null;
 
 	/**
 	 * The hex the physical mouse pointer is currently over, updated before any
@@ -884,7 +886,7 @@ export class HexGrid {
 			}
 		});
 
-		// Active creature (attacker) must never be xrayed — ghostOverlap for a
+		// Active creature (attacker) must never be xrayed ? ghostOverlap for a
 		// target's hexes can pick it up as a same-row or adjacent-row candidate.
 		if (abilityActiveCreature instanceof Creature) {
 			abilityActiveCreature.xray(false);
@@ -1379,7 +1381,11 @@ export class HexGrid {
 			const { y } = hex;
 
 			// Xray
-			this.xray(hex);
+			const xrayHexes =
+				hex.reachable && !(hex.creature instanceof Creature)
+					? getQueryFootprintHexes(this, hex, o.size, o.flipped, o.id)
+					: undefined;
+			this.xray(hex, xrayHexes);
 
 			// Clear display and overlay
 			game.UI.xrayQueue(-1);
@@ -1527,11 +1533,22 @@ export class HexGrid {
 	 *
 	 * If hex contain creature call ghostOverlap for each creature hexes
 	 */
-	xray(hex: Hex) {
+	xray(hex: Hex, referenceHexes?: Hex[]) {
 		if (this.game.animations?.xraySuppressed) {
 			return;
 		}
+		const shouldReuseLastFootprint =
+			!referenceHexes && this.lastXrayHex === hex && this.lastXrayHexes?.length;
 		this.lastXrayHex = hex;
+		if (referenceHexes?.length) {
+			this.lastXrayHexes = referenceHexes;
+		} else if (shouldReuseLastFootprint) {
+			referenceHexes = this.lastXrayHexes;
+		} else {
+			this.lastXrayHexes = null;
+		}
+
+		// Clear previous ghost
 		this.game.creatures.forEach((creature) => {
 			if (creature instanceof Creature) {
 				creature.xray(false);
@@ -1546,14 +1563,15 @@ export class HexGrid {
 		const noAbilitySelected = this.game.UI?.selectedAbility === -1;
 		const hoveredCreature =
 			hex.creature instanceof Creature ? (hex.creature as Creature) : undefined;
-		const hoveredTrapSprites = this.game.traps
+		const traps = this.game.traps ?? [];
+		const drops = this.game.drops ?? [];
+		const hoveredTrapSprites = traps
 			.filter((trap) => trap.x === hex.x && trap.y === hex.y)
 			.flatMap((trap) => trap.getVisualSprites())
 			.filter((sprite) => sprite.exists && typeof sprite.getBounds === 'function');
 		const hoveredTrap =
-			hoveredTrapSprites.length > 0 ||
-			this.game.traps.some((trap) => trap.x === hex.x && trap.y === hex.y);
-		const hoveredDropSprites = (this.game.drops ?? [])
+			hoveredTrapSprites.length > 0 || traps.some((trap) => trap.x === hex.x && trap.y === hex.y);
+		const hoveredDropSprites = drops
 			.filter((drop) => drop.x === hex.x && drop.y === hex.y && !drop.pickedUp)
 			.map((drop) => drop.display)
 			.filter((sprite) => sprite.exists && typeof sprite.getBounds === 'function');
@@ -1564,7 +1582,7 @@ export class HexGrid {
 			hoveredCreature && hoveredCreature !== activeCreature ? hoveredCreature : undefined;
 
 		// Exception 1/2: reveal hovered non-active target when no ability is selected.
-		// Skip when a trap/drop is also on the hex — Exception 3 handles that case
+		// Skip when a trap/drop is also on the hex ? Exception 3 handles that case
 		// and must also xray the creature standing on the trap.
 		if (hoveredNonActiveCreature && noAbilitySelected && !hoveredTrap && !hoveredDrop) {
 			hoveredNonActiveCreature.hexagons.forEach((hoveredHex) =>
@@ -1638,6 +1656,12 @@ export class HexGrid {
 				);
 			});
 			return;
+		}
+
+		if (referenceHexes?.length) {
+			referenceHexes.forEach((item) => item.ghostOverlap());
+		} else {
+			hex.ghostOverlap();
 		}
 
 		// Default: keep active creature visible through obstructions.
@@ -2217,6 +2241,7 @@ export class HexGrid {
 	 */
 	clearAllXray(immediate = false) {
 		this.lastXrayHex = null;
+		this.lastXrayHexes = null;
 		this.game.creatures.forEach((c) => {
 			if (!(c instanceof Creature)) {
 				return;

--- a/src/utility/query_footprint.ts
+++ b/src/utility/query_footprint.ts
@@ -1,0 +1,49 @@
+import type { Hex } from './hex';
+
+type HexGridLike = {
+	hexes: Array<Array<Hex | undefined>>;
+};
+
+export function getQueryFootprintHexes(
+	grid: HexGridLike,
+	hex: Hex,
+	size = 1,
+	flipped = false,
+	id = 0,
+): Hex[] {
+	if (!hex || size < 1) {
+		return [];
+	}
+
+	const row = grid.hexes[hex.y];
+	if (!row) {
+		return [];
+	}
+
+	let x = hex.x;
+	const offset = flipped ? size - 1 : 0;
+	const mult = flipped ? 1 : -1;
+
+	for (let i = 0; i < size; i++) {
+		const candidateX = x + offset - i * mult;
+		const candidate = row[candidateX];
+		if (!candidate) {
+			continue;
+		}
+
+		if (candidate.isWalkable(size, id)) {
+			x += offset - i * mult;
+			break;
+		}
+	}
+
+	const footprint: Hex[] = [];
+	for (let i = 0; i < size; i++) {
+		const occupiedHex = row[x - i];
+		if (occupiedHex) {
+			footprint.push(occupiedHex);
+		}
+	}
+
+	return footprint;
+}


### PR DESCRIPTION
## Summary
- add a shared helper that computes the full hex footprint for hovered move/target previews
- pass that full footprint into X-Ray so medium and large units ghost blockers for every occupied preview hex, not only the cursor hex
- keep the last footprint available for X-Ray reapply paths and clear it at turn-boundary cleanup

## Testing
- npx eslint src/utility/query_footprint.ts src/utility/hexgrid.ts src/__tests__/utility/query_footprint.ts src/__tests__/utility/hexgrid-xray.ts
- npx jest src/__tests__/utility/query_footprint.ts src/__tests__/utility/hexgrid-xray.ts --runInBand
- npx tsc --noEmit
- npm run build
- npx jest --runInBand

/claim #1301

Payout note: if this bounty can be paid as an EVM stablecoin instead of XTR, wallet is `0xe2e86bdb8753c24032f2ad42b4c1bd9748385a7d`.