### PR TITLE
fix(dash): don't offer the just-materialized unit as the random pick (fixes #1773)

### DIFF
--- a/src/__tests__/utility/summon-candidates.test.ts
+++ b/src/__tests__/utility/summon-candidates.test.ts
@@ -1,0 +1,63 @@
+import { expect, describe, test } from '@jest/globals';
+import { getRandomSummonCandidates } from '../../utility/summon-candidates';
+import type Game from '../../game';
+import type { CreatureType } from '../../data/types';
+
+const A1 = 'A1' as unknown as CreatureType;
+const G2 = 'G2' as unknown as CreatureType;
+
+/**
+ * Minimal Game stand-in. The helper only needs creature stats to work out
+ * plasma costs, which are level + size, so 'A1' costs 2 and 'G2' costs 4.
+ */
+function makeGame(): Game {
+	const game = {
+		retrieveCreatureStats: (type: CreatureType) => ({
+			size: Number.parseInt(type.substring(1, 2), 10),
+			playable: true,
+		}),
+	};
+
+	return game as unknown as Game;
+}
+
+describe('getRandomSummonCandidates', () => {
+	test('returns every candidate when nothing was materialized before', () => {
+		const candidates = [A1, G2];
+
+		expect(getRandomSummonCandidates(makeGame(), candidates, 10, null)).toEqual([A1, G2]);
+		expect(getRandomSummonCandidates(makeGame(), candidates, 10)).toEqual([A1, G2]);
+	});
+
+	test('drops the type materialized right before when something else is affordable', () => {
+		const candidates = [A1, G2];
+		const result = getRandomSummonCandidates(makeGame(), candidates, 10, A1);
+
+		expect(result).toEqual([G2]);
+	});
+
+	test('keeps the type materialized right before when nothing else is affordable', () => {
+		// 'A1' costs 2 and 'G2' costs 4, so 2 plasma only affords 'A1'.
+		const candidates = [A1, G2];
+		const result = getRandomSummonCandidates(makeGame(), candidates, 2, A1);
+
+		expect(result).toEqual([A1, G2]);
+	});
+
+	test('keeps the type materialized right before when it is the only candidate', () => {
+		const candidates = [A1];
+		const result = getRandomSummonCandidates(makeGame(), candidates, 10, A1);
+
+		expect(result).toEqual([A1]);
+	});
+
+	test('does not mutate the candidates it was given', () => {
+		// The caller shuffles the result in place, so the source array must survive.
+		const candidates = [A1, G2];
+		const result = getRandomSummonCandidates(makeGame(), candidates, 10, null);
+
+		result.reverse();
+
+		expect(candidates).toEqual([A1, G2]);
+	});
+});

--- a/src/game.ts
+++ b/src/game.ts
@@ -122,6 +122,7 @@ export default class Game {
 	unitDrops: number;
 	minimumTurnBeforeFleeing: number;
 	availableCreatures: CreatureType[];
+	lastSummonedType: CreatureType | null;
 	animationQueue: (Animation | AnimationID)[];
 	checkTimeFrequency: number;
 	gamelog: GameLog;
@@ -326,6 +327,7 @@ export default class Game {
 		this.unitDrops = 0;
 		this.minimumTurnBeforeFleeing = 12;
 		this.availableCreatures = [];
+		this.lastSummonedType = null;
 		this.animationQueue = [];
 		this.checkTimeFrequency = 1000;
 		this._deferredQueryMovePending = 0;
@@ -2198,6 +2200,7 @@ export default class Game {
 		this.pause = false;
 		this.gameState = 'initialized';
 		this.availableCreatures = [];
+		this.lastSummonedType = null;
 		this.animationQueue = [];
 		this.configData = {};
 		this.match = {};

--- a/src/player.ts
+++ b/src/player.ts
@@ -188,6 +188,9 @@ export class Player {
 
 		this.creatures.push(creature);
 		creature.summon(!this._summonCreaturesWithMaterializationSickness);
+		// Remember what was materialized last so a random materialization can
+		// offer something else instead of copy-catting this one.
+		game.lastSummonedType = type;
 		// @ts-expect-error 2554
 		game.onCreatureSummon(creature);
 	}

--- a/src/ui/interface.ts
+++ b/src/ui/interface.ts
@@ -24,7 +24,7 @@ import Game from '../game';
 import { CreatureType } from '../data/types';
 import { getAvatarSet } from '../style/avatar-styles';
 import { applyBuffDebuffStyle } from './buffs-debuffs';
-import { getSummonCandidates } from '../utility/summon-candidates';
+import { getRandomSummonCandidates, getSummonCandidates } from '../utility/summon-candidates';
 import { OpenCollectiveBanner, isThirdPartyContentBlocked } from './open-collective-banner';
 
 const SECRET_VIEW_ID = 'ab-secret-view';
@@ -2204,9 +2204,17 @@ export class UI {
 		// Figure out what the active player can summon
 		const activePlayer = game.players[this.game.activeCreature.player.id];
 		const deadOrSummonedTypes = new Set(activePlayer.creatures.map((creature) => creature.type));
-		const availableTypes = getSummonCandidates(game, activePlayer.availableCreatures, {
+		const summonableTypes = getSummonCandidates(game, activePlayer.availableCreatures, {
 			excludeTypes: deadOrSummonedTypes,
 		});
+		// Skip the unit that was materialized right before, so the random pick
+		// encourages some variety instead of copy-catting it.
+		const availableTypes = getRandomSummonCandidates(
+			game,
+			summonableTypes,
+			activePlayer.plasma,
+			game.lastSummonedType,
+		);
 
 		// Randomize array to grab a random creature
 		for (let i = availableTypes.length - 1; i > 0; i--) {

--- a/src/utility/summon-candidates.ts
+++ b/src/utility/summon-candidates.ts
@@ -53,3 +53,38 @@ export function getSummonCandidates(
 		return true;
 	});
 }
+
+function getPlasmaCost(game: Game, type: CreatureType) {
+	const level = Number.parseInt(type.substring(1, 2), 10);
+	const stats = game.retrieveCreatureStats(type);
+
+	return level + Number(stats?.size ?? 0);
+}
+
+/**
+ * Narrows a set of summon candidates for a *random* materialization so that the
+ * unit materialized immediately before isn't handed straight back, which is what
+ * produces copy-catting: one player materializes a unit and the next random pick
+ * offers the very same type again.
+ *
+ * The exclusion is a preference rather than a rule. If dropping that type would
+ * leave nothing the player can actually afford, the untouched candidate list is
+ * returned so a random pick is still possible.
+ */
+export function getRandomSummonCandidates(
+	game: Game,
+	candidates: readonly CreatureType[],
+	plasma: number,
+	lastSummonedType?: CreatureType | null,
+): CreatureType[] {
+	const allCandidates = [...candidates];
+
+	if (!lastSummonedType) {
+		return allCandidates;
+	}
+
+	const preferred = allCandidates.filter((type) => type !== lastSummonedType);
+	const canAffordPreferred = preferred.some((type) => getPlasmaCost(game, type) <= plasma);
+
+	return canAffordPreferred ? preferred : allCandidates;
+}


### PR DESCRIPTION
Fixes #1773

### What was happening

`showRandomCreature()` already narrowed the pool with `deadOrSummonedTypes`, so units that are on the field or dead were excluded â€” the first two conditions in the issue were covered. The third one wasn't: nothing looked at what had just been materialized, so the random suggestion could hand the previous materialization's type straight back. That is the copy-catting the issue is about.

### What this changes

- `Game` gains a `lastSummonedType`, set in `Player.summon()` and cleared on init and reset.
- `getRandomSummonCandidates()` is added next to the existing `getSummonCandidates()` in `src/utility/summon-candidates.ts`. It drops the last materialized type from the candidate list.
- `showRandomCreature()` runs its candidates through it before shuffling.

The skip is a preference, not a hard rule. If dropping that type would leave nothing the player can afford, the untouched list is returned, so a random pick is always possible and the dash never falls back to `--` because of this change. Costs are computed the same way the surrounding code does it (`level + size`).

Nothing about what a player is *allowed* to materialize changes â€” this only affects which unit the dash suggests at random.

### Tests

`src/__tests__/utility/summon-candidates.test.ts` covers the new helper: the type is dropped when something else is affordable, kept when nothing else is affordable, kept when it's the only candidate, ignored when there's no previous materialization, and the caller's array is not mutated (`showRandomCreature` shuffles the result in place).

### What I checked, and what I didn't

Lint, build and Jest run through CI on this PR â€” that's the verification I'm relying on. I haven't played a match to watch the dash behave, so a quick sanity check of the Godlet Printer flow would be worth having before merge, particularly whether you'd prefer the "last materialized by anyone" scope I used over "last materialized by the active player only". That's a one-line change if you'd rather have the narrower version.

Happy to adjust scope or naming. Not posting a wallet address here â€” let me know how you'd prefer to handle that if this lands.
