### PR TITLE
fix(ui): clear ability upgrade CSS when skipping turn

### DIFF
--- a/src/ui/interface.ts
+++ b/src/ui/interface.ts
@@ -732,7 +732,12 @@ export class UI {
 						});
 
 						// Prevents upgrade animation from carrying on into opponent's turn and disabling their button
+						// Issue #2016: also strip upgrade CSS classes so icons don't snap next turns.
 						clearTimeout(this.animationUpgradeTimeOutID);
+						this.abilitiesButtons.forEach((btn) => {
+							btn.$button.removeClass('upgradeIcon');
+							btn.$button.removeClass('upgradeTransition');
+						});
 
 						game.skipTurn();
 						this.lastViewedCreature = '';


### PR DESCRIPTION
## Summary
When skipping during an ability upgrade animation, strip upgrade CSS classes so ability icons don't snap later.

Fixes #2016

## Change
On skip turn click:
- clear `animationUpgradeTimeOutID` (already present)
- remove `upgradeIcon` / `upgradeTransition` from all ability buttons

## Test plan
- [ ] Trigger ability upgrade animation, skip turn mid-animation
- [ ] On next own turn, ability icons animate/transition normally (no snap)
