### PR TITLE
fix(ability): do not turn Golden Wyrm when casting Visible Stigmata

### DIFF
--- a/src/abilities/Golden-Wyrm.ts
+++ b/src/abilities/Golden-Wyrm.ts
@@ -320,6 +320,10 @@ export default (G: Game) => {
 		{
 			trigger: 'onQuery',
 
+			// #1965: do not turn to face allies when casting Visible Stigmata
+			// (especially frontal-diagonal adjacent targets).
+			doNotFaceTarget: true,
+
 			_targetTeam: Team.Ally,
 
 			_maxTransferAmount: 50,

--- a/src/ability.ts
+++ b/src/ability.ts
@@ -102,6 +102,11 @@ export class Ability {
 	showHoverPreviewRange?: boolean;
 	activate?: (target?: any, hex?: any, path?: Hex[]) => unknown;
 	getAnimationData?: (...args: unknown[]) => unknown;
+	/**
+	 * When true, casting animation keeps the unit facing its default player
+	 * direction instead of turning toward the target (e.g. Golden Wyrm #1965).
+	 */
+	doNotFaceTarget?: boolean;
 	damages?: Partial<CreatureMasteries> & { pure?: number };
 	effects?: AbilityEffect[];
 	message?: string;
@@ -560,8 +565,8 @@ export class Ability {
 
 		this.creature.facePlayerDefault();
 
-		// Force creatures to face towards their target
-		if (args[0]) {
+		// Force creatures to face towards their target (unless ability opts out)
+		if (args[0] && !this.doNotFaceTarget) {
 			if (args[0] instanceof Creature) {
 				this.creature.faceHex(args[0]);
 			} else if (args[0] instanceof Array) {


### PR DESCRIPTION
## Summary
Prevent Golden Wyrm from turning to face allies when casting **Visible Stigmata** (especially frontal-diagonal adjacent targets).

Fixes #1965

## Change
- Add optional `doNotFaceTarget` on `Ability`
- Skip `faceHex` in cast animation when set
- Enable on Visible Stigmata

## Test plan
- [ ] Cast Visible Stigmata on frontal-diagonal ally — Wyrm keeps default facing
- [ ] Other abilities still face targets as before
