### PR TITLE
fix(ui): progress cursor when hovering active unit without ability

### DIFF
--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -201,6 +201,19 @@ export class HexGrid {
 		return isLocalPlayerTurn ? normalCursor : 'wait';
 	}
 
+	/**
+	 * Issue #2246: progress cursor when hovering the active unit with no ability
+	 * selected, or when the unit cannot take further actions.
+	 */
+	private shouldUseProgressCursorOnActiveUnit(creature: Creature): boolean {
+		const game = this.game;
+		if (!(creature instanceof Creature) || creature !== game.activeCreature) {
+			return false;
+		}
+		const noAbilitySelected = !(game.UI && game.UI.selectedAbility >= 0);
+		return noAbilitySelected || Boolean(creature.noActionPossible);
+	}
+
 	get allhexes(): Hex[] {
 		return this.hexes.flat(1);
 	}
@@ -1230,13 +1243,8 @@ export class HexGrid {
 					// Filled hex with color
 					hex.displayVisualState('creature player' + hex.creature.team);
 				}
-			} else {
-				// #2246: progress cursor on active unit when no ability selected
-				// or the unit cannot act (already used / no action possible)
-				const noAbilitySelected = !(game.UI && game.UI.selectedAbility >= 0);
-				if (noAbilitySelected || game.activeCreature.noActionPossible) {
-					$j('canvas').css('cursor', this.getCursorForMultiplayer('progress'));
-				}
+			} else if (this.shouldUseProgressCursorOnActiveUnit(creature)) {
+				$j('canvas').css('cursor', this.getCursorForMultiplayer('progress'));
 			}
 			queueEffect(creature.id);
 		};
@@ -1411,19 +1419,15 @@ export class HexGrid {
 
 				hex.creature.startBounce();
 
-				if (game.activeCreature === hex.creature) {
-					// #2246: progress cursor when no ability selected or cannot act
-					const noAbilitySelected = !(game.UI && game.UI.selectedAbility >= 0);
-					if (noAbilitySelected || hex.creature.noActionPossible) {
-						$j('canvas').css('cursor', this.getCursorForMultiplayer('progress'));
-					}
-					if (hex.creature.noActionPossible) {
-						game.UI.hoveringNoActionCreature = true;
-						game.UI.btnSkipTurn.$button.removeClass('bounce');
-						game.UI.btnSkipTurn.$button.removeClass('hidden');
-						// Show "Skip Turn" icon
-						hex.creature.hint('Skip turn', 'no_action');
-					}
+				if (this.shouldUseProgressCursorOnActiveUnit(hex.creature)) {
+					$j('canvas').css('cursor', this.getCursorForMultiplayer('progress'));
+				}
+				if (game.activeCreature === hex.creature && hex.creature.noActionPossible) {
+					game.UI.hoveringNoActionCreature = true;
+					game.UI.btnSkipTurn.$button.removeClass('bounce');
+					game.UI.btnSkipTurn.$button.removeClass('hidden');
+					// Show "Skip Turn" icon
+					hex.creature.hint('Skip turn', 'no_action');
 				}
 				game.UI.chat.isOverCreature = true;
 			}

--- a/src/utility/hexgrid.ts
+++ b/src/utility/hexgrid.ts
@@ -1230,8 +1230,13 @@ export class HexGrid {
 					// Filled hex with color
 					hex.displayVisualState('creature player' + hex.creature.team);
 				}
-			} else if (game.activeCreature.noActionPossible) {
-				$j('canvas').css('cursor', this.getCursorForMultiplayer('progress'));
+			} else {
+				// #2246: progress cursor on active unit when no ability selected
+				// or the unit cannot act (already used / no action possible)
+				const noAbilitySelected = !(game.UI && game.UI.selectedAbility >= 0);
+				if (noAbilitySelected || game.activeCreature.noActionPossible) {
+					$j('canvas').css('cursor', this.getCursorForMultiplayer('progress'));
+				}
 			}
 			queueEffect(creature.id);
 		};
@@ -1406,12 +1411,19 @@ export class HexGrid {
 
 				hex.creature.startBounce();
 
-				if (game.activeCreature === hex.creature && hex.creature.noActionPossible) {
-					game.UI.hoveringNoActionCreature = true;
-					game.UI.btnSkipTurn.$button.removeClass('bounce');
-					game.UI.btnSkipTurn.$button.removeClass('hidden');
-					// Show "Skip Turn" icon
-					hex.creature.hint('Skip turn', 'no_action');
+				if (game.activeCreature === hex.creature) {
+					// #2246: progress cursor when no ability selected or cannot act
+					const noAbilitySelected = !(game.UI && game.UI.selectedAbility >= 0);
+					if (noAbilitySelected || hex.creature.noActionPossible) {
+						$j('canvas').css('cursor', this.getCursorForMultiplayer('progress'));
+					}
+					if (hex.creature.noActionPossible) {
+						game.UI.hoveringNoActionCreature = true;
+						game.UI.btnSkipTurn.$button.removeClass('bounce');
+						game.UI.btnSkipTurn.$button.removeClass('hidden');
+						// Show "Skip Turn" icon
+						hex.creature.hint('Skip turn', 'no_action');
+					}
 				}
 				game.UI.chat.isOverCreature = true;
 			}


### PR DESCRIPTION
## Summary
Show CSS `progress` cursor when hovering the active unit if no ability is selected (or unit cannot act).

Fixes #2246

## Change
- In hex hover / creature hover handlers: when target is active creature and `selectedAbility < 0` (or noActionPossible), set canvas cursor to progress.

## Test plan
- [ ] Active unit, no ability selected — hover unit → progress cursor
- [ ] Select an ability — cursor returns to pointer / ability cursor
- [ ] noActionPossible still shows progress + skip hint
