### PR TITLE
fix: prioritize Fatigued status over Fragile in fatigueText

### DIFF
--- a/src/__tests__/creature.ts
+++ b/src/__tests__/creature.ts
@@ -370,6 +370,47 @@ describe('Creature', () => {
 			jest.useRealTimers();
 		});
 	});
+
+	describe('creature.fatigueText', () => {
+		test('shows Fatigued over Fragile when endurance pool is minimal and depleted', () => {
+			const game = getGameMock();
+			const obj = getCreatureObjMock();
+			obj.materializationSickness = false;
+			obj.stats.endurance = 1;
+			// @ts-ignore
+			const creature = new Creature(obj, game);
+			creature.endurance = 0;
+			expect(creature.fatigueText).toBe('Fatigued');
+			// Depleting the last endurance point must not log a misleading
+			// "has become fragile" message. @see https://github.com/FreezingMoon/AncientBeast/issues/1986
+			expect(game.log).not.toHaveBeenCalledWith(
+				'%CreatureName' + creature.id + '% has become fragile',
+			);
+		});
+
+		test('shows Fragile when endurance pool is minimal but not depleted', () => {
+			const game = getGameMock();
+			const obj = getCreatureObjMock();
+			obj.materializationSickness = false;
+			obj.stats.endurance = 1;
+			// @ts-ignore
+			const creature = new Creature(obj, game);
+			creature.endurance = 1;
+			expect(creature.fatigueText).toBe('Fragile');
+			expect(game.log).toHaveBeenCalledWith('%CreatureName' + creature.id + '% has become fragile');
+		});
+
+		test('shows remaining endurance pool normally', () => {
+			const game = getGameMock();
+			const obj = getCreatureObjMock();
+			obj.materializationSickness = false;
+			obj.stats.endurance = 5;
+			// @ts-ignore
+			const creature = new Creature(obj, game);
+			creature.endurance = 3;
+			expect(creature.fatigueText).toBe('3/5');
+		});
+	});
 });
 
 jest.mock('../ability');

--- a/src/creature.ts
+++ b/src/creature.ts
@@ -2330,6 +2330,8 @@ export class Creature {
 			result = 'Sickened';
 		} else if (this.protectedFromFatigue || this.stats.fatigueImmunity) {
 			result = 'Protected';
+		} else if (this.isFatigued()) {
+			result = 'Fatigued';
 		} else if (this.isFragile()) {
 			result = 'Fragile';
 			// Display message if the creature has first become fragile
@@ -2340,8 +2342,6 @@ export class Creature {
 			if (this.#fatigueText !== result) {
 				this.game.log('%CreatureName' + this.id + '% has become fragile');
 			}
-		} else if (this.isFatigued()) {
-			result = 'Fatigued';
 		} else {
 			result = this.endurance + '/' + this.stats.endurance;
 		}


### PR DESCRIPTION
This fixes issue #1986

When a creature has a minimal endurance pool (max 1) and it is fully depleted, both `isFragile()` and `isFatigued()` are true. The `fatigueText` getter checked `Fragile` first, so the queue displayed a misleading `Fragile` status and logged `has become fragile` at the wrong moment.

Changes:
- `src/creature.ts`: check `isFatigued()` before `isFragile()` in the `fatigueText` getter, so the more severe status is displayed (the fragile log now only fires when the creature is fragile but not fatigued).
- `src/__tests__/creature.ts`: 3 new unit tests — fragile+fatigued overlap shows `Fatigued` (and does not log a misleading message), plain fragile shows `Fragile` + logs, normal pool shows `3/5`.

Validation: full suite 385 passed / lint clean. The new overlap test fails against the original ordering (verified by temporarily reverting the fix).

Note: no bounty attached to this issue, so no wallet address needed.