### PR TITLE
Fix audio hotkey behavior

### DIFF
--- a/src/__tests__/ui/hotkeys.ts
+++ b/src/__tests__/ui/hotkeys.ts
@@ -1,0 +1,40 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import { Hotkeys } from '../../ui/hotkeys';
+
+function createAudioHotkeys() {
+	const ui = {
+		btnAudio: {
+			triggerClick: jest.fn(),
+		},
+		cycleAudioMode: jest.fn(),
+		dashopen: true,
+		gridSelectLeft: jest.fn(),
+	};
+
+	return {
+		ui,
+		hotkeys: new Hotkeys(ui as unknown as ConstructorParameters<typeof Hotkeys>[0]),
+	};
+}
+
+describe('Hotkeys audio shortcuts', () => {
+	test('opens the audio player with A', () => {
+		const { hotkeys, ui } = createAudioHotkeys();
+
+		hotkeys.pressA({ shiftKey: false });
+
+		expect(ui.btnAudio.triggerClick).toHaveBeenCalledTimes(1);
+		expect(ui.cycleAudioMode).not.toHaveBeenCalled();
+		expect(ui.gridSelectLeft).not.toHaveBeenCalled();
+	});
+
+	test('cycles the audio mode with Shift+A', () => {
+		const { hotkeys, ui } = createAudioHotkeys();
+
+		hotkeys.pressA({ shiftKey: true });
+
+		expect(ui.cycleAudioMode).toHaveBeenCalledTimes(1);
+		expect(ui.btnAudio.triggerClick).not.toHaveBeenCalled();
+		expect(ui.gridSelectLeft).not.toHaveBeenCalled();
+	});
+});

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -835,8 +835,9 @@ div.section.info {
 	border: 2px solid white;
 	border-radius: 8px;
 	font-size: 12px;
-	white-space: nowrap;
-	max-width: 100px;
+	white-space: normal;
+	max-width: 220px;
+	text-align: center;
 	z-index: 10000;
 	transition: opacity 0.2s;
 }

--- a/src/templates/interface.html
+++ b/src/templates/interface.html
@@ -29,11 +29,11 @@
 					<div class="panel-control audio-control" style="position:relative">
 						<div id="audio" class="toggle-music-player button">
 							<img id="audio-icon" src="data:," alt="audio icon" width="32" height="32" />
-							<div class="tooltiptext" id="audio-tooltip">Audio: Full</div>
+							<div class="tooltiptext" id="audio-tooltip">Audio: Full (A opens, Shift+A/right-click cycles)</div>
 						</div>
 												<div class="desc">
 							<div class="arrow"></div>
-							<div class="shortcut">hotkey Shift + A</div>
+							<div class="shortcut">hotkey A / Shift+A</div>
 							<span>Audio Player</span>
 							<p>Listen to some really fine epic tracks.</p>
 						</div>

--- a/src/ui/hotkeys.ts
+++ b/src/ui/hotkeys.ts
@@ -110,9 +110,9 @@ export class Hotkeys {
 
 	pressA(event) {
 		if (event.shiftKey) {
-			this.ui.btnAudio.triggerClick();
+			this.ui.cycleAudioMode();
 		} else {
-			this.ui.dashopen && this.ui.gridSelectLeft();
+			this.ui.btnAudio.triggerClick();
 		}
 	}
 

--- a/src/ui/interface.ts
+++ b/src/ui/interface.ts
@@ -16,7 +16,7 @@ import { pretty as version } from '../utility/version';
 import { capitalize } from '../utility/string';
 import { throttle } from 'underscore';
 import { DEBUG_DISABLE_HOTKEYS } from '../debug';
-import { cycleAudioMode } from '../sound/soundsys';
+import { cycleAudioMode as cycleSoundAudioMode } from '../sound/soundsys';
 import Game from '../game';
 import { CreatureType } from '../data/types';
 import { getAvatarSet } from '../style/avatar-styles';
@@ -339,8 +339,7 @@ export class UI {
 		this.buttons.push(this.btnAudio);
 		this.btnAudio.$button.on('contextmenu', (e) => {
 			e.preventDefault();
-			const newMode = cycleAudioMode(this.game.soundsys);
-			this.updateAudioIcon(newMode);
+			this.cycleAudioMode();
 		});
 		// Skip Turn Button
 		this.btnSkipTurn = new Button(
@@ -2698,16 +2697,19 @@ export class UI {
 			}
 		}
 	}
+	cycleAudioMode() {
+		cycleSoundAudioMode(this.game.soundsys, this);
+	}
 	updateAudioIcon(mode) {
 		let iconKey = 'icons/audio';
-		let tooltipText = 'Audio: Full';
+		let tooltipText = 'Audio: Full (A opens, Shift+A/right-click cycles)';
 
 		if (mode === 'sfx') {
 			iconKey = 'icons/SFX';
-			tooltipText = 'Audio: SFX';
+			tooltipText = 'Audio: SFX (A opens, Shift+A/right-click cycles)';
 		} else if (mode === 'muted') {
 			iconKey = 'icons/muted';
-			tooltipText = 'Audio: Muted';
+			tooltipText = 'Audio: Muted (A opens, Shift+A/right-click cycles)';
 		}
 
 		const iconUrl = getUrl(iconKey);


### PR DESCRIPTION
Fixes #1481

## Summary
- Make `A` open the audio player instead of moving dashboard selection left.
- Make `Shift+A` use the same full/SFX/muted cycling path as right-clicking the audio button.
- Update the audio button shortcut/tooltip copy and allow the tooltip to wrap cleanly.
- Add a focused regression test for the audio hotkey behavior.

## Testing
- `npm run lint`
- `npm run build`
- `npm run test:jest -- src/__tests__/ui/hotkeys.ts --runInBand`

Wallet address: can provide separately before bounty payout.
