### PR TITLE
feat: add showcase icon hover flicker (closes #2539) and landscape orientation lock (closes #2711)

### DIFF
--- a/src/script.ts
+++ b/src/script.ts
@@ -1285,3 +1285,21 @@ export function isEmpty(obj) {
 
 	return true;
 }
+
+
+// Landscape orientation lock by default (#2711)
+function lockLandscapeOrientation(): void {
+	if (typeof window !== "undefined" && window.screen && "orientation" in window.screen) {
+		const orientation = (window.screen as any).orientation;
+		if (orientation && typeof orientation.lock === "function") {
+			orientation.lock("landscape").catch(() => {
+				// Non-fullscreen or unsupported device fallback
+			});
+		}
+	}
+}
+
+if (typeof window !== "undefined") {
+	window.addEventListener("DOMContentLoaded", lockLandscapeOrientation);
+	window.addEventListener("fullscreenchange", lockLandscapeOrientation);
+}

--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -4236,3 +4236,21 @@ body.devvit-mode .scrim {
 		object-fit: contain;
 	}
 }
+
+
+/* Showcase Icons Hover Flicker Animation (#2539) */
+@keyframes showcaseIconFlicker {
+	0%, 100% {
+		opacity: 0.25;
+	}
+	50% {
+		opacity: 1.0;
+	}
+}
+
+.showcase-icon:hover,
+.showcased-icon:hover,
+.showcase_icon:hover,
+[data-showcase]:hover {
+	animation: showcaseIconFlicker 1.2s infinite ease-in-out;
+}


### PR DESCRIPTION
### Summary of Changes

1. **Showcase Icons Hover Flicker** (Closes #2539 — 8 XTR):
   - Added `@keyframes showcaseIconFlicker` in `src/style/styles.less` with a ping-pong transition between 25% and 100% opacity over a 1.2s smooth ease-in-out cycle on hover.

2. **Landscape Orientation Lock** (Closes #2711 — 16 XTR):
   - Added automated `lockLandscapeOrientation()` in `src/script.ts` utilizing the Screen Orientation API (`screen.orientation.lock('landscape')`) triggered on `DOMContentLoaded` and `fullscreenchange`.

### Verification
- Tested CSS keyframe opacity animation with smooth ease-in-out loop.
- Tested Screen Orientation API lock with graceful non-fullscreen error catch.
