### PR TITLE
fix(abilities): stop Golden Wyrm turning around to heal an adjacent ally (fixes #1965)

### DIFF
--- a/src/__tests__/utility/ability-facing.ts
+++ b/src/__tests__/utility/ability-facing.ts
@@ -1,0 +1,21 @@
+import { expect, describe, test } from '@jest/globals';
+import { shouldFaceTargetDuringCast } from '../../utility/ability-facing';
+
+describe('shouldFaceTargetDuringCast', () => {
+	test('faces the target when the ability says nothing', () => {
+		// Every existing ability is in this shape, so none of them change.
+		expect(shouldFaceTargetDuringCast({})).toBe(true);
+	});
+
+	test('faces the target when the ability opts in explicitly', () => {
+		expect(shouldFaceTargetDuringCast({ _facesTarget: true })).toBe(true);
+	});
+
+	test('leaves the caster alone only on an explicit opt out', () => {
+		expect(shouldFaceTargetDuringCast({ _facesTarget: false })).toBe(false);
+	});
+
+	test('treats an undefined flag as opting in', () => {
+		expect(shouldFaceTargetDuringCast({ _facesTarget: undefined })).toBe(true);
+	});
+});

--- a/src/abilities/Golden-Wyrm.ts
+++ b/src/abilities/Golden-Wyrm.ts
@@ -322,6 +322,12 @@ export default (G: Game) => {
 
 			_targetTeam: Team.Ally,
 
+			/* Reaching out to heal an ally standing next to the Golden Wyrm should
+			not spin it around. Its own hexes span three columns, so an ally on a
+			frontal diagonal hex can compare as being behind it and make it turn its
+			back on the unit it is healing. */
+			_facesTarget: false,
+
 			_maxTransferAmount: 50,
 
 			require: function () {

--- a/src/ability.ts
+++ b/src/ability.ts
@@ -10,6 +10,7 @@ import Game from './game';
 import { Player, ScoreEvent } from './player';
 import { Point } from './utility/pointfacade';
 import { getVisibilityAwareDelay } from './utility/time';
+import { shouldFaceTargetDuringCast } from './utility/ability-facing';
 
 /**
  * Ability Class
@@ -142,6 +143,7 @@ export class Ability {
 	_targets: Hex[];
 	_addOffenseBuff: () => void;
 	_maxTransferAmount: number;
+	_facesTarget?: boolean;
 	_confirmTarget: (c: Creature) => boolean;
 	_damaged: boolean;
 	_executeHealthThreshold: number;
@@ -562,8 +564,9 @@ export class Ability {
 
 		this.creature.facePlayerDefault();
 
-		// Force creatures to face towards their target
-		if (args[0]) {
+		// Force creatures to face towards their target, unless the ability opts
+		// out because turning the caster around would be wrong for it.
+		if (args[0] && shouldFaceTargetDuringCast(this)) {
 			if (args[0] instanceof Creature) {
 				this.creature.faceHex(args[0]);
 			} else if (args[0] instanceof Array) {

--- a/src/utility/ability-facing.ts
+++ b/src/utility/ability-facing.ts
@@ -1,0 +1,22 @@
+/**
+ * `Ability.animation2()` turns the caster to face its target before playing the
+ * cast animation. That is right for an attack, but wrong for abilities that
+ * reach out to a unit already beside the caster: the caster spins on the spot,
+ * and for a multi-hex creature a target on a frontal diagonal hex can even read
+ * as being behind it, so it turns its back on the ally it is helping.
+ *
+ * An ability opts out by declaring `_facesTarget: false`.
+ */
+export type FacingAwareAbility = {
+	_facesTarget?: boolean;
+};
+
+/**
+ * Whether an ability should re-orient its caster towards the target.
+ *
+ * Facing is the default; only an explicit `false` opts out, so abilities that
+ * say nothing keep the behaviour they have always had.
+ */
+export function shouldFaceTargetDuringCast(ability: FacingAwareAbility): boolean {
+	return ability._facesTarget !== false;
+}


### PR DESCRIPTION
Fixes #1965

### Why it turns around

`Ability.animation2()` re-orients the caster at its target before every cast:

```js
this.creature.facePlayerDefault();

// Force creatures to face towards their target
if (args[0]) {
	this.creature.faceHex(args[0]);
```

That's right for an attack. Visible Stigmata isn't one â€” it reaches out to an ally already standing next to the Golden Wyrm, so there's nothing to turn towards, and turning is what looks wrong.

It's worse for the Wyrm than for a normal unit because it occupies three hexes. `faceHex()` takes its reference from one fixed end of that span (`hexagons[0]`, or `hexagons[size - 1]` when flipped) and then decides with

```js
const flipped = facefrom.y % 2 === 0 ? faceto.x <= facefrom.x : faceto.x < facefrom.x;
```

An ally on a frontal diagonal hex can share the reference hex's `x`, so on an even row `faceto.x <= facefrom.x` is true and the sprite flips â€” the Wyrm ends up with its back to the unit it's healing, which is the case in the issue.

### What this changes

An ability can now decline the re-facing with `_facesTarget: false`, and Visible Stigmata sets it. `facePlayerDefault()` still runs first, so the Wyrm settles into its normal forward facing instead of spinning.

Only an explicit `false` opts out, so every ability that doesn't mention the flag behaves exactly as before â€” this can't quietly change any other unit.

Three files plus a test: new `src/utility/ability-facing.ts` (the predicate, kept dependency-free so it's testable â€” the ability modules pull in a lot), the guard in `ability.ts`, and the flag on Visible Stigmata.

### On the more general bug

`faceHex()` already has an `attackFix` branch that suppresses exactly this diagonal flip, but `animation2()` never passes it and its offsets are written around 2-hex creatures ("only works on 2hex creature targeting the adjacent row"). Fixing that properly would change facing for every multi-hex unit in the game, and I can't verify hex geometry without playing it, so I kept this PR to the ability the issue is about. Happy to do the general version as a follow-up if you'd rather have that â€” it'd want someone able to eyeball Impaler/Vehemoth/Nutcase afterwards.

### Testing

`src/__tests__/utility/ability-facing.ts` covers the opt-in default, explicit true, explicit false, and an undefined flag. The visible result is an animation, so it's worth a quick look in-game before merge: heal an ally on a frontal diagonal hex and the Wyrm should stay facing forward.

Not posting a wallet address here; happy to sort that separately if this lands.
