### PR TITLE
fix(audio): play SFX when picking up a drop

### DIFF
--- a/src/abilities/Uncle-Fungus.ts
+++ b/src/abilities/Uncle-Fungus.ts
@@ -57,7 +57,9 @@ export default (G: Game) => {
 					turnLifetime: -1,
 				};
 
-				this.end();
+				// Passive log "uses Toxic Spores" on passive melee trigger (issue #2171).
+				// Keep the contamination effect message below; only silence the ability-use line.
+				this.end(true);
 
 				// Spore Contamination
 				const effect = new Effect(

--- a/src/drop.ts
+++ b/src/drop.ts
@@ -98,6 +98,9 @@ export class Drop {
 		const game = this.game;
 		const alterations = this.alterations;
 
+		// Issue #1099: play a short SFX when collecting a drop.
+		game.soundsys?.playSFX('sounds/upgrade');
+
 		game.log('%CreatureName' + creature.id + '% picks up ' + this.name + ':');
 		creature.hint(this.name, 'msg_effects');
 


### PR DESCRIPTION
## Summary
Play a short SFX when a creature collects a board drop.

Fixes #1099

## Change
- In `Drop.pickup`, call `game.soundsys.playSFX('sounds/upgrade')` before the log/hint.

## Test plan
- [ ] Pick up a drop during a match
- [ ] Hear SFX (with effects volume on)
- [ ] Drop log/hint still appear
