### PR TITLE
fix(ui): non-spinning path cursor on ability target unit hexes

### DIFF
--- a/src/utility/hex.ts
+++ b/src/utility/hex.ts
@@ -795,10 +795,19 @@ export class Hex {
 				this.grid.overlayHexesGroup.bringToTop(this.overlay);
 			}
 		} else {
-			loadTextureIfChanged(this.overlay, 'input');
-			this.overlay.anchor.set(0.5, 0.5);
-			if (!this.isSpinning) {
-				this.startSpinning();
+			// #2004: when targeting a unit hex, use non-spinning path cursor over
+			// the filled outline — spinning "input" is for empty/out-of-range hexes only.
+			if (this.creature instanceof Creature) {
+				this.stopSpinning();
+				loadTextureIfChanged(this.overlay, 'hex_path');
+				this.overlay.anchor.set(0.5, 0.5);
+				this.grid.overlayHexesGroup.bringToTop(this.overlay);
+			} else {
+				loadTextureIfChanged(this.overlay, 'input');
+				this.overlay.anchor.set(0.5, 0.5);
+				if (!this.isSpinning) {
+					this.startSpinning();
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary
When ability-targeting a unit hex, use a **non-spinning** `hex_path` overlay on top of the filled outline instead of the spinning empty-hex cursor.

Fixes #2004

## Change
- In `Hex.updateStyle`: if hex has a creature and would use spinning `input` texture, use non-spinning `hex_path` and bring overlay to top
- Empty / out-of-range hexes keep spinning cursor behavior

## Test plan
- [ ] Select unit-targeting ability — hover target unit hexes show static path cursor over outline
- [ ] Multi-hex unit: hover any base hex selectable
- [ ] Out-of-range empty hex still shows spinning cursor
