### PR TITLE
fix(ui): hex coordinate view without unit x-ray

### DIFF
--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -738,7 +738,7 @@ export class Hex {
 			this.overlay.alignIn(this.hitBox, Phaser.CENTER);
 		}
 
-		// Display Coord
+		// Display Coord (#2250: always visible on top of units when showGrid)
 		if (this.displayClasses.match(/showGrid/g)) {
 			if (!(this.coordText && this.coordText.exists)) {
 				this.coordText = this.game.Phaser.add.text(
@@ -751,12 +751,19 @@ export class Hex {
 						align: 'center',
 					},
 				);
-				if (this.creature || this.trap || this.drop) {
-					this.coordText.stroke = '#ffffff';
-					this.coordText.strokeThickness = 5;
-				}
+				// White stroke so coords stay readable over units/sprites
+				this.coordText.stroke = '#ffffff';
+				this.coordText.strokeThickness = 5;
 				this.coordText.anchor.setTo(0.5);
+				// Use overlay group so text sits above units
 				this.grid.overlayHexesGroup.add(this.coordText);
+			}
+			if (this.coordText && this.grid.overlayHexesGroup.bringToTop) {
+				this.grid.overlayHexesGroup.bringToTop(this.coordText);
+			}
+			// #2250: dashed hex at 25% opacity when hex has no unit; full when occupied
+			if (this.displayClasses.match(/\bdashed\b/) && !this.creature) {
+				this.display.alpha = Math.min(this.display.alpha, 0.25);
 			}
 		} else if (this.coordText && this.coordText.exists) {
 			this.coordText.destroy();

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -1951,20 +1951,26 @@ export class HexGrid {
 		return hexes;
 	}
 
+	/**
+	 * Hexagon coordinate view (shift / round-marker hover).
+	 * Spec #2250:
+	 * - no unit x-ray
+	 * - coordinates on top of units
+	 * - dashed hex grid on top of units
+	 * - dashed hexes at 25% opacity where no unit
+	 */
 	showGrid(val) {
 		this.forEachHex((hex) => {
+			// #2250: never x-ray units in coordinate view (was tedious)
 			if (hex.creature) {
-				hex.creature.xray(val);
-			}
-
-			if (hex.drop) {
-				return;
+				hex.creature.xray(false);
 			}
 
 			if (val) {
-				hex.displayVisualState('showGrid');
+				hex.displayVisualState('showGrid dashed');
 			} else {
 				hex.cleanDisplayVisualState('showGrid');
+				hex.cleanDisplayVisualState('dashed');
 			}
 		});
 	}


### PR DESCRIPTION
## Summary
Improve hexagon coordinate view (shift / round-marker hover) per #2250.

Fixes #2250

## Spec
- Units are **not** x-rayed in coordinate view
- Coordinates render with stroke and stay on top (overlay group)
- Dashed hex grid enabled with showGrid
- Empty hexes use lower dashed opacity (~25%) so units stay readable

## Test plan
- [ ] Hold shift or hover round marker → coords + dashed grid
- [ ] Units stay solid (no x-ray)
- [ ] Coords readable over units
- [ ] Release shift → grid/coords clear
