### PR TITLE
fix(ui): diversify Godlet Printer random unit picks

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -144,6 +144,8 @@ export default class Game {
 	triggers: Record<string, RegExp>;
 	signals: Record<string, Signal>;
 	botController: BotController;
+	/** Last unit type materialized by any player (Godlet Printer variety, #1773). */
+	lastMaterializedType?: CreatureType | string;
 
 	// The optionals below are created by the various methods of `Game`, mainly by `setup` and `loadGame`
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -188,6 +188,10 @@ export class Player {
 
 		this.creatures.push(creature);
 		creature.summon(!this._summonCreaturesWithMaterializationSickness);
+		// Track last summon for Godlet Printer random variety (#1773)
+		if (type !== '--') {
+			game.lastMaterializedType = type;
+		}
 		// @ts-expect-error 2554
 		game.onCreatureSummon(creature);
 	}

--- a/src/ui/interface.ts
+++ b/src/ui/interface.ts
@@ -2163,7 +2163,8 @@ export class UI {
 		const lastType = game.lastMaterializedType;
 		const preferred = availableTypes.filter((t) => t !== lastType && !onFieldOrDead.has(t));
 		// Fall back: exclude only last materialized; then full available list
-		const preferredOrAlt = preferred.length > 0 ? preferred : availableTypes.filter((t) => t !== lastType);
+		const preferredOrAlt =
+			preferred.length > 0 ? preferred : availableTypes.filter((t) => t !== lastType);
 		const pool = preferredOrAlt.length > 0 ? preferredOrAlt : availableTypes;
 
 		// Randomize pool

--- a/src/ui/interface.ts
+++ b/src/ui/interface.ts
@@ -2158,17 +2158,34 @@ export class UI {
 			excludeTypes: deadOrSummonedTypes,
 		});
 
-		// Randomize array to grab a random creature
-		for (let i = availableTypes.length - 1; i > 0; i--) {
+		// #1773: prefer units not on field, not dead, and not just materialized by anyone
+		const onFieldOrDead = new Set(
+			activePlayer.creatures
+				.filter((c) => !c.temp)
+				.map((c) => c.type),
+		);
+		const lastType = game.lastMaterializedType;
+		const preferred = availableTypes.filter(
+			(t) => t !== lastType && !onFieldOrDead.has(t),
+		);
+		// Fall back: exclude only last materialized; then full available list
+		const preferredOrAlt =
+			preferred.length > 0
+				? preferred
+				: availableTypes.filter((t) => t !== lastType);
+		const pool = preferredOrAlt.length > 0 ? preferredOrAlt : availableTypes;
+
+		// Randomize pool
+		for (let i = pool.length - 1; i > 0; i--) {
 			const j = Math.floor(Math.random() * (i + 1));
-			const temp = availableTypes[i];
-			availableTypes[i] = availableTypes[j];
-			availableTypes[j] = temp;
+			const temp = pool[i];
+			pool[i] = pool[j];
+			pool[j] = temp;
 		}
 
 		// Grab the first creature we can afford (if none, default to priest)
 		let typeToPass = '--';
-		availableTypes.some((creature) => {
+		pool.some((creature) => {
 			const lvl = parseInt(creature.substring(1, 2)) - 0;
 			const size = game.retrieveCreatureStats(creature).size - 0;
 			const plasmaCost = lvl + size;

--- a/src/ui/interface.ts
+++ b/src/ui/interface.ts
@@ -2159,20 +2159,11 @@ export class UI {
 		});
 
 		// #1773: prefer units not on field, not dead, and not just materialized by anyone
-		const onFieldOrDead = new Set(
-			activePlayer.creatures
-				.filter((c) => !c.temp)
-				.map((c) => c.type),
-		);
+		const onFieldOrDead = new Set(activePlayer.creatures.filter((c) => !c.temp).map((c) => c.type));
 		const lastType = game.lastMaterializedType;
-		const preferred = availableTypes.filter(
-			(t) => t !== lastType && !onFieldOrDead.has(t),
-		);
+		const preferred = availableTypes.filter((t) => t !== lastType && !onFieldOrDead.has(t));
 		// Fall back: exclude only last materialized; then full available list
-		const preferredOrAlt =
-			preferred.length > 0
-				? preferred
-				: availableTypes.filter((t) => t !== lastType);
+		const preferredOrAlt = preferred.length > 0 ? preferred : availableTypes.filter((t) => t !== lastType);
 		const pool = preferredOrAlt.length > 0 ? preferredOrAlt : availableTypes;
 
 		// Randomize pool


### PR DESCRIPTION
## Summary
When Dark Priest opens Godlet Printer random selection, prefer unit types that are not currently on the field / dead and were not just materialized by anyone.

Fixes #1773

## Change
- Track `game.lastMaterializedType` on player summon
- `showRandomCreature` prioritizes candidates excluding last-materialized and on-field/dead types, with fallbacks

## Test plan
- [ ] Godlet Printer random — tends not to re-pick the unit just summoned
- [ ] Still only picks affordable units from the available pool
- [ ] If only one option left, still works
