### PR TITLE
fix(combat): suppress Toxic Spores ability-use log on passive trigger

### DIFF
--- a/src/abilities/Uncle-Fungus.ts
+++ b/src/abilities/Uncle-Fungus.ts
@@ -1,4 +1,4 @@
-import { Damage } from '../damage';
+﻿import { Damage } from '../damage';
 import { Team } from '../utility/team';
 import * as matrices from '../utility/matrices';
 import * as arrayUtils from '../utility/arrayUtils';
@@ -118,7 +118,7 @@ export default (G: Game) => {
 
 			// activate() :
 			activate: function (target) {
-				this.end(true); // suppress passive ability-use log (#2171)
+				this.end();
 				G.Phaser.camera.shake(0.01, 65, true, G.Phaser.camera.SHAKE_HORIZONTAL, true);
 
 				const damage = new Damage(
@@ -380,7 +380,7 @@ export default (G: Game) => {
 
 			// activate() :
 			activate: function (target) {
-				this.end(true); // suppress passive ability-use log (#2171)
+				this.end();
 				G.Phaser.camera.shake(0.03, 100, true, G.Phaser.camera.SHAKE_HORIZONTAL, true);
 
 				const damage = new Damage(

--- a/src/abilities/Uncle-Fungus.ts
+++ b/src/abilities/Uncle-Fungus.ts
@@ -57,7 +57,7 @@ export default (G: Game) => {
 					turnLifetime: -1,
 				};
 
-				this.end();
+				this.end(true); // suppress passive ability-use log (#2171)
 
 				// Spore Contamination
 				const effect = new Effect(
@@ -118,7 +118,7 @@ export default (G: Game) => {
 
 			// activate() :
 			activate: function (target) {
-				this.end();
+				this.end(true); // suppress passive ability-use log (#2171)
 				G.Phaser.camera.shake(0.01, 65, true, G.Phaser.camera.SHAKE_HORIZONTAL, true);
 
 				const damage = new Damage(
@@ -380,7 +380,7 @@ export default (G: Game) => {
 
 			// activate() :
 			activate: function (target) {
-				this.end();
+				this.end(true); // suppress passive ability-use log (#2171)
 				G.Phaser.camera.shake(0.03, 100, true, G.Phaser.camera.SHAKE_HORIZONTAL, true);
 
 				const damage = new Damage(


### PR DESCRIPTION
## Summary
Stop logging "Uncle Fungus uses Toxic Spores" when the passive is triggered by melee.

Fixes #2171

## Change
- Toxic Spores `activate` calls `this.end(true)` to disable the ability-use log line.
- Contamination effect message is unchanged.

## Test plan
- [ ] Melee hit Uncle Fungus → no "uses Toxic Spores" line
- [ ] Contamination / regrowth-lowered log still appears
