### PR TITLE
feat(ui): fade the HUD while a full screen view is open (fixes #2092)

### DIFF
--- a/src/style/styles.less
+++ b/src/style/styles.less
@@ -291,6 +291,33 @@
 	pointer-events: none;
 }
 
+/*
+ * While a full screen view is open the HUD is just clutter sitting behind it,
+ * so fade it well back. This keys off each view's own open state rather than a
+ * class we would have to set and clear from JS, so no close path can leave the
+ * HUD stuck dim.
+ */
+#unit-hover-panel,
+#bottompanel {
+	transition: opacity 0.3s ease-in-out;
+}
+
+#ui:has(#dash.active),
+#ui:has(#scoreboard:not(.hide)),
+#ui:has(#musicplayerwrapper:not(.hide)) {
+	#unit-hover-panel,
+	#bottompanel {
+		opacity: 0.12;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	#unit-hover-panel,
+	#bottompanel {
+		transition: none;
+	}
+}
+
 #rightpanel {
 	position: fixed;
 	right: 0;


### PR DESCRIPTION
Fixes #2092

Opening the dash, scoreboard or music player left the queue, the side panels and the unit hover panel sitting at full strength behind the view, so they kept pulling the eye while you were reading something else.

### Approach

One block in `styles.less`, no JS:

```less
#ui:has(#dash.active),
#ui:has(#scoreboard:not(.hide)),
#ui:has(#musicplayerwrapper:not(.hide)) {
	#unit-hover-panel,
	#bottompanel {
		opacity: 0.12;
	}
}
```

I went this way rather than toggling a class from `interface.ts` because the views are opened and closed from a lot of places â€” `toggleDash`, `closeDash`, `toggleScoreboard`, `closeScoreboard`, `toggleMusicPlayer`, `closeView`, `closeOpenInterfaceViews`, the signal handler, and the Escape path. Keying off each view's own open state means every one of those routes is covered without touching any of them, and there's no way for a close path to leave the HUD stuck dim.

`#bottompanel` covers the queue and the left/right panels since they nest inside it; `#unit-hover-panel` is a sibling so it's listed too.

Purely visual â€” I left `pointer-events` alone so nothing about interaction changes â€” and the fade is dropped under `prefers-reduced-motion`.

### Worth knowing

- **`:has()`** is what makes the JS-free version possible. It's in every current browser (Chrome 105+, Safari 15.4+, Firefox 121+) and the codebase already leans on comparable things â€” `backdrop-filter`, `inset`, WAAPI `commitStyles`. If you support something older than that, say so and I'll switch it to a class toggled from `interface.ts` instead.
- **0.12 is a guess** at "very transparent". It's one number if you want it nearer 0.05 or 0.25.
- The dash fades out over `dashAnimSpeed` while `.active` is still on it, so the HUD comes back up as the dash goes down rather than snapping.

### Testing

No unit test â€” it's a stylesheet rule with no JS surface to assert against, and the repo's UI tests drive `Queue` directly rather than rendering the interface. Worth eyeballing: open each of the three views and check the HUD fades and comes back, including the dash's animated close.
