### PR TITLE
[codex] Show cancel icon for unusable abilities

### DIFF
--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -431,6 +431,10 @@
 .button#skip {
 	background-image: url('~assets/autoload/interface/skip.svg');
 
+	&.cancelIcon {
+		background-image: url('~assets/icons/cancel.svg') !important;
+	}
+
 	&.disabled {
 		transform: perspective(900px) rotateY(0deg) !important;
 		opacity: 0.35;
@@ -443,6 +447,10 @@
 
 .button#delay {
 	background-image: url('~assets/icons/delay.svg');
+
+	&.cancelIcon {
+		background-image: url('~assets/icons/cancel.svg') !important;
+	}
 
 	&.disabled {
 		transform: perspective(900px) rotateY(0deg) !important;

--- a/src/ui/hotkeys.ts
+++ b/src/ui/hotkeys.ts
@@ -9,6 +9,9 @@ export class Hotkeys {
 
 	pressQ() {
 		if (this.ui.game.botController?.isBotTurn()) {
+			if (!this.ui.dashopen) {
+				this.ui.showCancelIconOnButton(this.ui.abilitiesButtons[0].$button);
+			}
 			return;
 		}
 		if (this.ui.dashopen) {
@@ -49,6 +52,10 @@ export class Hotkeys {
 			if (this.ui.dashopen) {
 				this.ui.gridSelectDown();
 			} else {
+				if (this.ui.game.botController?.isBotTurn()) {
+					this.ui.showCancelIconOnButton(this.ui.btnSkipTurn.$button);
+					return;
+				}
 				this.ui.btnSkipTurn.triggerClick();
 			}
 		}
@@ -69,6 +76,10 @@ export class Hotkeys {
 			if (this.ui.dashopen) {
 				this.ui.gridSelectRight();
 			} else {
+				if (this.ui.game.botController?.isBotTurn()) {
+					this.ui.showCancelIconOnButton(this.ui.btnDelay.$button);
+					return;
+				}
 				this.ui.btnDelay.triggerClick();
 			}
 		}
@@ -76,6 +87,9 @@ export class Hotkeys {
 
 	pressW() {
 		if (this.ui.game.botController?.isBotTurn()) {
+			if (!this.ui.dashopen) {
+				this.ui.showCancelIconOnButton(this.ui.abilitiesButtons[1].$button);
+			}
 			return;
 		}
 		if (!this.ui.dashopen) {
@@ -88,6 +102,9 @@ export class Hotkeys {
 
 	pressE() {
 		if (this.ui.game.botController?.isBotTurn()) {
+			if (!this.ui.dashopen) {
+				this.ui.showCancelIconOnButton(this.ui.abilitiesButtons[2].$button);
+			}
 			return;
 		}
 		if (!this.ui.dashopen) {
@@ -139,6 +156,9 @@ export class Hotkeys {
 		}
 
 		if (this.ui.game.botController?.isBotTurn()) {
+			if (!this.ui.dashopen) {
+				this.ui.showCancelIconOnButton(this.ui.abilitiesButtons[3].$button);
+			}
 			return;
 		}
 		if (!this.ui.dashopen) {

--- a/src/ui/interface.ts
+++ b/src/ui/interface.ts
@@ -911,6 +911,7 @@ export class UI {
 									if (!game.freezedInput) {
 										this.animateNoTargetAbilityRanges();
 									}
+									b.cssTransition('cancelIcon', 1000);
 									this.flashAbilityBtn(0);
 									return;
 								}
@@ -937,6 +938,14 @@ export class UI {
 									b.cssTransition('cancelIcon', 1000);
 									this.flashAbilityBtn(0);
 								}
+								return;
+							}
+							if (
+								ability.used ||
+								ability.message === game.msg.abilities.noTarget ||
+								b.state === ButtonStateEnum.noClick
+							) {
+								b.cssTransition('cancelIcon', 1000);
 								return;
 							}
 							// Colored frame around selected ability
@@ -1054,7 +1063,14 @@ export class UI {
 				{ isAcceptingInput: this.configuration.isAcceptingInput },
 			);
 			// Native listener fires even when Button state is disabled (jQuery unbind doesn't remove it).
-			b.$button[0].addEventListener('click', () => this.flashAbilityBtn(i));
+			b.$button[0].addEventListener('click', () => {
+				this.flashAbilityBtn(i);
+
+				const ability = this.game.activeCreature?.abilities[i];
+				if (ability && i !== 0 && (ability.used || b.state === ButtonStateEnum.disabled)) {
+					b.cssTransition('cancelIcon', 1000);
+				}
+			});
 			this.buttons.push(b);
 			this.abilitiesButtons.push(b);
 		}

--- a/src/ui/interface.ts
+++ b/src/ui/interface.ts
@@ -895,7 +895,11 @@ export class UI {
 							}
 						}
 
-						this.flashAbilityBtn(i);
+						// During bot turns (freezedInput), skip the invert-flash animation
+						// and directly show cancelIcon/nextIcon without blinking.
+						if (!game.freezedInput) {
+							this.flashAbilityBtn(i);
+						}
 
 						if (this.selectedAbility != i) {
 							if (this.dashopen) {
@@ -908,8 +912,12 @@ export class UI {
 								this.checkAbilities(); // Ensure state is up to date
 								const ab = game.activeCreature.abilities[0];
 								if (ab.message === game.msg.abilities.passiveUnavailable) {
-									this.animateNoTargetAbilityRanges();
-									this.flashAbilityBtn(0);
+									if (!game.freezedInput) {
+										this.animateNoTargetAbilityRanges();
+										this.flashAbilityBtn(0);
+									} else {
+										b.cssTransition('cancelIcon', 1000);
+									}
 									return;
 								}
 								// Joywin
@@ -923,7 +931,9 @@ export class UI {
 										}
 									});
 									b.cssTransition('nextIcon', 1000);
-									this.flashAbilityBtn(0);
+									if (!game.freezedInput) {
+										this.flashAbilityBtn(0);
+									}
 								} else if (selectedAbility === -1) {
 									this.abilitiesButtons.forEach((btn, index) => {
 										if (index === 0) {
@@ -932,7 +942,10 @@ export class UI {
 											this.clickedAbility = -1;
 										}
 									});
-									this.flashAbilityBtn(0);
+									b.cssTransition('cancelIcon', 1000);
+									if (!game.freezedInput) {
+										this.flashAbilityBtn(0);
+									}
 								}
 								return;
 							}
@@ -1067,7 +1080,9 @@ export class UI {
 					this.game.freezedInput &&
 					ability &&
 					i !== 0 &&
-					(ability.used || b.state === ButtonStateEnum.disabled || b.state === ButtonStateEnum.noClick)
+					(ability.used ||
+						b.state === ButtonStateEnum.disabled ||
+						b.state === ButtonStateEnum.noClick)
 				) {
 					b.cssTransition('cancelIcon', 1000);
 				}

--- a/src/ui/interface.ts
+++ b/src/ui/interface.ts
@@ -908,13 +908,9 @@ export class UI {
 								this.checkAbilities(); // Ensure state is up to date
 								const ab = game.activeCreature.abilities[0];
 								if (ab.message === game.msg.abilities.passiveUnavailable) {
-							if (!game.freezedInput) {
 									this.animateNoTargetAbilityRanges();
-								} else {
-									b.cssTransition('cancelIcon', 1000);
-								}
-								this.flashAbilityBtn(0);
-								return;
+									this.flashAbilityBtn(0);
+									return;
 								}
 								// Joywin
 								const selectedAbility = this.selectNextAbility();
@@ -928,31 +924,25 @@ export class UI {
 									});
 									b.cssTransition('nextIcon', 1000);
 									this.flashAbilityBtn(0);
-						} else if (selectedAbility === -1) {
-								this.abilitiesButtons.forEach((btn, index) => {
-									if (index === 0) {
-										btn.$button.removeClass('nextIcon');
-										btn.$button.removeClass('cancelIcon');
-										this.clickedAbility = -1;
-									}
-								});
-								if (game.freezedInput) {
-									b.cssTransition('cancelIcon', 1000);
+								} else if (selectedAbility === -1) {
+									this.abilitiesButtons.forEach((btn, index) => {
+										if (index === 0) {
+											btn.$button.removeClass('nextIcon');
+											btn.$button.removeClass('cancelIcon');
+											this.clickedAbility = -1;
+										}
+									});
+									this.flashAbilityBtn(0);
 								}
-								this.flashAbilityBtn(0);
-							}
 								return;
 							}
-					if (
-							ability.used ||
-							ability.message === game.msg.abilities.noTarget ||
-							b.state === ButtonStateEnum.noClick
-						) {
-							if (game.freezedInput) {
-								b.cssTransition('cancelIcon', 1000);
+							if (
+								ability.used ||
+								ability.message === game.msg.abilities.noTarget ||
+								b.state === ButtonStateEnum.noClick
+							) {
+								return;
 							}
-							return;
-						}
 							// Colored frame around selected ability
 							if (ability.require() == true && i != 0) {
 								if (ability._abilityRangeHexes?.length) {
@@ -1072,10 +1062,14 @@ export class UI {
 				this.flashAbilityBtn(i);
 
 				const ability = this.game.activeCreature?.abilities[i];
-				if (ability && i !== 0 && (ability.used || b.state === ButtonStateEnum.disabled)) {
-					if (this.game.freezedInput) {
-						b.cssTransition('cancelIcon', 1000);
-					}
+				if (
+					this.game.botController.isBotTurn() &&
+					this.game.freezedInput &&
+					ability &&
+					i !== 0 &&
+					(ability.used || b.state === ButtonStateEnum.disabled || b.state === ButtonStateEnum.noClick)
+				) {
+					b.cssTransition('cancelIcon', 1000);
 				}
 			});
 			this.buttons.push(b);

--- a/src/ui/interface.ts
+++ b/src/ui/interface.ts
@@ -908,12 +908,13 @@ export class UI {
 								this.checkAbilities(); // Ensure state is up to date
 								const ab = game.activeCreature.abilities[0];
 								if (ab.message === game.msg.abilities.passiveUnavailable) {
-									if (!game.freezedInput) {
-										this.animateNoTargetAbilityRanges();
-									}
+							if (!game.freezedInput) {
+									this.animateNoTargetAbilityRanges();
+								} else {
 									b.cssTransition('cancelIcon', 1000);
-									this.flashAbilityBtn(0);
-									return;
+								}
+								this.flashAbilityBtn(0);
+								return;
 								}
 								// Joywin
 								const selectedAbility = this.selectNextAbility();
@@ -927,27 +928,31 @@ export class UI {
 									});
 									b.cssTransition('nextIcon', 1000);
 									this.flashAbilityBtn(0);
-								} else if (selectedAbility === -1) {
-									this.abilitiesButtons.forEach((btn, index) => {
-										if (index === 0) {
-											btn.$button.removeClass('nextIcon');
-											btn.$button.removeClass('cancelIcon');
-											this.clickedAbility = -1;
-										}
-									});
+						} else if (selectedAbility === -1) {
+								this.abilitiesButtons.forEach((btn, index) => {
+									if (index === 0) {
+										btn.$button.removeClass('nextIcon');
+										btn.$button.removeClass('cancelIcon');
+										this.clickedAbility = -1;
+									}
+								});
+								if (game.freezedInput) {
 									b.cssTransition('cancelIcon', 1000);
-									this.flashAbilityBtn(0);
 								}
+								this.flashAbilityBtn(0);
+							}
 								return;
 							}
-							if (
-								ability.used ||
-								ability.message === game.msg.abilities.noTarget ||
-								b.state === ButtonStateEnum.noClick
-							) {
+					if (
+							ability.used ||
+							ability.message === game.msg.abilities.noTarget ||
+							b.state === ButtonStateEnum.noClick
+						) {
+							if (game.freezedInput) {
 								b.cssTransition('cancelIcon', 1000);
-								return;
 							}
+							return;
+						}
 							// Colored frame around selected ability
 							if (ability.require() == true && i != 0) {
 								if (ability._abilityRangeHexes?.length) {
@@ -1068,7 +1073,9 @@ export class UI {
 
 				const ability = this.game.activeCreature?.abilities[i];
 				if (ability && i !== 0 && (ability.used || b.state === ButtonStateEnum.disabled)) {
-					b.cssTransition('cancelIcon', 1000);
+					if (this.game.freezedInput) {
+						b.cssTransition('cancelIcon', 1000);
+					}
 				}
 			});
 			this.buttons.push(b);

--- a/src/ui/interface.ts
+++ b/src/ui/interface.ts
@@ -939,14 +939,13 @@ export class UI {
 						}
 								return;
 							}
-						if (
-							ability.used ||
-							ability.message === game.msg.abilities.noTarget ||
-							b.state === ButtonStateEnum.noClick
-						) {
-							b.cssTransition('cancelIcon', 1000);
-							return;
-						}
+					if (
+						ability.used ||
+						ability.message === game.msg.abilities.noTarget ||
+						b.state === ButtonStateEnum.noClick
+					) {
+						return;
+					}
 							// Colored frame around selected ability
 							if (ability.require() == true && i != 0) {
 								if (ability._abilityRangeHexes?.length) {
@@ -2992,6 +2991,16 @@ export class UI {
 		)
 			return;
 		const $btn = this.abilitiesButtons[i].$button;
+
+		// During bot turns, skip the blink animation and just show cancelIcon briefly
+		if (this.game.botController?.isBotTurn()) {
+			$btn.removeClass('cancelIcon');
+			void $btn[0].offsetWidth;
+			$btn.addClass('cancelIcon');
+			setTimeout(() => $btn.removeClass('cancelIcon'), 1000);
+			return;
+		}
+
 		$btn.removeClass('iconInvertFlash');
 		void $btn[0].offsetWidth;
 		$btn.addClass('iconInvertFlash');

--- a/src/ui/interface.ts
+++ b/src/ui/interface.ts
@@ -895,11 +895,7 @@ export class UI {
 							}
 						}
 
-						// During bot turns (freezedInput), skip the invert-flash animation
-						// and directly show cancelIcon/nextIcon without blinking.
-						if (!game.freezedInput) {
-							this.flashAbilityBtn(i);
-						}
+						this.flashAbilityBtn(i);
 
 						if (this.selectedAbility != i) {
 							if (this.dashopen) {
@@ -911,14 +907,12 @@ export class UI {
 							if (i == 0) {
 								this.checkAbilities(); // Ensure state is up to date
 								const ab = game.activeCreature.abilities[0];
-								if (ab.message === game.msg.abilities.passiveUnavailable) {
-									if (!game.freezedInput) {
-										this.animateNoTargetAbilityRanges();
-										this.flashAbilityBtn(0);
-									} else {
-										b.cssTransition('cancelIcon', 1000);
-									}
-									return;
+							if (ab.message === game.msg.abilities.passiveUnavailable) {
+								if (!game.freezedInput) {
+									this.animateNoTargetAbilityRanges();
+								}
+								this.flashAbilityBtn(0);
+								return;
 								}
 								// Joywin
 								const selectedAbility = this.selectNextAbility();
@@ -930,32 +924,29 @@ export class UI {
 											this.clickedAbility = -1;
 										}
 									});
-									b.cssTransition('nextIcon', 1000);
-									if (!game.freezedInput) {
-										this.flashAbilityBtn(0);
-									}
-								} else if (selectedAbility === -1) {
-									this.abilitiesButtons.forEach((btn, index) => {
-										if (index === 0) {
-											btn.$button.removeClass('nextIcon');
-											btn.$button.removeClass('cancelIcon');
-											this.clickedAbility = -1;
-										}
-									});
-									b.cssTransition('cancelIcon', 1000);
-									if (!game.freezedInput) {
-										this.flashAbilityBtn(0);
-									}
+							b.cssTransition('nextIcon', 1000);
+							this.flashAbilityBtn(0);
+						} else if (selectedAbility === -1) {
+							this.abilitiesButtons.forEach((btn, index) => {
+								if (index === 0) {
+									btn.$button.removeClass('nextIcon');
+									btn.$button.removeClass('cancelIcon');
+									this.clickedAbility = -1;
 								}
+							});
+							b.cssTransition('cancelIcon', 1000);
+							this.flashAbilityBtn(0);
+						}
 								return;
 							}
-							if (
-								ability.used ||
-								ability.message === game.msg.abilities.noTarget ||
-								b.state === ButtonStateEnum.noClick
-							) {
-								return;
-							}
+						if (
+							ability.used ||
+							ability.message === game.msg.abilities.noTarget ||
+							b.state === ButtonStateEnum.noClick
+						) {
+							b.cssTransition('cancelIcon', 1000);
+							return;
+						}
 							// Colored frame around selected ability
 							if (ability.require() == true && i != 0) {
 								if (ability._abilityRangeHexes?.length) {
@@ -1071,22 +1062,7 @@ export class UI {
 				{ isAcceptingInput: this.configuration.isAcceptingInput },
 			);
 			// Native listener fires even when Button state is disabled (jQuery unbind doesn't remove it).
-			b.$button[0].addEventListener('click', () => {
-				this.flashAbilityBtn(i);
-
-				const ability = this.game.activeCreature?.abilities[i];
-				if (
-					this.game.botController.isBotTurn() &&
-					this.game.freezedInput &&
-					ability &&
-					i !== 0 &&
-					(ability.used ||
-						b.state === ButtonStateEnum.disabled ||
-						b.state === ButtonStateEnum.noClick)
-				) {
-					b.cssTransition('cancelIcon', 1000);
-				}
-			});
+			b.$button[0].addEventListener('click', () => this.flashAbilityBtn(i));
 			this.buttons.push(b);
 			this.abilitiesButtons.push(b);
 		}

--- a/src/ui/interface.ts
+++ b/src/ui/interface.ts
@@ -686,6 +686,9 @@ export class UI {
 				click: () => {
 					if (!this.dashopen) {
 						if (game.turnThrottle || game.botController.isBotTurn()) {
+							if (game.botController.isBotTurn()) {
+								this.showCancelIconOnButton(this.btnSkipTurn.$button);
+							}
 							return;
 						}
 
@@ -722,6 +725,9 @@ export class UI {
 							!game.activeCreature?.canWait ||
 							game.queue.isCurrentEmpty()
 						) {
+							if (game.botController.isBotTurn()) {
+								this.showCancelIconOnButton(this.btnDelay.$button);
+							}
 							return;
 						}
 
@@ -826,16 +832,17 @@ export class UI {
 				{
 					$button: $j('.ability[ability="' + i + '"]'),
 					hasShortcut: true,
-					click: () => {
-						const game = this.game;
+				click: () => {
+					const game = this.game;
 
-						// Don't show ability range circles during bot's turn
-						if (game.botController.isBotTurn()) {
-							return;
-						}
+					// During bot turns, show cancelIcon and block interaction
+					if (game.botController.isBotTurn()) {
+						this.showCancelIconOnButton(b.$button);
+						return;
+					}
 
-						// Block all ability interactions while an animation is running
-						if (game.freezedInput) {
+					// Block all ability interactions while an animation is running
+					if (game.freezedInput) {
 							return;
 						}
 
@@ -2977,6 +2984,17 @@ export class UI {
 				});
 			}
 		});
+	}
+
+	/**
+	 * Show cancelIcon briefly on any button element during bot turns.
+	 * Used for skip/delay buttons and ability hotkey feedback.
+	 */
+	showCancelIconOnButton($btn: JQuery<HTMLElement>) {
+		$btn.removeClass('cancelIcon');
+		void $btn[0].offsetWidth; // force reflow
+		$btn.addClass('cancelIcon');
+		setTimeout(() => $btn.removeClass('cancelIcon'), 1000);
 	}
 
 	flashAbilityBtn(i: number) {


### PR DESCRIPTION
## Summary

Fixes #2174.

Shows the temporary cancel icon when clicking abilities that cannot be used:
- passive ability when it has no available ability to cycle to
- active abilities that are already used
- active abilities with no target
- active buttons in a no-click or disabled state

## Impact

Players now get the expected visual feedback instead of a silent click or an attempted unusable ability activation.

## Validation

- `npm run lint -- --quiet src/ui/interface.ts`
- `npm run build`
- `env NODE_OPTIONS=--max-old-space-size=4096 npm run test:jest -- --runInBand`
